### PR TITLE
commitCompositionが呼ばれたときに未確定文字列を確定するように修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -127,6 +127,14 @@ class InputController: IMKInputController {
         super.deactivateServer(sender)
     }
 
+    /// クライアントが入力中状態を即座に確定してほしいときに呼ばれる
+    override func commitComposition(_ sender: Any!) {
+        logger.log("commitCompositionが呼ばれた")
+        // TODO: 現在未確定の入力を強制的に確定させて状態を入力前の状態にする
+        // 状態がComposing (未確定) なら "▽" より後ろの文字を確定で入力する
+
+    }
+
     override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
         guard let value = value as? String else { return }
         guard let inputMode = InputMode(rawValue: value) else { return }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -130,9 +130,8 @@ class InputController: IMKInputController {
     /// クライアントが入力中状態を即座に確定してほしいときに呼ばれる
     override func commitComposition(_ sender: Any!) {
         logger.log("commitCompositionが呼ばれた")
-        // TODO: 現在未確定の入力を強制的に確定させて状態を入力前の状態にする
-        // 状態がComposing (未確定) なら "▽" より後ろの文字を確定で入力する
-
+        // 現在未確定の入力を強制的に確定させて状態を入力前の状態にする
+        stateMachine.commitComposition()
     }
 
     override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -129,7 +129,6 @@ class InputController: IMKInputController {
 
     /// クライアントが入力中状態を即座に確定してほしいときに呼ばれる
     override func commitComposition(_ sender: Any!) {
-        logger.log("commitCompositionが呼ばれた")
         // 現在未確定の入力を強制的に確定させて状態を入力前の状態にする
         stateMachine.commitComposition()
     }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -806,8 +806,10 @@ class StateMachine {
     ///   - 現在選択中の変換候補の "▼" より後ろの文字列を確定で入力する
     ///   - ユーザー辞書には登録しない (仮)
     /// - 状態が上記でないときは仮で次のように実装してみる。いろんなソフトで不具合があるかどうかを見る
-    ///   - 状態がRegister (単語登録中) なら 空文字列で確定する
-    ///   - 状態がUnregister (ユーザー辞書から削除するか質問中) なら削除に移行する前の "▼" より後ろの文字列を確定で入力する
+    ///   - 状態がRegister (単語登録中)
+    ///     - 空文字列で確定する
+    ///   - 状態がUnregister (ユーザー辞書から削除するか質問中)
+    ///     - 空文字列で確定する
     func commitComposition() {
         if let specialState = state.specialState {
             state.inputMethod = .normal

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -796,7 +796,8 @@ class StateMachine {
 
     /// 現在の入力中文字列を確定して状態を入力前に戻す。カーソル位置が文字列の途中でも末尾にあるものとして扱う
     /// - 状態がNormalおよびローマ字未確定入力中
-    ///   - 空文字列を確定させる
+    ///   - 空文字列で確定させる
+    ///   - nだけ入力してるときも空文字列 (仮)
     /// - 状態がComposing (未確定)
     ///   - "▽" より後ろの文字列を確定で入力する
     /// - 状態がSelecting (変換候補選択中)
@@ -812,15 +813,18 @@ class StateMachine {
             case .unregister:
                 break
             }
-        }
-
-        switch state.inputMethod {
-        case .normal:
-            return
-        case .composing(let composing):
-            return
-        case .selecting(let selectiong):
-            return
+        } else {
+            switch state.inputMethod {
+            case .normal:
+                return
+            case .composing(let composing):
+                let fixedText = composing.string(for: state.inputMode, convertHatsuon: false)
+                state.inputMethod = .normal
+                addFixedText(fixedText)
+                return
+            case .selecting(let selectiong):
+                return
+            }
         }
     }
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -810,12 +810,9 @@ class StateMachine {
     ///   - 状態がUnregister (ユーザー辞書から削除するか質問中) なら削除に移行する前の "▼" より後ろの文字列を確定で入力する
     func commitComposition() {
         if let specialState = state.specialState {
-            switch specialState {
-            case .register:
-                break
-            case .unregister:
-                break
-            }
+            state.inputMethod = .normal
+            state.specialState = nil
+            addFixedText("")
         } else {
             switch state.inputMethod {
             case .normal:

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -795,6 +795,8 @@ class StateMachine {
     }
 
     /// 現在の入力中文字列を確定して状態を入力前に戻す。カーソル位置が文字列の途中でも末尾にあるものとして扱う
+    ///
+    /// 仕様はどうあるべきか検討中。不明なものは仮としている。
     /// - 状態がNormalおよびローマ字未確定入力中
     ///   - 空文字列で確定させる
     ///   - nだけ入力してるときも空文字列 (仮)
@@ -802,6 +804,7 @@ class StateMachine {
     ///   - "▽" より後ろの文字列を確定で入力する
     /// - 状態がSelecting (変換候補選択中)
     ///   - 現在選択中の変換候補の "▼" より後ろの文字列を確定で入力する
+    ///   - ユーザー辞書には登録しない (仮)
     /// - 状態が上記でないときは仮で次のように実装してみる。いろんなソフトで不具合があるかどうかを見る
     ///   - 状態がRegister (単語登録中) なら 空文字列で確定する
     ///   - 状態がUnregister (ユーザー辞書から削除するか質問中) なら削除に移行する前の "▼" より後ろの文字列を確定で入力する
@@ -821,9 +824,11 @@ class StateMachine {
                 let fixedText = composing.string(for: state.inputMode, convertHatsuon: false)
                 state.inputMethod = .normal
                 addFixedText(fixedText)
-                return
-            case .selecting(let selectiong):
-                return
+            case .selecting(let selecting):
+                // エンター押したときと違って辞書登録はスキップ (仮)
+                updateCandidates(selecting: nil)
+                state.inputMethod = .normal
+                addFixedText(selecting.fixedText())
             }
         }
     }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -794,6 +794,36 @@ class StateMachine {
         state.inputMode = mode
     }
 
+    /// 現在の入力中文字列を確定して状態を入力前に戻す。カーソル位置が文字列の途中でも末尾にあるものとして扱う
+    /// - 状態がNormalおよびローマ字未確定入力中
+    ///   - 空文字列を確定させる
+    /// - 状態がComposing (未確定)
+    ///   - "▽" より後ろの文字列を確定で入力する
+    /// - 状態がSelecting (変換候補選択中)
+    ///   - 現在選択中の変換候補の "▼" より後ろの文字列を確定で入力する
+    /// - 状態が上記でないときは仮で次のように実装してみる。いろんなソフトで不具合があるかどうかを見る
+    ///   - 状態がRegister (単語登録中) なら 空文字列で確定する
+    ///   - 状態がUnregister (ユーザー辞書から削除するか質問中) なら削除に移行する前の "▼" より後ろの文字列を確定で入力する
+    func commitComposition() {
+        if let specialState = state.specialState {
+            switch specialState {
+            case .register:
+                break
+            case .unregister:
+                break
+            }
+        }
+
+        switch state.inputMethod {
+        case .normal:
+            return
+        case .composing(let composing):
+            return
+        case .selecting(let selectiong):
+            return
+        }
+    }
+
     private func addFixedText(_ text: String) {
         if let specialState = state.specialState {
             // state.markedTextを更新してinputMethodEventSubjectにstate.displayText()をsendする

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1410,14 +1410,19 @@ final class StateMachineTests: XCTestCase {
 
     func testCommitCompositionNormal() {
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(3).sink { events in
+        stateMachine.inputMethodEvent.collect(4).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText(text: "k", cursor: nil)))
             XCTAssertEqual(events[1], .markedText(MarkedText(text: "", cursor: nil)))
-            XCTAssertEqual(events[2], .fixedText(""))
+            XCTAssertEqual(events[2], .markedText(MarkedText(text: "n", cursor: nil)))
+            XCTAssertEqual(events[3], .markedText(MarkedText(text: "", cursor: nil)), "nが未確定になってても空文字列になる")
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
         stateMachine.commitComposition()
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
+        stateMachine.commitComposition()
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal)
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1408,6 +1408,19 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testCommitCompositionNormal() {
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(3).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText(text: "k", cursor: nil)))
+            XCTAssertEqual(events[1], .markedText(MarkedText(text: "", cursor: nil)))
+            XCTAssertEqual(events[2], .fixedText(""))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
+        stateMachine.commitComposition()
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     private func nextInputMethodEvent() async -> InputMethodEvent {
         var cancellation: Cancellable?
         let cancel = { cancellation?.cancel() }


### PR DESCRIPTION
Webブラウザでアドレスバーに文字列を入力中、サジェストされたサイトをクリックしても未確定文字が入力中のままになってしまうことに気付いた。

| どんなとき | macSKK | AquaSKK | 標準(旧ことえり) |
| :--: | :--: | :--: | :--: |
| Google Chromeのアドレスバーに入力中にサジェストされたサイトをクリック | 入力中のまま | クエリパラメータが `q=(クリックした文字列)&oq=▼相` でグーグル検索 | `q=(クリックした文字列)&oq=相` でグーグル検索 |

こういうときIMKInputControllerのcommitCompositionが呼ばれるので、そのタイミングで入力中文字列を確定してしまえばよさそう。
`▼(表示されている文字列)` になっちゃうのはどうしようもないかな。。。