### PR TITLE
abbrevモードでシフト押しながら非アルファベットを入力するとシフトが反映されないバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -639,7 +639,7 @@ class StateMachine {
             state.inputMethod = .composing(
                 ComposingState(
                     isShift: isShift,
-                    text: text + [action.shiftIsPressed() ? input.uppercased() : input],
+                    text: text + [action.characters() ?? ""],
                     okuri: nil,
                     romaji: ""))
             updateMarkedText()


### PR DESCRIPTION
絵文字辞書が有効になってみつけたバグ。
abbrevモード (日本語入力でスラッシュ入力) でシフトキーが必要な `_` とか `!` とかを入力しようとするとシフトキー押してないときのキーが入力されてしまうという問題があったので修正。