### PR TITLE
プライベートモードかどうかをグローバル変数でもつようにした

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -54,8 +54,8 @@ class InputController: IMKInputController {
                 textInput.selectMode(inputMode.rawValue)
                 if let self {
                     self.inputModePanel.show(at: cursorPosition.origin,
-                                              mode: inputMode,
-                                              privateMode: self.stateMachine.privateMode)
+                                             mode: inputMode,
+                                             privateMode: privateMode.value)
                 }
             }
         }.store(in: &cancellables)
@@ -117,7 +117,7 @@ class InputController: IMKInputController {
         let privateModeItem = NSMenuItem(title: NSLocalizedString("MenuPrivateMode", comment: "Private mode"),
                                          action: #selector(togglePrivateMode),
                                          keyEquivalent: "")
-        privateModeItem.state = stateMachine.privateMode ? .on : .off
+        privateModeItem.state = privateMode.value ? .on : .off
         preferenceMenu.addItem(privateModeItem)
         #if DEBUG
         // デバッグ用
@@ -153,7 +153,7 @@ class InputController: IMKInputController {
         // カーソル位置あたりを取得する
         var cursorPosition: NSRect = .zero
         _ = textInput.attributes(forCharacterIndex: 0, lineHeightRectangle: &cursorPosition)
-        inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: stateMachine.privateMode)
+        inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: privateMode.value)
     }
 
     @objc func showSettings() {
@@ -175,13 +175,13 @@ class InputController: IMKInputController {
     }
 
     @objc func togglePrivateMode() {
-        stateMachine.togglePrivateMode()
+        privateMode.send(!privateMode.value)
     }
 
     #if DEBUG
     @objc func showPanel() {
         let point = NSPoint(x: 100, y: 500)
-        self.inputModePanel.show(at: point, mode: .hiragana, privateMode: stateMachine.privateMode)
+        self.inputModePanel.show(at: point, mode: .hiragana, privateMode: privateMode.value)
     }
     #endif
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -19,8 +19,6 @@ enum InputMethodEvent: Equatable {
 
 class StateMachine {
     private(set) var state: IMEState
-    /// ユーザー辞書に保存しないプライベートモードかどうか
-    private(set) var privateMode: Bool
     let inputMethodEvent: AnyPublisher<InputMethodEvent, Never>
     private let inputMethodEventSubject = PassthroughSubject<InputMethodEvent, Never>()
     let candidateEvent: AnyPublisher<Candidates?, Never>
@@ -32,11 +30,10 @@ class StateMachine {
     /// 変換候補パネルに一度に表示する変換候補の数
     let displayCandidateCount = 9
 
-    init(initialState: IMEState = IMEState(), privateMode: Bool = false) {
+    init(initialState: IMEState = IMEState()) {
         state = initialState
         inputMethodEvent = inputMethodEventSubject.eraseToAnyPublisher()
         candidateEvent = candidateEventSubject.removeDuplicates().eraseToAnyPublisher()
-        self.privateMode = privateMode
     }
 
     func handle(_ action: Action) -> Bool {
@@ -833,12 +830,6 @@ class StateMachine {
                 addFixedText(selecting.fixedText())
             }
         }
-    }
-
-    /// プライベートモードの有効無効を反転します。
-    func togglePrivateMode() {
-        privateMode = !privateMode
-        dictionary.privateMode = privateMode
     }
 
     private func addFixedText(_ text: String) {

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 mtgto <hogerappa@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import Combine
 import InputMethodKit
 import SwiftUI
 import os
 
 let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "main")
 var dictionary: UserDict!
+let privateMode = CurrentValueSubject<Bool, Never>(false)
 
 func isTest() -> Bool {
     return ProcessInfo.processInfo.environment["MACSKK_IS_TEST"] == "1"

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -28,7 +28,7 @@ struct macSKKApp: App {
 
     init() {
         do {
-            dictionary = try UserDict(dicts: [])
+            dictionary = try UserDict(dicts: [], privateMode: privateMode)
             dictionariesDirectoryUrl = try FileManager.default.url(
                 for: .documentDirectory,
                 in: .userDomainMask,
@@ -42,7 +42,7 @@ struct macSKKApp: App {
         setupUserDefaults()
         if isTest() {
             do {
-                dictionary = try UserDict(dicts: [])
+                dictionary = try UserDict(dicts: [], privateMode: privateMode)
             } catch {
                 logger.error("Error while loading userDictionary")
             }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1429,7 +1429,7 @@ final class StateMachineTests: XCTestCase {
     func testPrivateMode() throws {
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
         let dict = MemoryDict(entries: ["と": [Word("都")]])
-        dictionary = try UserDict(dicts: [dict], userDictEntries: [:])
+        dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode)
 
         let expectation = XCTestExpectation()
         privateMode.send(true)

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import macSKK
 
 final class StateMachineTests: XCTestCase {
-    var stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana), privateMode: false)
+    var stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
     var cancellables: Set<AnyCancellable> = []
 
     override func setUpWithError() throws {
@@ -1432,8 +1432,7 @@ final class StateMachineTests: XCTestCase {
         dictionary = try UserDict(dicts: [dict], userDictEntries: [:])
 
         let expectation = XCTestExpectation()
-        stateMachine = StateMachine(initialState: stateMachine.state, privateMode: true)
-        dictionary.privateMode = true
+        privateMode.send(true)
         stateMachine.inputMethodEvent.collect(4).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText(text: "▽t", cursor: nil)))
             XCTAssertEqual(events[1], .markedText(MarkedText(text: "▽と", cursor: nil)))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1427,6 +1427,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     func testPrivateMode() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
         let dict = MemoryDict(entries: ["と": [Word("都")]])
         dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode)

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -41,8 +41,8 @@ final class UserDictTests: XCTestCase {
     }
 
     func testPrivateMode() throws {
+        privateMode.send(true)
         let userDict = try UserDict(dicts: [], userDictEntries: [:])
-        userDict.privateMode = true
         let word1 = Word("井")
         let word2 = Word("伊")
         // addのテスト
@@ -61,7 +61,7 @@ final class UserDictTests: XCTestCase {
         XCTAssertTrue(userDict.delete(yomi: "い", word: Word("井")))
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["伊"])
         // プライベートモードが解除されるとプライベートモードでのエントリがリセットされる
-        userDict.privateMode = false
+        privateMode.send(false)
         XCTAssertTrue(userDict.privateUserDictEntries.isEmpty)
     }
 

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import XCTest
+import Combine
 
 @testable import macSKK
 
 final class UserDictTests: XCTestCase {
     func testSerialize() throws {
-        var userDict = try UserDict(dicts: [], userDictEntries: [:])
+        var userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode)
         XCTAssertEqual(userDict.serialize(), "")
-        userDict = try UserDict(dicts: [], userDictEntries: ["あ": [Word("亜", annotation: "亜の注釈")]])
+        userDict = try UserDict(dicts: [], userDictEntries: ["あ": [Word("亜", annotation: "亜の注釈")]], privateMode: privateMode)
         XCTAssertEqual(userDict.serialize(), "あ /亜;亜の注釈/")
     }
 
     func testAdd() throws {
-        let userDict = try UserDict(dicts: [], userDictEntries: [:])
+        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode)
         let word1 = Word("井")
         let word2 = Word("伊")
         userDict.add(yomi: "い", word: word1)
@@ -28,12 +29,12 @@ final class UserDictTests: XCTestCase {
     func testRefer() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]])
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]])
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]])
+        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]], privateMode: privateMode)
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊", "胃", "意"])
     }
 
     func testDelete() throws {
-        let userDict = try UserDict(dicts: [], userDictEntries: ["あr": [Word("有"), Word("在")]])
+        let userDict = try UserDict(dicts: [], userDictEntries: ["あr": [Word("有"), Word("在")]], privateMode: privateMode)
         XCTAssertTrue(userDict.delete(yomi: "あr", word: Word("在")))
         XCTAssertEqual(userDict.userDictEntries["あr"], [Word("有")])
         XCTAssertFalse(userDict.delete(yomi: "いいい", word: Word("いいい")))
@@ -41,8 +42,8 @@ final class UserDictTests: XCTestCase {
     }
 
     func testPrivateMode() throws {
-        privateMode.send(true)
-        let userDict = try UserDict(dicts: [], userDictEntries: [:])
+        let localPrivateMode = CurrentValueSubject<Bool, Never>(true)
+        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: localPrivateMode)
         let word1 = Word("井")
         let word2 = Word("伊")
         // addのテスト
@@ -61,12 +62,12 @@ final class UserDictTests: XCTestCase {
         XCTAssertTrue(userDict.delete(yomi: "い", word: Word("井")))
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["伊"])
         // プライベートモードが解除されるとプライベートモードでのエントリがリセットされる
-        privateMode.send(false)
+        localPrivateMode.send(false)
         XCTAssertTrue(userDict.privateUserDictEntries.isEmpty)
     }
 
     func testAppendDict() throws {
-        let userDict = try UserDict(dicts: [])
+        let userDict = try UserDict(dicts: [], privateMode: privateMode)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
         let fileDict = try FileDict(contentsOf: fileURL, encoding: .utf8)
         userDict.appendDict(fileDict)
@@ -79,7 +80,7 @@ final class UserDictTests: XCTestCase {
     func testDeleteDict() throws {
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
         let fileDict = try FileDict(contentsOf: fileURL, encoding: .utf8)
-        let userDict = try UserDict(dicts: [fileDict])
+        let userDict = try UserDict(dicts: [fileDict], privateMode: privateMode)
         XCTAssertFalse(userDict.deleteDict(id: "foo"))
         XCTAssertEqual(userDict.dicts.count, 1)
         XCTAssertTrue(userDict.deleteDict(id: "SKK-JISYO.test.utf8"), "idはファイル名")

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -8,6 +8,7 @@ import Combine
 
 final class UserDictTests: XCTestCase {
     func testSerialize() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         var userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode)
         XCTAssertEqual(userDict.serialize(), "")
         userDict = try UserDict(dicts: [], userDictEntries: ["あ": [Word("亜", annotation: "亜の注釈")]], privateMode: privateMode)
@@ -15,6 +16,7 @@ final class UserDictTests: XCTestCase {
     }
 
     func testAdd() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode)
         let word1 = Word("井")
         let word2 = Word("伊")
@@ -27,6 +29,7 @@ final class UserDictTests: XCTestCase {
     }
 
     func testRefer() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]])
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]])
         let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]], privateMode: privateMode)
@@ -34,6 +37,7 @@ final class UserDictTests: XCTestCase {
     }
 
     func testDelete() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         let userDict = try UserDict(dicts: [], userDictEntries: ["あr": [Word("有"), Word("在")]], privateMode: privateMode)
         XCTAssertTrue(userDict.delete(yomi: "あr", word: Word("在")))
         XCTAssertEqual(userDict.userDictEntries["あr"], [Word("有")])
@@ -42,8 +46,8 @@ final class UserDictTests: XCTestCase {
     }
 
     func testPrivateMode() throws {
-        let localPrivateMode = CurrentValueSubject<Bool, Never>(true)
-        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: localPrivateMode)
+        let privateMode = CurrentValueSubject<Bool, Never>(true)
+        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode)
         let word1 = Word("井")
         let word2 = Word("伊")
         // addのテスト
@@ -62,11 +66,12 @@ final class UserDictTests: XCTestCase {
         XCTAssertTrue(userDict.delete(yomi: "い", word: Word("井")))
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["伊"])
         // プライベートモードが解除されるとプライベートモードでのエントリがリセットされる
-        localPrivateMode.send(false)
+        privateMode.send(false)
         XCTAssertTrue(userDict.privateUserDictEntries.isEmpty)
     }
 
     func testAppendDict() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         let userDict = try UserDict(dicts: [], privateMode: privateMode)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
         let fileDict = try FileDict(contentsOf: fileURL, encoding: .utf8)
@@ -78,6 +83,7 @@ final class UserDictTests: XCTestCase {
     }
 
     func testDeleteDict() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
         let fileDict = try FileDict(contentsOf: fileURL, encoding: .utf8)
         let userDict = try UserDict(dicts: [fileDict], privateMode: privateMode)


### PR DESCRIPTION
プライベートモードの実装 (#12) ではプライベートモードかどうかをInputControllerごとにもっていたが、InputControllerのインスタンスは入力ごとに異なるためアプリをきりかえるとプライベートモードかどうかがきりかわってしまう問題があることがわかった。

プライベートモードかどうかをグローバル変数にもつように修正。
ついでの修正でグローバルではCurrentValueSubjectでもつようにしてUserDictとInputControlerではメンバでは持たずにグローバル変数の値を見るようにした。