### PR TITLE
辞書アプリで並んでいる順序によらず、国語辞典を参照するようにした

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		CEB0888B2A7F342000EFD1E3 /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		CEB0888D2A7F393600EFD1E3 /* AnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationView.swift; sourceTree = "<group>"; };
 		CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pasteboard.swift; sourceTree = "<group>"; };
+		CEB088922A81342E00EFD1E3 /* macSKK-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macSKK-Bridging-Header.h"; sourceTree = "<group>"; };
+		CEB088952A81353400EFD1E3 /* DictionaryServiceExtention.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DictionaryServiceExtention.h; sourceTree = "<group>"; };
 		CEC376E72965199500D9C432 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		CEC376EA2965211200D9C432 /* KeyEventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyEventView.swift; sourceTree = "<group>"; };
 		CEE3717429653112000DB2C3 /* GeneralView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralView.swift; sourceTree = "<group>"; };
@@ -147,6 +149,8 @@
 				CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */,
 				CEA78FAB2960401F00B67E25 /* String+Transform.swift */,
 				CEC376E929651DE000D9C432 /* Settings */,
+				CEB088922A81342E00EFD1E3 /* macSKK-Bridging-Header.h */,
+				CEB088952A81353400EFD1E3 /* DictionaryServiceExtention.h */,
 				CE5ECF392957034D00E7BE7D /* Assets.xcassets */,
 				CE5ECF612957061A00E7BE7D /* Info.plist */,
 				CE5ECF3E2957034D00E7BE7D /* macSKK.entitlements */,
@@ -243,6 +247,7 @@
 				TargetAttributes = {
 					CE5ECF312957034B00E7BE7D = {
 						CreatedOnToolsVersion = 14.2;
+						LastSwiftMigration = 1430;
 					};
 					CE5ECF422957034D00E7BE7D = {
 						CreatedOnToolsVersion = 14.2;
@@ -487,6 +492,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = macSKK/macSKK.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -507,6 +513,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.mtgto.inputmethod.macSKK;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "macSKK/macSKK-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -516,6 +524,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = macSKK/macSKK.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -536,6 +545,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.mtgto.inputmethod.macSKK;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "macSKK/macSKK-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/macSKK/DictionaryServiceExtention.h
+++ b/macSKK/DictionaryServiceExtention.h
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#import <CoreServices/CoreServices.h>
+
+// Dictionary.appで有効になっている辞書を返す
+NSArray * _Nonnull DCSGetActiveDictionaries();
+// Dictionary.appで無効になっているものを含めて利用可能な辞書を返す
+NSSet * _Nonnull DCSCopyAvailableDictionaries();
+NSString * _Nullable DCSDictionaryGetName(DCSDictionaryRef _Nullable dictID);
+NSString * _Nullable DCSDictionaryGetShortName(DCSDictionaryRef _Nullable dictID);

--- a/macSKK/DictionaryServiceExtention.h
+++ b/macSKK/DictionaryServiceExtention.h
@@ -8,4 +8,4 @@ NSArray * _Nonnull DCSGetActiveDictionaries();
 // Dictionary.appで無効になっているものを含めて利用可能な辞書を返す
 NSSet * _Nonnull DCSCopyAvailableDictionaries();
 NSString * _Nullable DCSDictionaryGetName(DCSDictionaryRef _Nullable dictID);
-NSString * _Nullable DCSDictionaryGetShortName(DCSDictionaryRef _Nullable dictID);
+NSString * _Nullable DCSDictionaryGetIdentifier(DCSDictionaryRef _Nullable dictID);

--- a/macSKK/SystemDict.swift
+++ b/macSKK/SystemDict.swift
@@ -19,7 +19,8 @@ class SystemDict {
             return nil
         }
         return dictionaries.first { dict in
-            return DCSDictionaryGetName(dict) == "スーパー大辞林"
+            // DCSDictionaryGetNameだと"スーパー大辞林"
+            return DCSDictionaryGetIdentifier(dict) == "com.apple.dictionary.ja.Daijirin"
         }
     }
 }

--- a/macSKK/SystemDict.swift
+++ b/macSKK/SystemDict.swift
@@ -6,10 +6,20 @@ import Foundation
 /// Dictionary Serviceを使ってシステム辞書から検索する
 class SystemDict {
     class func lookup(_ word: String) -> String? {
-        var dictionary: DCSDictionary? = nil
+        let dictionary: DCSDictionary? = findSystemJapaneseDict()
         if let result = DCSCopyTextDefinition(dictionary, word as NSString, CFRangeMake(0, word.count)) {
             return result.takeRetainedValue() as String
         }
         return nil
+    }
+
+    class func findSystemJapaneseDict() -> DCSDictionary? {
+        guard let dictionaries = DCSCopyAvailableDictionaries() as? Set<DCSDictionary> else {
+            logger.error("システム辞書が見つかりません")
+            return nil
+        }
+        return dictionaries.first { dict in
+            return DCSDictionaryGetName(dict) == "スーパー大辞林"
+        }
     }
 }

--- a/macSKK/SystemDict.swift
+++ b/macSKK/SystemDict.swift
@@ -5,8 +5,9 @@ import Foundation
 
 /// Dictionary Serviceを使ってシステム辞書から検索する
 class SystemDict {
+    private static let dictionary: DCSDictionary? = findSystemJapaneseDict()
+
     class func lookup(_ word: String) -> String? {
-        let dictionary: DCSDictionary? = findSystemJapaneseDict()
         if let result = DCSCopyTextDefinition(dictionary, word as NSString, CFRangeMake(0, word.count)) {
             return result.takeRetainedValue() as String
         }
@@ -18,9 +19,15 @@ class SystemDict {
             logger.error("システム辞書が見つかりません")
             return nil
         }
-        return dictionaries.first { dict in
-            // DCSDictionaryGetNameだと"スーパー大辞林"
-            return DCSDictionaryGetIdentifier(dict) == "com.apple.dictionary.ja.Daijirin"
+        let dictionary = dictionaries.first {
+            // DCSDictionaryGetNameは "スーパー大辞林"
+            DCSDictionaryGetIdentifier($0) == "com.apple.dictionary.ja.Daijirin"
+        }
+        if let dictionary {
+            return dictionary
+        } else {
+            logger.warning("スーパー大辞林が利用可能な辞書にありませんでした")
+            return nil
         }
     }
 }

--- a/macSKK/macSKK-Bridging-Header.h
+++ b/macSKK/macSKK-Bridging-Header.h
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Use this file to import your target's public headers that you would like to expose to Swift.
+
+#import "DictionaryServiceExtention.h"


### PR DESCRIPTION
DictionaryServiceの非公開APIを使用して、辞書アプリの順序によらず国語辞典を使うようにします。
`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices.tbd` を参考にして、実際に呼び出した結果を元にnullable/nonnullなど型を推測で定義しています。