### PR TITLE
設定の辞書設定からファイル辞書の優先順位をマウスで入れ替え可能にした

### DIFF
--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -11,27 +11,37 @@ struct DictionariesView: View {
         VStack {
             Form {
                 Section {
-                    ForEach($settingsViewModel.dictSettings) { dictSetting in
-                        HStack(alignment: .top) {
-                            Toggle(isOn: dictSetting.enabled) {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(dictSetting.id)
-                                        .font(.body)
-                                    Text(loadingStatus(of: dictSetting.wrappedValue))
-                                        .font(.footnote)
+                    List {
+                        ForEach($settingsViewModel.dictSettings) { dictSetting in
+                            HStack(alignment: .top) {
+                                Toggle(isOn: dictSetting.enabled) {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(dictSetting.id)
+                                            .font(.body)
+                                        Text(loadingStatus(of: dictSetting.wrappedValue))
+                                            .font(.footnote)
+                                    }
                                 }
+                                .toggleStyle(.switch)
+                                Button {
+                                    selectedDictSetting = dictSetting.wrappedValue
+                                } label: {
+                                    Image(systemName: "info.circle")
+                                        .resizable()
+                                        .frame(width: 16, height: 16)
+                                }
+                                .buttonStyle(.borderless)
                             }
-                            .toggleStyle(.switch)
-                            Button {
-                                selectedDictSetting = dictSetting.wrappedValue
-                            } label: {
-                                Image(systemName: "info.circle")
-                                    .resizable()
-                                    .frame(width: 16, height: 16)
-                            }
-                            .buttonStyle(.borderless)
+                            .padding(EdgeInsets(top: 4, leading: 2, bottom: 4, trailing: 2))
+                        }.onMove { from, to in
+                            settingsViewModel.dictSettings.move(fromOffsets: from, toOffset: to)
                         }
                     }
+                } header: {
+                    Text("SettingsFileDictionariesTitle")
+                    Text("SettingsFileDictionariesSubtitle")
+                        .font(.subheadline)
+                        .fontWeight(.light)
                 } footer: {
                     Button {
                         NSWorkspace.shared.open(settingsViewModel.dictionariesDirectoryUrl)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -13,8 +13,8 @@ class UserDict: DictProtocol {
     let fileURL: URL
     let fileHandle: FileHandle
     let source: DispatchSourceFileSystemObject
-    /// 有効になっている辞書
-    private(set) var dicts: [DictProtocol]
+    /// 有効になっている辞書。優先度が高い順。
+    var dicts: [DictProtocol]
     /// 非プライベートモードのユーザー辞書。変換や単語登録すると更新されマイ辞書ファイルに永続化されます。
     var userDictEntries: [String: [Word]] = [:]
     /// プライベートモードのユーザー辞書。プライベートモードが有効な時に変換や単語登録するとuserDictEntriesとは別に更新されます。
@@ -207,40 +207,6 @@ class UserDict: DictProtocol {
             }
         }
         return nil
-    }
-
-    /// ファイル辞書を追加する。すでに追加済だった場合はさしかえる。
-    func appendDict(_ fileDict: FileDict) {
-        let index = dicts.firstIndex(where: { dict in
-            if let dict = dict as? FileDict {
-                if dict.id == fileDict.id {
-                    return true
-                }
-            }
-            return false
-        })
-        if let index {
-            dicts[index] = fileDict
-        } else {
-            dicts.append(fileDict)
-        }
-    }
-
-    func deleteDict(id: FileDict.ID) -> Bool {
-        let index = dicts.firstIndex(where: { dict in
-            if let fileDict = dict as? FileDict {
-                if fileDict.id == id {
-                    return true
-                }
-            }
-            return false
-        })
-        if let index {
-            dicts.remove(at: index)
-            return true
-        } else {
-            return false
-        }
     }
 
     private func serializeWords(_ words: [Word]) -> String {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -7,6 +7,8 @@
 "SettingsNameSystemDict" = "System Dict";
 "SettingsOpenDictionaryFolder" = "Show Dictionaries in Finder";
 "SettingsNoteDictionaries" = "If you want to add a dictionary, place your dictionary file in the dictionary folder and activate it on this panel.";
+"SettingsFileDictionariesTitle" = "Dictionary files";
+"SettingsFileDictionariesSubtitle" = "You can reorder the priorities of dictionary by drag & drop";
 "LoadingStatusLoaded" = "%d entries";
 "LoadingStatusLoading" = "Loading…";
 "LoadingStatusError" = "Error: %@";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -7,6 +7,8 @@
 "SettingsNameSystemDict" = "システム辞書";
 "SettingsOpenDictionaryFolder" = "辞書フォルダをFinderで表示";
 "SettingsNoteDictionaries" = "辞書を追加したい場合は辞書フォルダに辞書ファイルを置き、この画面で有効化してください。";
+"SettingsFileDictionariesTitle" = "ファイル辞書";
+"SettingsFileDictionariesSubtitle" = "項目をドラッグすることで優先順位を入れ替え可能です。";
 "LoadingStatusLoaded" = "%d エントリ";
 "LoadingStatusLoading" = "読み込み中…";
 "LoadingStatusError" = "エラー: %@";

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -69,27 +69,4 @@ final class UserDictTests: XCTestCase {
         privateMode.send(false)
         XCTAssertTrue(userDict.privateUserDictEntries.isEmpty)
     }
-
-    func testAppendDict() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let userDict = try UserDict(dicts: [], privateMode: privateMode)
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
-        let fileDict = try FileDict(contentsOf: fileURL, encoding: .utf8)
-        userDict.appendDict(fileDict)
-        XCTAssertEqual(userDict.dicts.count, 1)
-        // FIXME: ほんとはIDが同じで中身が異なる辞書を作って、それを追加すると置換になることをテストしたい
-        userDict.appendDict(fileDict)
-        XCTAssertEqual(userDict.dicts.count, 1, "同じIDをもつ辞書を追加しても個数は増えない")
-    }
-
-    func testDeleteDict() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
-        let fileDict = try FileDict(contentsOf: fileURL, encoding: .utf8)
-        let userDict = try UserDict(dicts: [fileDict], privateMode: privateMode)
-        XCTAssertFalse(userDict.deleteDict(id: "foo"))
-        XCTAssertEqual(userDict.dicts.count, 1)
-        XCTAssertTrue(userDict.deleteDict(id: "SKK-JISYO.test.utf8"), "idはファイル名")
-        XCTAssertEqual(userDict.dicts.count, 0)
-    }
 }


### PR DESCRIPTION
`ForEach#onMove` を実装してあげれば、ForEachをもったListなら並び換え可能になる。
ただのForEachだとドラッグが発生しなかったのでListに入れてあげる必要があるようです。

<img width="552" alt="reorder" src="https://github.com/mtgto/macSKK/assets/1213991/2752cdf7-16d3-400b-9739-23021fe96875">
