### PR TITLE
インライン注釈が表示されたあと次の候補が注釈がないときに空パネルが残るバグを修正

### DIFF
--- a/macSKK/AnnotationView.swift
+++ b/macSKK/AnnotationView.swift
@@ -70,5 +70,17 @@ struct AnnotationView_Previews: PreviewProvider {
         )
         .frame(width: 300)
         .previewDisplayName("SKK辞書の注釈 & システム辞書の注釈")
+        AnnotationView(
+            annotations: .constant([]),
+            systemAnnotation: .constant(String(repeating: "これはシステム辞書の注釈です。", count: 10))
+        )
+        .frame(width: 300)
+        .previewDisplayName("システム辞書のみ")
+        AnnotationView(
+            annotations: .constant([]),
+            systemAnnotation: .constant(nil)
+        )
+        .frame(width: 300)
+        .previewDisplayName("注釈なし")
     }
 }

--- a/macSKK/CandidatesPanel.swift
+++ b/macSKK/CandidatesPanel.swift
@@ -24,7 +24,7 @@ final class CandidatesPanel: NSPanel {
     }
 
     func setSystemAnnotation(_ systemAnnotation: String, for word: Word.Word) {
-        viewModel.systemAnnotations.updateValue(systemAnnotation, forKey: word)
+        viewModel.systemAnnotations[word] = systemAnnotation
     }
 
     func setCursorPosition(_ cursorPosition: NSRect) {

--- a/macSKK/CandidatesView.swift
+++ b/macSKK/CandidatesView.swift
@@ -91,10 +91,25 @@ struct CandidatesView_Previews: PreviewProvider {
                      annotations: [Annotation(dictId: "SKK-JISYO.L", text: "注釈\($0)")])
     }
 
-    static var previews: some View {
+    private static func pageViewModel() -> CandidatesViewModel {
         let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3)
         viewModel.selected = words.first
         viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 10)]
-        return CandidatesView(candidates: viewModel)
+        return viewModel
+    }
+
+    private static func inlineViewModel() -> CandidatesViewModel {
+        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3)
+        viewModel.candidates = .inline
+        viewModel.selected = words.first
+        viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 10)]
+        return viewModel
+    }
+
+    static var previews: some View {
+        CandidatesView(candidates: pageViewModel())
+            .previewDisplayName("パネル表示")
+        CandidatesView(candidates: inlineViewModel())
+            .previewDisplayName("インライン表示")
     }
 }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -87,15 +87,14 @@ class InputController: IMKInputController {
                                                                       currentPage: page.current,
                                                                       totalPageCount: page.total)
                     self?.candidatesPanel.setCandidates(currentCandidates, selected: candidates.selected)
-                    self?.selectedWord.send(candidates.selected.word)
                     self?.candidatesPanel.show()
                 } else {
-                    self?.candidatesPanel.setCandidates(.inline, selected: candidates.selected)
-                    self?.selectedWord.send(candidates.selected.word)
-                    if !candidates.selected.annotations.isEmpty {
-                        self?.candidatesPanel.setCandidates(.inline, selected: candidates.selected)
+                    if candidates.selected.annotations.isEmpty {
+                        self?.candidatesPanel.orderOut(nil)
+                    } else {
                         self?.candidatesPanel.show()
                     }
+                    self?.candidatesPanel.setCandidates(.inline, selected: candidates.selected)
                 }
             } else {
                 // 変換→キャンセル→再変換しても注釈が表示されなくならないように状態を変えておく

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -91,6 +91,9 @@ struct macSKKApp: App {
                     candidatesPanel.setCursorPosition(NSRect(origin: NSPoint(x: 100, y: 640), size: CGSize(width: 0, height: 30)))
                     candidatesPanel.show()
                 }
+                Button("Hide AnnotataionsPanel") {
+                    candidatesPanel.orderOut(nil)
+                }
                 Button("SystemAnnotation") {
                     candidatesPanel.viewModel.systemAnnotations = ["インライン": (String(repeating: "これはシステム辞書の注釈です。", count: 5))]
                 }


### PR DESCRIPTION
1. 辞書注釈 or システム辞書にエントリがある変換候補を選択 → インライン注釈が表示される
2. スペースを押し次の変換候補を表示する
3. 新しい変換候補がいずれの注釈ももたない場合、インラインの注釈パネルが表示されたままになってしまう

注釈がなければ注釈パネルを非表示にすればいいだけだけど、システム辞書を引くタイミングがCandidatesViewModel.selectedが更新されたタイミングなのでViewModelに値をセットするタイミングを遅らせる必要があった。