### PR TITLE
インストーラ作成時にxcarchiveのexportArchiveから作成するように修正

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -676,6 +676,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = macSKK/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Input Methods";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -709,6 +710,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = macSKK/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Input Methods";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/script/export-options.plist
+++ b/script/export-options.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>compileBitcode</key>
+	<false/>
+	<key>method</key>
+	<string>developer-id</string>
+</dict>
+</plist>


### PR DESCRIPTION
0.2.0の配布アプリケーションにPreviewProvider用にDevelopment Assetsに追加したファイルが含まれていることに気付きました。
0.2.0では配布アプリケーションのビルドに `xcodebuild build` を使っているのですが、Development Assetsを含まないようにする処理が入るのはarchiveするときだけらしいです。

> Files and directories used only for development. Archive and install builds will exclude this content.
https://developer.apple.com/documentation/xcode/build-settings-reference#Development-Assets

dmgの作成の手順を次のように変更します。

### before

1. xcodebuild buildで `macSKK.app` を作成
2. macSKK.appを `/Library/Input Methods` に配置してpkgを作成
3. SKK-JISYO.Lインストール用のpkgを作成
4. 2と3をふくむpkgを作成
5. 4をNotarization, stapleする

### after

1. xcodebuild archiveで macSKK-x.y.z.xcarchive を作成 (NEW)
2. xcarchiveからexport (NEW)
3. export先にあるmacSKK.appを `/Library/Input Methods` に配置してpkgを作成
4. SKK-JISYO.Lインストール用のpkgを作成
5. 2と3をふくむpkgを作成
6. 4をNotarization, stapleする

差分はちゃんと見てないですが、xcodebuild buildのときよりもバイナリサイズも小さくなってそう。