### PR TITLE
注釈の表示位置がまれにスクリーン最下部になってしまう

### DIFF
--- a/macSKK/CandidatesPanel.swift
+++ b/macSKK/CandidatesPanel.swift
@@ -13,6 +13,7 @@ final class CandidatesPanel: NSPanel {
         let rootView = CandidatesView(candidates: self.viewModel)
         let viewController = NSHostingController(rootView: rootView)
         super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
+        //viewController.sizingOptions = .preferredContentSize
         viewController.sizingOptions = .standardBounds
         contentViewController = viewController
     }
@@ -28,7 +29,6 @@ final class CandidatesPanel: NSPanel {
 
     func show(at point: NSPoint) {
         // TODO: もしスクリーン下にはみ出す場合は setOrigin を使って左下座標を指定する。
-        setFrameTopLeftPoint(point)
         if let viewController = contentViewController as? NSHostingController<CandidatesView> {
             print("content size = \(viewController.sizeThatFits(in: CGSize(width: Int.max, height: Int.max)))")
             print("intrinsicContentSize = \(viewController.view.intrinsicContentSize)")
@@ -38,6 +38,8 @@ final class CandidatesPanel: NSPanel {
         } else {
             print("\(contentViewController!.className)")
         }
+        setContentSize(NSSize(width: 300, height: 300))
+        setFrameTopLeftPoint(point)
         level = .floating
         orderFrontRegardless()
     }

--- a/macSKK/CandidatesPanel.swift
+++ b/macSKK/CandidatesPanel.swift
@@ -13,7 +13,7 @@ final class CandidatesPanel: NSPanel {
         let rootView = CandidatesView(candidates: self.viewModel)
         let viewController = NSHostingController(rootView: rootView)
         super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
-        viewController.sizingOptions = .preferredContentSize
+        viewController.sizingOptions = .standardBounds
         contentViewController = viewController
     }
 

--- a/macSKK/CandidatesPanel.swift
+++ b/macSKK/CandidatesPanel.swift
@@ -13,8 +13,6 @@ final class CandidatesPanel: NSPanel {
         let rootView = CandidatesView(candidates: self.viewModel)
         let viewController = NSHostingController(rootView: rootView)
         super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
-        //viewController.sizingOptions = .preferredContentSize
-        viewController.sizingOptions = .standardBounds
         contentViewController = viewController
     }
 
@@ -30,15 +28,17 @@ final class CandidatesPanel: NSPanel {
     func show(at point: NSPoint) {
         // TODO: もしスクリーン下にはみ出す場合は setOrigin を使って左下座標を指定する。
         if let viewController = contentViewController as? NSHostingController<CandidatesView> {
+            #if DEBUG
             print("content size = \(viewController.sizeThatFits(in: CGSize(width: Int.max, height: Int.max)))")
             print("intrinsicContentSize = \(viewController.view.intrinsicContentSize)")
             print("frame = \(frame)")
             print("preferredContentSize = \(viewController.preferredContentSize)")
             print("sizeThatFits = \(viewController.sizeThatFits(in: CGSize(width: 10000, height: 10000)))")
-        } else {
-            print("\(contentViewController!.className)")
+            #endif
+            let width = viewController.rootView.minWidth()
+            let height = CGFloat(self.viewModel.candidates.words.count) * CandidatesView.lineHeight + CandidatesView.footerHeight
+            setContentSize(NSSize(width: width, height: height))
         }
-        setContentSize(NSSize(width: 300, height: 300))
         setFrameTopLeftPoint(point)
         level = .floating
         orderFrontRegardless()

--- a/macSKK/CandidatesView.swift
+++ b/macSKK/CandidatesView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// 変換候補ビュー
 /// とりあえず10件ずつ縦に表示、スペースで次の10件が表示される
 struct CandidatesView: View {
-    @StateObject var candidates: CandidatesViewModel
+    @ObservedObject var candidates: CandidatesViewModel
     /// 一行の高さ
     static let lineHeight: CGFloat = 20
     static let footerHeight: CGFloat = 20
@@ -30,16 +30,6 @@ struct CandidatesView: View {
                 .frame(height: Self.lineHeight)
                 // .border(Color.red) // Listの謎のInsetのデバッグ時に使用する
                 .contentShape(Rectangle())
-                .popover(
-                    isPresented: .constant(candidate == candidates.selected && (candidate.annotation != nil || candidates.systemAnnotations[candidate] != nil)),
-                    arrowEdge: .trailing
-                ) {
-                    AnnotationView(
-                        annotation: .constant(candidate.annotation),
-                        systemAnnotation: $candidates.systemAnnotations[candidate]
-                    )
-                    .frame(width: 300, alignment: .topLeading)
-                }
             }
             .listStyle(.plain)
             .environment(\.defaultMinListRowHeight, Self.lineHeight)  // Listの行の上下の余白を削除
@@ -51,6 +41,20 @@ struct CandidatesView: View {
                     .padding(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 4))
             }
             .frame(width: minWidth(), height: Self.footerHeight)
+        }
+        .popover(
+            isPresented: $candidates.popoverIsPresented,
+            attachmentAnchor: .rect(.rect(CGRect(x: 0,
+                                                 y: CGFloat(candidates.selectedIndex ?? 0) * Self.lineHeight,
+                                                 width: minWidth(),
+                                                 height: Self.lineHeight))),
+            arrowEdge: .trailing
+        ) {
+            AnnotationView(
+                annotation: $candidates.selectedSystemAnnotation,
+                systemAnnotation: $candidates.selectedAnnotation
+            )
+            .frame(width: 300, alignment: .topLeading)
         }
     }
 

--- a/macSKK/CandidatesView.swift
+++ b/macSKK/CandidatesView.swift
@@ -42,6 +42,7 @@ struct CandidatesView: View {
             }
             .frame(width: minWidth(), height: Self.footerHeight)
         }
+        .frame(width: minWidth(), height: CGFloat(candidates.candidates.words.count) * Self.lineHeight + Self.footerHeight)
         .popover(
             isPresented: $candidates.popoverIsPresented,
             attachmentAnchor: .rect(.rect(CGRect(x: 0,
@@ -51,8 +52,8 @@ struct CandidatesView: View {
             arrowEdge: .trailing
         ) {
             AnnotationView(
-                annotation: $candidates.selectedSystemAnnotation,
-                systemAnnotation: $candidates.selectedAnnotation
+                annotation: $candidates.selectedAnnotation,
+                systemAnnotation: $candidates.selectedSystemAnnotation
             )
             .frame(width: 300, alignment: .topLeading)
         }

--- a/macSKK/CandidatesView.swift
+++ b/macSKK/CandidatesView.swift
@@ -56,6 +56,9 @@ struct CandidatesView: View {
             )
             .frame(width: 300, alignment: .topLeading)
         }
+        .onAppear {
+            candidates.viewIsAppeared = true
+        }
     }
 
     // 最長のテキストを表示するために必要なビューのサイズを返す

--- a/macSKK/CandidatesView.swift
+++ b/macSKK/CandidatesView.swift
@@ -42,7 +42,6 @@ struct CandidatesView: View {
             }
             .frame(width: minWidth(), height: Self.footerHeight)
         }
-        .frame(width: minWidth(), height: CGFloat(candidates.candidates.words.count) * Self.lineHeight + Self.footerHeight)
         .popover(
             isPresented: $candidates.popoverIsPresented,
             attachmentAnchor: .rect(.rect(CGRect(x: 0,
@@ -63,7 +62,7 @@ struct CandidatesView: View {
     }
 
     // 最長のテキストを表示するために必要なビューのサイズを返す
-    private func minWidth() -> CGFloat {
+    func minWidth() -> CGFloat {
         let width = candidates.candidates.words.map { candidate -> CGFloat in
             let size = candidate.word.boundingRect(
                 with: CGSize(width: .greatestFiniteMagnitude, height: Self.lineHeight),

--- a/macSKK/CandidatesViewModel.swift
+++ b/macSKK/CandidatesViewModel.swift
@@ -26,6 +26,7 @@ final class CandidatesViewModel: ObservableObject {
     @Published var selectedIndex: Int?
     @Published var selectedSystemAnnotation: String?
     @Published var selectedAnnotation: String?
+    @Published var viewIsAppeared: Bool = false
     private var cancellables: Set<AnyCancellable> = []
 
     init(candidates: [Word], currentPage: Int, totalPageCount: Int) {
@@ -34,12 +35,12 @@ final class CandidatesViewModel: ObservableObject {
             self.selected = first
         }
 
-        $selected.combineLatest($systemAnnotations).sink { (selected, systemAnnotations) in
+        $selected.combineLatest($systemAnnotations, $viewIsAppeared).sink { (selected, systemAnnotations, viewIsAppeared) in
             if let selected {
                 self.selectedIndex = self.candidates.words.firstIndex(of: selected)
                 self.selectedAnnotation = selected.annotation
                 self.selectedSystemAnnotation = systemAnnotations[selected]
-                self.popoverIsPresented = (self.selectedAnnotation ?? self.selectedSystemAnnotation) != nil
+                self.popoverIsPresented = viewIsAppeared && (self.selectedAnnotation ?? self.selectedSystemAnnotation) != nil
             }
         }
         .store(in: &cancellables)

--- a/macSKK/CandidatesViewModel.swift
+++ b/macSKK/CandidatesViewModel.swift
@@ -22,11 +22,26 @@ final class CandidatesViewModel: ObservableObject {
     @Published var doubleSelected: Word?
     /// 選択中の変換候補のシステム辞書での注釈
     @Published var systemAnnotations = Dictionary<Word, String>()
+    @Published var popoverIsPresented: Bool = false
+    @Published var selectedIndex: Int?
+    @Published var selectedSystemAnnotation: String?
+    @Published var selectedAnnotation: String?
+    private var cancellables: Set<AnyCancellable> = []
 
     init(candidates: [Word], currentPage: Int, totalPageCount: Int) {
         self.candidates = CurrentCandidates(words: candidates, currentPage: currentPage, totalPageCount: totalPageCount)
         if let first = candidates.first {
             self.selected = first
         }
+
+        $selected.combineLatest($systemAnnotations).sink { (selected, systemAnnotations) in
+            if let selected {
+                self.selectedIndex = self.candidates.words.firstIndex(of: selected)
+                self.selectedAnnotation = selected.annotation
+                self.selectedSystemAnnotation = systemAnnotations[selected]
+                self.popoverIsPresented = (self.selectedAnnotation ?? self.selectedSystemAnnotation) != nil
+            }
+        }
+        .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
変換候補パネルの初回表示時など、特定のタイミングで変換候補とは全然違う位置、スクリーン最下部にNSPopoverらしきものが表示されてしまうのを修正します。

原因ははっきりわかってないんですが、NSPanel.setContentSizeを正しいものを指定してあげたら再現しなくなったようなのでこれで様子見してみます。

あとついでのリファクタで `.constant` を使わずに `@Binding` を作るようにしました。