### PR TITLE
ローマ字の子音のあとにハイフンを打つと半角のハイフンが入力されるバグ修正

### DIFF
--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -260,7 +260,7 @@ struct Romaji: Equatable {
      *
      * - "ka" が入力されたら確定文字 "か" と残りのローマ字文字列 "" を返す
      * - "k" が入力されたら確定文字はnil, 残りのローマ字文字列 "k" を返す
-     * - "kt" のように連続できない子音が連続したinputの場合は"t"だけをローマ字文字列として返す
+     * - "kt" のように連続できない子音が連続したinputの場合は"t"をinput引数としたときのconvertの結果を返す
      * - "kya" のように確定した文字が複数の場合がありえる
      * - "aiueo" のように複数の確定が可能な場合は最初に確定できた文字だけを確定文字として返し、残りは(確定可能だが)inputとして返す
      * - ",", "." は"、", "。"にする (将来設定で切り変えられるようにするかも)
@@ -292,9 +292,11 @@ struct Romaji: Equatable {
         } else if array.contains(input) {
             return ConvertedMoji(input: input, kakutei: nil)
         } else if let firstIndex = array.firstIndex(where: { input.hasPrefix($0) }) {
-            return ConvertedMoji(input: String(input.dropFirst(array[firstIndex].utf8.count)), kakutei: nil)
+            return convert(String(input.dropFirst(array[firstIndex].utf8.count)))
+        } else if input.count == 1 {
+            return ConvertedMoji(input: input, kakutei: nil)
         } else if let c = input.last {
-            return ConvertedMoji(input: String(c), kakutei: nil)
+            return convert(String(c))
         }
         return ConvertedMoji(input: input, kakutei: nil)
     }

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -26,5 +26,8 @@ class RomajiTests: XCTestCase {
             Romaji.convert("tsh"), Romaji.ConvertedMoji(input: "h", kakutei: nil),
             "続けられない子音が連続した場合は最後の子音だけ残る (shじゃなくてhだけ残す)")
         XCTAssertEqual(Romaji.convert("nf"), Romaji.ConvertedMoji(input: "f", kakutei: Romaji.n))
+        XCTAssertEqual(Romaji.convert("s-"), Romaji.ConvertedMoji(input: "", kakutei: Romaji.symbolTable["-"]), "二文字目が一文字目に続けられないRomaji.symbolTableの文字のときは一文字目を捨てる")
+        XCTAssertEqual(Romaji.convert("ty,"), Romaji.ConvertedMoji(input: "", kakutei: Romaji.symbolTable[","]))
+        XCTAssertEqual(Romaji.convert("xts["), Romaji.ConvertedMoji(input: "", kakutei: Romaji.symbolTable["["]))
     }
 }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -769,6 +769,24 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleComposingPrintableSymbol() {
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(5).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText(text: "▽s", cursor: nil)))
+            XCTAssertEqual(events[1], .markedText(MarkedText(text: "▽ー", cursor: nil)), "Romaji.symbolTableに対応")
+            XCTAssertEqual(events[2], .markedText(MarkedText(text: "▽ーt", cursor: nil)))
+            XCTAssertEqual(events[3], .markedText(MarkedText(text: "▽ーty", cursor: nil)))
+            XCTAssertEqual(events[4], .markedText(MarkedText(text: "▽ー、", cursor: nil)))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "-")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "y")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ",")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleComposingCancel() {
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(6).sink { events in


### PR DESCRIPTION
未確定文字列入力中 (Shift押しながら子音) のあとに、Romaji.symbolTableにあるハイフンやピリオドなどの文字を打ってもsymbolTableを参照してなかったのでASCIIのまま入力されていたのが原因。
Romaji.convert自体だいぶ初期に書いたものなのでリファクタしてもよさそう。