### PR TITLE
ユーザー辞書の情報を辞書設定に表示する

### DIFF
--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -11,6 +11,16 @@ struct DictionariesView: View {
         VStack {
             Form {
                 Section {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(UserDict.userDictFilename)
+                            .font(.body)
+                        Text(loadingStatus(of: settingsViewModel.userDictLoadingStatus))
+                            .font(.footnote)
+                    }
+                } header: {
+                    Text("SettingsNameUserDictTitle")
+                }
+                Section {
                     List {
                         ForEach($settingsViewModel.dictSettings) { dictSetting in
                             HStack(alignment: .top) {
@@ -18,7 +28,7 @@ struct DictionariesView: View {
                                     VStack(alignment: .leading, spacing: 2) {
                                         Text(dictSetting.id)
                                             .font(.body)
-                                        Text(loadingStatus(of: dictSetting.wrappedValue))
+                                        Text(loadingStatus(setting: dictSetting.wrappedValue))
                                             .font(.footnote)
                                     }
                                 }
@@ -66,23 +76,27 @@ struct DictionariesView: View {
         }
     }
 
-    private func loadingStatus(of setting: DictSetting) -> String {
+    private func loadingStatus(setting: DictSetting) -> String {
         if let status = settingsViewModel.dictLoadingStatuses[setting.id] {
-            switch status {
-            case .loaded(let count):
-                return String(format: NSLocalizedString("LoadingStatusLoaded", comment: "%d エントリ"), count)
-            case .loading:
-                return NSLocalizedString("LoadingStatusLoading", comment: "読み込み中…")
-            case .disabled:
-                return NSLocalizedString("LoadingStatusDisabled", comment: "無効")
-            case .fail(let error):
-                return String(format: NSLocalizedString("LoadingStatusError", comment: "エラー: %@"), error as NSError)
-            }
+            return loadingStatus(of: status)
         } else if !setting.enabled {
             // 元々無効になっていて、設定を今回の起動で切り替えてない辞書
             return NSLocalizedString("LoadingStatusDisabled", comment: "無効")
         } else {
             return NSLocalizedString("LoadingStatusUnknown", comment: "不明")
+        }
+    }
+
+    private func loadingStatus(of status: LoadStatus) -> String {
+        switch status {
+        case .loaded(let count):
+            return String(format: NSLocalizedString("LoadingStatusLoaded", comment: "%d エントリ"), count)
+        case .loading:
+            return NSLocalizedString("LoadingStatusLoading", comment: "読み込み中…")
+        case .disabled:
+            return NSLocalizedString("LoadingStatusDisabled", comment: "無効")
+        case .fail(let error):
+            return String(format: NSLocalizedString("LoadingStatusError", comment: "エラー: %@"), error as NSError)
         }
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -6,7 +6,7 @@ import Foundation
 import SwiftUI
 
 final class DictSetting: ObservableObject, Identifiable {
-    typealias ID = String
+    typealias ID = FileDict.ID
     @Published var filename: String
     @Published var enabled: Bool
     @Published var encoding: String.Encoding
@@ -99,7 +99,9 @@ final class SettingsViewModel: ObservableObject {
     @Published var fetchingRelease: Bool = false
     /// すべての利用可能なSKK辞書の設定
     @Published var dictSettings: [DictSetting] = []
-    /// 利用可能な辞書の読み込み状態
+    /// ユーザー辞書の読み込み状況
+    @Published var userDictLoadingStatus: LoadStatus = .loading
+    /// 利用可能なユーザー辞書以外の辞書の読み込み状態
     @Published var dictLoadingStatuses: [DictSetting.ID: LoadStatus] = [:]
     /// 直接入力するアプリケーションのBundle Identifier
     @Published var directModeApplications: [DirectModeApplication] = []
@@ -181,6 +183,11 @@ final class SettingsViewModel: ObservableObject {
         $dictSettings.filter({ !$0.isEmpty }).first().sink { [weak self] _ in
             self?.setupNotification()
         }.store(in: &cancellables)
+
+        dictionary.entryCount.sink { [weak self] entryCount in
+            self?.userDictLoadingStatus = .loaded(entryCount)
+        }
+        .store(in: &cancellables)
     }
 
     // PreviewProvider用

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -7,6 +7,7 @@
 "SettingsNameDirectMode" = "Direct Mode";
 "SettingsNameKeyEvent" = "Key Event";
 "SettingsNameSystemDict" = "System Dict";
+"SettingsNameUserDictTitle" = "User Dictionary";
 "SettingsOpenDictionaryFolder" = "Show Dictionaries in Finder";
 "SettingsNoteDictionaries" = "If you want to add a dictionary, place your dictionary file in the dictionary folder and activate it on this panel.";
 "SettingsFileDictionariesTitle" = "Dictionary files";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -7,6 +7,7 @@
 "SettingsNameDirectMode" = "直接入力";
 "SettingsNameKeyEvent" = "キーイベント";
 "SettingsNameSystemDict" = "システム辞書";
+"SettingsNameUserDictTitle" = "ユーザー辞書";
 "SettingsOpenDictionaryFolder" = "辞書フォルダをFinderで表示";
 "SettingsNoteDictionaries" = "辞書を追加したい場合は辞書フォルダに辞書ファイルを置き、この画面で有効化してください。";
 "SettingsFileDictionariesTitle" = "ファイル辞書";


### PR DESCRIPTION
ユーザー辞書の情報も設定の辞書に表示するようにします。
機能は思いつかないのでひとまず登録されたエントリ数だけ表示してみます。
たとえばエントリ一覧が見れて削除がUIからできてもいいかもしれない。
あとはプライベートモードかどうかを表示するとか?

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/96c1f667-5d8d-4ea5-bf67-7d5c995a976e">
