### PR TITLE
ユーザー辞書にマジックコメントを追加。単語削除時に保存する処理を入れてなかったのを修正

### DIFF
--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -19,6 +19,9 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     var version: NSFileVersion?
     private(set) var dict: MemoryDict
 
+    /// シリアライズ時に先頭に付ける
+    static let headers = [";; -*- mode: fundamental; coding: utf-8 -*-"]
+
     // MARK: NSFilePresenter
     var presentedItemURL: URL? { fileURL }
     let presentedItemOperationQueue: OperationQueue = OperationQueue()
@@ -96,9 +99,9 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     /// ユーザー辞書をSKK辞書形式に変換する
     func serialize() -> String {
         // FIXME: 送り仮名あり・なしでエントリを分けるようにする?
-        return dict.entries.map { entry in
+        return (Self.headers + dict.entries.map { entry in
             return "\(entry.key) /\(serializeWords(entry.value))/"
-        }.joined(separator: "\n")
+        }).joined(separator: "\n")
     }
 
     var entryCount: Int { return dict.entries.count }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -160,7 +160,10 @@ class UserDict: NSObject, DictProtocol {
                 }
             }
         } else if let dict = dict as? FileDict {
-            return dict.delete(yomi: yomi, word: word)
+            if dict.delete(yomi: yomi, word: word) {
+                savePublisher.send(())
+                return true
+            }
         }
         return false
     }

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -32,8 +32,8 @@ final class FileDictTests: XCTestCase {
 
     func testSerialize() throws {
         let dict = try FileDict(contentsOf: fileURL, encoding: .utf8)
-        XCTAssertEqual(dict.serialize(), "")
+        XCTAssertEqual(dict.serialize(), FileDict.headers[0])
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))
-        XCTAssertEqual(dict.serialize(), "あ /亜;亜の注釈/")
+        XCTAssertEqual(dict.serialize(), FileDict.headers[0] + "\nあ /亜;亜の注釈/")
     }
 }


### PR DESCRIPTION
- 単語削除時にファイル保存を予定する処理を入れ忘れてたのを修正
  - デバッグできづいたけど終了時に強制永続化する処理が必要そう。別pull reqでやる
- マジックコメントでヘッダーを追加。
  - マジックコメントでエンコーディング判定とかしようかと思ったけどついてないやつも当然あるので普通にEUC-JPとUTF-8で試行錯誤したほうがよさそう。