### PR TITLE
読みに非アルファベットを入力できるようにする

### DIFF
--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -30,10 +30,18 @@ struct Romaji: Equatable {
     }
 
     /**
-     * 入力されたローマ字をMojiに変換した結果
+     * 入力されたローマ字をMojiに変換した結果。Romaji.convertの返値として利用する。
+     *
+     * 例
+     * - aを入力: input: "", kakutei: "あ"
+     * - bを入力: input: "b", kakutei: nil
+     * - bbと入力: input: "b", kakutei: "っ"
+     * - dgと入力: input: "g", kakutei: nil (dのあとに続けられないgを入力したのでdは無効となった)
      */
     struct ConvertedMoji: Equatable {
+        /// 未確定で残っているローマ字
         let input: String
+        /// 確定した文字。
         let kakutei: Moji?
     }
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -647,6 +647,16 @@ class StateMachine {
                     }
                 }
                 updateMarkedText()
+            } else if !input.isAlphabet() {
+                // 非ローマ字で特殊な記号でない場合。特殊な辞書で数字が読みとして使われている場合を想定。
+                if okuri == nil {
+                    // ローマ字が残っていた場合は消去してキー入力をそのままくっつける
+                    state.inputMethod = .composing(composing.resetRomaji().appendText(Romaji.Moji(firstRomaji: input, kana: input)))
+                    updateMarkedText()
+                } else {
+                    // 送り仮名入力モード時は入力しなかった扱いとする
+                }
+                return true
             } else {  // converted.kakutei == nil
                 if !text.isEmpty && okuri == nil && action.shiftIsPressed() {
                     state.inputMethod = .composing(

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -265,10 +265,9 @@ class StateMachine {
             }
         }
 
-        let isAlphabet = input.unicodeScalars.allSatisfy { CharacterSet.letters.contains($0) }
         switch state.inputMode {
         case .hiragana, .katakana, .hankaku:
-            if isAlphabet && !action.optionIsPressed() {
+            if input.isAlphabet() && !action.optionIsPressed() {
                 let result = Romaji.convert(input)
                 if let moji = result.kakutei {
                     if action.shiftIsPressed() {

--- a/macSKK/String+Transform.swift
+++ b/macSKK/String+Transform.swift
@@ -38,4 +38,15 @@ extension String {
         }
         return converted
     }
+
+    /**
+     * アルファベットだけで構成されているかを返す。
+     *
+     * どちらかに決めないといけないので空文字列はtrue (そっちの方が自然だから)
+     */
+    func isAlphabet() -> Bool {
+        return self.unicodeScalars.allSatisfy {
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".unicodeScalars.contains($0)
+        }
+    }
 }

--- a/macSKKTests/String+TransformTests.swift
+++ b/macSKKTests/String+TransformTests.swift
@@ -41,4 +41,13 @@ final class StringTransformTests: XCTestCase {
         XCTAssertEqual("あっ".toKatakana(), "アッ")
         XCTAssertEqual("ぐう゛ぇ".toKatakana(), "グヴェ")
     }
+
+    func testIsAlphabet() {
+        XCTAssertTrue("".isAlphabet(), "空文字列はtrue")
+        XCTAssertTrue("abcdefghijklmnopqrstuvwxyz".isAlphabet())
+        XCTAssertTrue("ABCDEFGHIJKLMNOPQRSTUVWXYZ".isAlphabet())
+        XCTAssertFalse("1".isAlphabet())
+        XCTAssertFalse("å".isAlphabet(), "Option+A")
+        XCTAssertFalse("!".isAlphabet())
+    }
 }


### PR DESCRIPTION
英数字をそのまま読みとして使うabbrevモードを除き、通常読みの入力中は数字などが入力される可能性はあまりないため読みとして入力できないようにしていました。
実際SKK-JISYO.Lにはひらがなとセットで読みとして登録されているエントリは現時点ではありません。

しかし「い168」を「伊168」の読みとして登録する辞書があったり、AquaSKKやddskkでも読みに数字を含む文字を使えるようだったので対応します。

- 読み部分
  - 数字 → そのまま採用
  - Shift + 数字 → `!@#` のような変換後の記号を採用
  - ハイフン → 長音として採用
- 送り仮名
  - 非アルファベット → 全部入力されなかったものとして無視
    - AquaSKKは一文字以上入力済みの場合は入力済み送り仮名(として確定する前のローマ字)が消滅するがこのPull Requestでは非アルファベットは無視するため送り仮名のローマ字は残る、という些細な違いがある