### PR TITLE
プライベートモードをMemoryDictを使うようにリファクタ

### DIFF
--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -191,8 +191,6 @@ class UserDict: NSObject, DictProtocol {
 }
 
 extension UserDict: NSFilePresenter {
-    // TODO: dictSettingsに追加
-    // TODO: .DS_Storeのようなファイルも追加しようとしてないか確認
     func presentedSubitemDidAppear(at url: URL) {
         do {
             if try isValidFile(url) {
@@ -227,7 +225,6 @@ extension UserDict: NSFilePresenter {
                     NotificationCenter.default.post(name: notificationNameDictFileDidAppear, object: url)
                 } else {
                     // 辞書ファイルが別フォルダに移動したときにはpresentedSubitem:at:didMoveToも呼ばれる
-                    // FIXME: 辞書ファイルが削除されたときはdidMoveTo呼ばれるのか確認する
                     logger.log("ファイル \(url.lastPathComponent, privacy: .public) が更新されましたが辞書フォルダ外なので無視します")
                 }
 
@@ -240,7 +237,6 @@ extension UserDict: NSFilePresenter {
     }
 
     // 子要素を他フォルダに移動した場合に発生する
-    // TODO: dictSettingsを更新
     func presentedSubitem(at oldURL: URL, didMoveTo newURL: URL) {
         logger.log("ファイル \(oldURL.lastPathComponent, privacy: .public) が辞書フォルダから移動されました")
         NotificationCenter.default.post(name: notificationNameDictFileDidMove, object: oldURL)

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1542,13 +1542,13 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertNil(dictionary.entries())
-        XCTAssertTrue(dictionary.privateUserDictEntries.isEmpty)
+        XCTAssertTrue(dictionary.privateUserDict.entries.isEmpty)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertNil(dictionary.entries())
-        XCTAssertFalse(dictionary.privateUserDictEntries.isEmpty)
+        XCTAssertFalse(dictionary.privateUserDict.entries.isEmpty)
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -31,11 +31,11 @@ final class UserDictTests: XCTestCase {
         let word2 = Word("伊")
         // addのテスト
         userDict.add(yomi: "い", word: word1)
-        XCTAssertEqual(userDict.privateUserDictEntries, ["い": [word1]])
+        XCTAssertEqual(userDict.privateUserDict.entries, ["い": [word1]])
         userDict.add(yomi: "い", word: word2)
-        XCTAssertEqual(userDict.privateUserDictEntries, ["い": [word2, word1]])
+        XCTAssertEqual(userDict.privateUserDict.entries, ["い": [word2, word1]])
         userDict.add(yomi: "い", word: word1)
-        XCTAssertEqual(userDict.privateUserDictEntries, ["い": [word1, word2]])
+        XCTAssertEqual(userDict.privateUserDict.entries, ["い": [word1, word2]])
         // referのテスト
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊"])
         // deleteのテスト
@@ -43,6 +43,6 @@ final class UserDictTests: XCTestCase {
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["伊"])
         // プライベートモードが解除されるとプライベートモードでのエントリがリセットされる
         privateMode.send(false)
-        XCTAssertTrue(userDict.privateUserDictEntries.isEmpty)
+        XCTAssertTrue(userDict.privateUserDict.entries.isEmpty)
     }
 }


### PR DESCRIPTION
#27 でDictProtocolに追加・削除をつけてMemoryDictに破壊的命令ができるようになったのでプライベートモード辞書をMemoryDict構造体を使うように修正。