### PR TITLE
辞書をシリアライズするときに送りありなしや使用順序を記録する

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		CED7CA3E2A8397E4004EF988 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA3D2A8397E4004EF988 /* UpdateCheckerTests.swift */; };
 		CED7CA592A83CD67004EF988 /* releases.atom in Resources */ = {isa = PBXBuildFile; fileRef = CED7CA582A83CD67004EF988 /* releases.atom */; };
 		CED7CA5B2A83DE7F004EF988 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA5A2A83DE7F004EF988 /* SettingsViewModel.swift */; };
+		CED7F51F2AB5F4A7007FC6BD /* Character+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7F51E2AB5F4A7007FC6BD /* Character+Additions.swift */; };
 		CEE2D9772A99FE1B00A4CD76 /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE2D9762A99FE1B00A4CD76 /* Word.swift */; };
 		CEE2D9792A99FEC700A4CD76 /* WordTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE2D9782A99FEC700A4CD76 /* WordTest.swift */; };
 		CEE3717529653112000DB2C3 /* SoftwareUpdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE3717429653112000DB2C3 /* SoftwareUpdateView.swift */; };
@@ -161,6 +162,7 @@
 		CED7CA3D2A8397E4004EF988 /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
 		CED7CA582A83CD67004EF988 /* releases.atom */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = releases.atom; sourceTree = "<group>"; };
 		CED7CA5A2A83DE7F004EF988 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		CED7F51E2AB5F4A7007FC6BD /* Character+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+Additions.swift"; sourceTree = "<group>"; };
 		CEE2D9762A99FE1B00A4CD76 /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
 		CEE2D9782A99FEC700A4CD76 /* WordTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordTest.swift; sourceTree = "<group>"; };
 		CEE3717429653112000DB2C3 /* SoftwareUpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateView.swift; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				CE6DBAAF2A85AA1200F5A227 /* LatestReleaseFetcher.swift */,
 				CED7CA3B2A839603004EF988 /* UpdateChecker.swift */,
 				CEA78FAB2960401F00B67E25 /* String+Transform.swift */,
+				CED7F51E2AB5F4A7007FC6BD /* Character+Additions.swift */,
 				CE485A892A8FA5C6008271EF /* UserNotificationDelegate.swift */,
 				CEC376E929651DE000D9C432 /* Settings */,
 				CEB088922A81342E00EFD1E3 /* macSKK-Bridging-Header.h */,
@@ -502,6 +505,7 @@
 				CED7CA5B2A83DE7F004EF988 /* SettingsViewModel.swift in Sources */,
 				CE5EB6AF2AAC0DEB00389B98 /* MemoryDict.swift in Sources */,
 				CEA78FAC2960401F00B67E25 /* String+Transform.swift in Sources */,
+				CED7F51F2AB5F4A7007FC6BD /* Character+Additions.swift in Sources */,
 				CE84A3B929570C37009394C4 /* InputController.swift in Sources */,
 				CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */,
 				CE84A3EB295DA715009394C4 /* Dict.swift in Sources */,

--- a/macSKK/Character+Additions.swift
+++ b/macSKK/Character+Additions.swift
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+extension Character {
+    /**
+     * アルファベットだけで構成されているかを返す。
+     */
+    var isAlphabet: Bool {
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".contains(self)
+    }
+}

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -27,6 +27,8 @@ class FileDict: NSObject, DictProtocol, Identifiable {
 
     /// シリアライズ時に先頭に付ける
     static let headers = [";; -*- mode: fundamental; coding: utf-8 -*-"]
+    static let okuriAriHeader = ";; okuri-ari entries."
+    static let okuriNashiHeader = ";; okuri-nasi entries."
 
     // MARK: NSFilePresenter
     var presentedItemURL: URL? { fileURL }
@@ -110,10 +112,24 @@ class FileDict: NSObject, DictProtocol, Identifiable {
 
     /// ユーザー辞書をSKK辞書形式に変換する
     func serialize() -> String {
-        // FIXME: 送り仮名あり・なしでエントリを分けるようにする?
-        return (Self.headers + dict.entries.map { entry in
-            return "\(entry.key) /\(serializeWords(entry.value))/"
-        }).joined(separator: "\n")
+        if readonly {
+            return (Self.headers + dict.entries.map { entry in
+                return "\(entry.key) /\(serializeWords(entry.value))/"
+            }).joined(separator: "\n")
+        }
+        var result: [String] = Self.headers + [Self.okuriAriHeader]
+        for yomi in dict.okuriAriYomis.reversed() {
+            if let words = dict.entries[yomi] {
+                result.append("\(yomi) /\(serializeWords(words))/")
+            }
+        }
+        result.append(Self.okuriNashiHeader)
+        for yomi in dict.okuriNashiYomis.reversed() {
+            if let words = dict.entries[yomi] {
+                result.append("\(yomi) /\(serializeWords(words))/")
+            }
+        }
+        return result.joined(separator: "\n")
     }
 
     var entryCount: Int { return dict.entryCount }

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -113,9 +113,9 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     /// ユーザー辞書をSKK辞書形式に変換する
     func serialize() -> String {
         if readonly {
-            return (Self.headers + dict.entries.map { entry in
+            return dict.entries.map { entry in
                 return "\(entry.key) /\(serializeWords(entry.value))/"
-            }).joined(separator: "\n")
+            }.joined(separator: "\n")
         }
         var result: [String] = Self.headers + [Self.okuriAriHeader]
         for yomi in dict.okuriAriYomis.reversed() {
@@ -129,6 +129,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
                 result.append("\(yomi) /\(serializeWords(words))/")
             }
         }
+        result.append("")
         return result.joined(separator: "\n")
     }
 

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -5,27 +5,55 @@ import Foundation
 
 /// 実ファイルをもたないSKK辞書
 struct MemoryDict: DictProtocol {
+    /**
+     * 読み込み専用で保存しないかどうか
+     *
+     * okuriNashiYomisを管理するのに使います。
+     */
+    private let readonly: Bool
     private(set) var entries: [String: [Word]]
+    /**
+     * 送りなしの読みの配列。最近変換したものが後に登場する。
+     *
+     * シリアライズするときはddskkに合わせて最近変換したものが前に登場するようにする。
+     * ユーザー辞書だと更新されるのでNSOrderedSetにしたほうが先頭への追加が早いかも?
+     */
+    private(set) var okuriNashiYomis: [String] = []
+    /// 送りありの読みの配列。最近変換したものが後に登場する。
+    private(set) var okuriAriYomis: [String] = []
 
-    init(dictId: FileDict.ID, source: String) throws {
+    init(dictId: FileDict.ID, source: String, readonly: Bool) throws {
+        self.readonly = readonly
         var dict: [String: [Word]] = [:]
+        var okuriNashiYomis: [String] = []
+        var okuriAriYomis: [String] = []
         let pattern = try Regex(#"^(\S+) (/(?:[^/\n\r]+/)+)$"#).anchorsMatchLineEndings()
         for match in source.matches(of: pattern) {
-            guard let word = match.output[1].substring else { continue }
+            guard let yomi = match.output[1].substring.map({ String($0) }) else { continue }
             guard let wordsText = match.output[2].substring else { continue }
+            if let first = yomi.first, let last = yomi.last, !readonly && (!last.isASCII || first.isASCII) {
+                okuriNashiYomis.append(yomi)
+            } else {
+                okuriAriYomis.append(yomi)
+            }
             let words = wordsText.split(separator: Character("/")).map { word -> Word in
                 let words = word.split(separator: Character(";"), maxSplits: 1)
                 let annotation = words.count == 2 ? Annotation(dictId: dictId, text: Self.decode(String(words[1]))) : nil
                 return Word(Self.decode(String(words[0])), annotation: annotation)
             }
-            dict[String(word)] = words
+            dict[yomi] = words
         }
         entries = dict
+        self.okuriNashiYomis = okuriNashiYomis.reversed()
+        self.okuriAriYomis = okuriAriYomis.reversed()
     }
 
-    init(entries: [String: [Word]]) {
+    init(entries: [String: [Word]], readonly: Bool) {
+        self.readonly = readonly
         self.entries = entries
     }
+
+    var entryCount: Int { return entries.count }
 
     // MARK: DictProtocol
     func refer(_ yomi: String) -> [Word] {

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -11,6 +11,9 @@ struct MemoryDict: DictProtocol {
      * okuriNashiYomisを管理するのに使います。
      */
     private let readonly: Bool
+    /**
+     * 辞書のエントリ一覧。キーは読み、値は変換候補 (優先度の高い順)
+     */
     private(set) var entries: [String: [Word]]
     /**
      * 送りなしの読みの配列。最近変換したものが後に登場する。
@@ -70,6 +73,9 @@ struct MemoryDict: DictProtocol {
     }
 
     /// 辞書にエントリを追加する。
+    ///
+    /// すでに同じ読みが登録されている場合、
+    /// ユーザー辞書で最近変換したものが次回も変換候補になるように値の配列の先頭に追加する。
     ///
     /// - Parameters:
     ///   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -128,7 +128,7 @@ final class SettingsViewModel: ObservableObject {
                         do {
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
                             self.loadStatusPublisher.send((dictSetting.id, .loading))
-                            let fileDict = try FileDict(contentsOf: fileURL, encoding: dictSetting.encoding)
+                            let fileDict = try FileDict(contentsOf: fileURL, encoding: dictSetting.encoding, readonly: true)
                             self.loadStatusPublisher.send((dictSetting.id, .loaded(fileDict.entryCount)))
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
                             return fileDict

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -267,7 +267,7 @@ class StateMachine {
 
         switch state.inputMode {
         case .hiragana, .katakana, .hankaku:
-            if input.isAlphabet() && !action.optionIsPressed() {
+            if input.isAlphabet && !action.optionIsPressed() {
                 let result = Romaji.convert(input)
                 if let moji = result.kakutei {
                     if action.shiftIsPressed() {
@@ -647,7 +647,7 @@ class StateMachine {
                     }
                 }
                 updateMarkedText()
-            } else if !input.isAlphabet() {
+            } else if !input.isAlphabet {
                 // 非ローマ字で特殊な記号でない場合。特殊な辞書で数字が読みとして使われている場合を想定。
                 if okuri == nil {
                     // ローマ字が残っていた場合は消去してキー入力をそのままくっつける

--- a/macSKK/String+Transform.swift
+++ b/macSKK/String+Transform.swift
@@ -42,11 +42,19 @@ extension String {
     /**
      * アルファベットだけで構成されているかを返す。
      *
-     * どちらかに決めないといけないので空文字列はtrue (そっちの方が自然だから)
+     * どちらかに決めないといけないので空文字列はtrue
      */
-    func isAlphabet() -> Bool {
-        return self.unicodeScalars.allSatisfy {
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".unicodeScalars.contains($0)
+    var isAlphabet: Bool { self.allSatisfy { $0.isAlphabet } }
+
+    /**
+     * 自身が見出し語のとき、送り仮名ありの見出し語かどうかを返す。
+     *
+     * どちらかに決めないといけないので一文字もしくは空文字列はfalse
+     */
+    var isOkuriAri: Bool {
+        if let first = first, let last = last, count > 1 {
+            return last.isAlphabet && !first.isAlphabet
         }
+        return false
     }
 }

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -35,12 +35,40 @@ final class FileDictTests: XCTestCase {
         dict.add(yomi: "あ", word: Word("阿", annotation: Annotation(dictId: "testDict", text: "阿の注釈")))
         dict.add(yomi: "あr", word: Word("有", annotation: Annotation(dictId: "testDict", text: "有の注釈")))
         dict.add(yomi: "あr", word: Word("在", annotation: Annotation(dictId: "testDict", text: "在の注釈")))
-        let expected = [
+        var expected = [
             FileDict.headers[0],
             FileDict.okuriAriHeader,
             "あr /在;在の注釈/有;有の注釈/",
             FileDict.okuriNashiHeader,
             "あ /阿;阿の注釈/亜;亜の注釈/",
+            "",
+        ].joined(separator: "\n")
+        XCTAssertEqual(dict.serialize(), expected)
+        // 追加したエントリはシリアライズ時は先頭に付く
+        dict.add(yomi: "い", word: Word("伊"))
+        dict.add(yomi: "いr", word: Word("射"))
+        expected = [
+            FileDict.headers[0],
+            FileDict.okuriAriHeader,
+            "いr /射/",
+            "あr /在;在の注釈/有;有の注釈/",
+            FileDict.okuriNashiHeader,
+            "い /伊/",
+            "あ /阿;阿の注釈/亜;亜の注釈/",
+            "",
+        ].joined(separator: "\n")
+        XCTAssertEqual(dict.serialize(), expected)
+        // 追加更新した場合は順序を変更する。削除更新した場合は順序を変更しない
+        XCTAssertTrue(dict.delete(yomi: "あ", word: "亜"))
+        dict.add(yomi: "あr", word: Word("或"))
+        expected = [
+            FileDict.headers[0],
+            FileDict.okuriAriHeader,
+            "あr /或/在;在の注釈/有;有の注釈/",
+            "いr /射/",
+            FileDict.okuriNashiHeader,
+            "い /伊/",
+            "あ /阿;阿の注釈/",
             "",
         ].joined(separator: "\n")
         XCTAssertEqual(dict.serialize(), expected)

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -34,6 +34,14 @@ final class FileDictTests: XCTestCase {
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))
         dict.add(yomi: "あ", word: Word("阿", annotation: Annotation(dictId: "testDict", text: "阿の注釈")))
         dict.add(yomi: "あr", word: Word("有", annotation: Annotation(dictId: "testDict", text: "有の注釈")))
-        XCTAssertEqual(dict.serialize(), FileDict.headers[0] + "\nあ /亜;亜の注釈/")
+        dict.add(yomi: "あr", word: Word("在", annotation: Annotation(dictId: "testDict", text: "在の注釈")))
+        let expected = [
+            FileDict.headers[0],
+            FileDict.okuriAriHeader,
+            "あr /在;在の注釈/有;有の注釈/",
+            FileDict.okuriNashiHeader,
+            "あ /阿;阿の注釈/亜;亜の注釈/",
+        ].joined(separator: "\n")
+        XCTAssertEqual(dict.serialize(), expected)
     }
 }

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -28,9 +28,12 @@ final class FileDictTests: XCTestCase {
     }
 
     func testSerialize() throws {
-        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8, readonly: true)
-        XCTAssertEqual(dict.serialize(), FileDict.headers[0])
+        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8, readonly: false)
+        XCTAssertEqual(dict.serialize(),
+                       [FileDict.headers[0], FileDict.okuriAriHeader, FileDict.okuriNashiHeader].joined(separator: "\n"))
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))
+        dict.add(yomi: "あ", word: Word("阿", annotation: Annotation(dictId: "testDict", text: "阿の注釈")))
+        dict.add(yomi: "あr", word: Word("有", annotation: Annotation(dictId: "testDict", text: "有の注釈")))
         XCTAssertEqual(dict.serialize(), FileDict.headers[0] + "\nあ /亜;亜の注釈/")
     }
 }

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -30,7 +30,7 @@ final class FileDictTests: XCTestCase {
     func testSerialize() throws {
         let dict = try FileDict(contentsOf: fileURL, encoding: .utf8, readonly: false)
         XCTAssertEqual(dict.serialize(),
-                       [FileDict.headers[0], FileDict.okuriAriHeader, FileDict.okuriNashiHeader].joined(separator: "\n"))
+                       [FileDict.headers[0], FileDict.okuriAriHeader, FileDict.okuriNashiHeader, ""].joined(separator: "\n"))
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))
         dict.add(yomi: "あ", word: Word("阿", annotation: Annotation(dictId: "testDict", text: "阿の注釈")))
         dict.add(yomi: "あr", word: Word("有", annotation: Annotation(dictId: "testDict", text: "有の注釈")))
@@ -41,6 +41,7 @@ final class FileDictTests: XCTestCase {
             "あr /在;在の注釈/有;有の注釈/",
             FileDict.okuriNashiHeader,
             "あ /阿;阿の注釈/亜;亜の注釈/",
+            "",
         ].joined(separator: "\n")
         XCTAssertEqual(dict.serialize(), expected)
     }

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -9,34 +9,26 @@ final class FileDictTests: XCTestCase {
     let fileURL = Bundle(for: FileDictTests.self).url(forResource: "empty", withExtension: "txt")!
 
     func testAdd() throws {
-        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8)
+        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8, readonly: true)
         XCTAssertEqual(dict.entryCount, 0)
-        let word1 = Word("井")
-        let word2 = Word("伊")
+        let word = Word("井")
         XCTAssertFalse(dict.hasUnsavedChanges)
-        dict.add(yomi: "い", word: word1)
-        XCTAssertEqual(dict.refer("い"), [word1])
+        dict.add(yomi: "い", word: word)
+        XCTAssertEqual(dict.refer("い"), [word])
         XCTAssertTrue(dict.hasUnsavedChanges)
-        dict.add(yomi: "い", word: word2)
-        XCTAssertEqual(dict.refer("い"), [word2, word1])
-        dict.add(yomi: "い", word: word1)
-        XCTAssertEqual(dict.refer("い"), [word1, word2])
     }
 
     func testDelete() throws {
-        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8)
-        dict.setEntries(["あr": [Word("有"), Word("在")]])
+        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8, readonly: true)
+        dict.setEntries(["あr": [Word("有"), Word("在")]], readonly: true)
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
         XCTAssertFalse(dict.hasUnsavedChanges)
         XCTAssertTrue(dict.delete(yomi: "あr", word: "在"))
         XCTAssertTrue(dict.hasUnsavedChanges)
-        XCTAssertEqual(dict.refer("あr"), [Word("有")])
-        XCTAssertFalse(dict.delete(yomi: "いいい", word: "いいい"))
-        XCTAssertFalse(dict.delete(yomi: "あr", word: "在"))
     }
 
     func testSerialize() throws {
-        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8)
+        let dict = try FileDict(contentsOf: fileURL, encoding: .utf8, readonly: true)
         XCTAssertEqual(dict.serialize(), FileDict.headers[0])
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))
         XCTAssertEqual(dict.serialize(), FileDict.headers[0] + "\nあ /亜;亜の注釈/")

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -51,18 +51,25 @@ class MemoryDictTests: XCTestCase {
         let word2 = Word("伊")
         dict.add(yomi: "い", word: word1)
         XCTAssertEqual(dict.refer("い"), [word1])
+        XCTAssertEqual(dict.okuriNashiYomis, ["い"])
+        dict.add(yomi: "う", word: Word("宇"))
+        XCTAssertEqual(dict.okuriNashiYomis, ["い", "う"])
         dict.add(yomi: "い", word: word2)
         XCTAssertEqual(dict.refer("い"), [word2, word1])
+        XCTAssertEqual(dict.okuriNashiYomis, ["う", "い"])
         dict.add(yomi: "い", word: word1)
         XCTAssertEqual(dict.refer("い"), [word1, word2])
     }
 
     func testDelete() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")]], readonly: false)
+        XCTAssertEqual(dict.okuriAriYomis, ["あr"])
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
         XCTAssertTrue(dict.delete(yomi: "あr", word: "在"))
         XCTAssertEqual(dict.refer("あr"), [Word("有")])
         XCTAssertFalse(dict.delete(yomi: "いいい", word: "いいい"))
         XCTAssertFalse(dict.delete(yomi: "あr", word: "在"))
+        XCTAssertTrue(dict.delete(yomi: "あr", word: "有"))
+        XCTAssertEqual(dict.okuriAriYomis, [])
     }
 }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1513,9 +1513,9 @@ final class StateMachineTests: XCTestCase {
         let annotation1 = Annotation(dictId: "dict1", text: "dict1")
         let annotation2 = Annotation(dictId: "dict2", text: "dict2")
         let annotation3 = Annotation(dictId: "dict3", text: "dict2")
-        let dict1 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation1)]])
-        let dict2 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation2)]])
-        let dict3 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation3)]])
+        let dict1 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation1)]], readonly: true)
+        let dict2 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation2)]], readonly: true)
+        let dict3 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation3)]], readonly: true)
         dictionary.dicts = [dict1, dict2, dict3]
 
         let expectation = XCTestExpectation()
@@ -1537,7 +1537,7 @@ final class StateMachineTests: XCTestCase {
     func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
-        let dict = MemoryDict(entries: ["と": [Word("都")]])
+        let dict = MemoryDict(entries: ["と": [Word("都")]], readonly: true)
         dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode)
 
         let expectation = XCTestExpectation()

--- a/macSKKTests/String+TransformTests.swift
+++ b/macSKKTests/String+TransformTests.swift
@@ -43,11 +43,22 @@ final class StringTransformTests: XCTestCase {
     }
 
     func testIsAlphabet() {
-        XCTAssertTrue("".isAlphabet(), "空文字列はtrue")
-        XCTAssertTrue("abcdefghijklmnopqrstuvwxyz".isAlphabet())
-        XCTAssertTrue("ABCDEFGHIJKLMNOPQRSTUVWXYZ".isAlphabet())
-        XCTAssertFalse("1".isAlphabet())
-        XCTAssertFalse("å".isAlphabet(), "Option+A")
-        XCTAssertFalse("!".isAlphabet())
+        XCTAssertTrue("".isAlphabet, "空文字列はtrue")
+        XCTAssertTrue("abcdefghijklmnopqrstuvwxyz".isAlphabet)
+        XCTAssertTrue("ABCDEFGHIJKLMNOPQRSTUVWXYZ".isAlphabet)
+        XCTAssertFalse("1".isAlphabet)
+        XCTAssertFalse("å".isAlphabet, "Option+A")
+        XCTAssertFalse("!".isAlphabet)
+        XCTAssertFalse("あ".isAlphabet)
+    }
+
+    func testIsOkuriAri() {
+        XCTAssertFalse("".isOkuriAri, "空文字列はfalse")
+        XCTAssertTrue("あr".isOkuriAri)
+        XCTAssertFalse("あいうえお".isOkuriAri)
+        XCTAssertFalse("い58".isOkuriAri)
+        XCTAssertFalse("skk".isOkuriAri, "Abbrevの見出し")
+        XCTAssertFalse("b".isOkuriAri)
+        XCTAssertFalse("ん".isOkuriAri)
     }
 }

--- a/macSKKTests/UserDict+Utilities.swift
+++ b/macSKKTests/UserDict+Utilities.swift
@@ -6,7 +6,7 @@
 extension UserDict {
     func setEntries(_ entries: [String: [Word]]) {
         if let dict = userDict as? FileDict {
-            dict.setEntries(entries)
+            dict.setEntries(entries, readonly: true)
         }
     }
 

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -9,16 +9,16 @@ import Combine
 final class UserDictTests: XCTestCase {
     func testRefer() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]])
-        let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]])
+        let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]], readonly: true)
+        let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true)
         let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]], privateMode: privateMode)
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊", "胃", "意"])
     }
 
     func testReferMergeAnnotation() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]])
-        let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]])
+        let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true)
+        let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
         let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: [:], privateMode: privateMode)
         XCTAssertEqual(userDict.refer("い").map({ $0.word }).sorted(), ["伊", "意", "胃", "胃"], "dict1, dict2に胃が1つずつある")
         XCTAssertEqual(userDict.refer("い").compactMap({ $0.annotation?.dictId }), ["dict1", "dict2"])


### PR DESCRIPTION
ユーザー辞書から補完機能を作るにあたって、前準備としてシリアライズのやりかたを変更します。

- ユーザー辞書のみ辞書エントリの読みを順序つきで保持するようにします。
  - MemoryDictのコンストラクタでreadonly=falseで呼び出したときだけ保持する。
  - 読み配列への追加処理がO(1)で済むように追加・更新は末尾に追加します。
- 辞書のシリアライズの方法を変更し、送りありなしを分けてそれぞれの先頭に `okuri-ari entries` `okuri-nashi entries` ヘッダーをコメントでつけるようにします。
- シリアライズする際に使用順序を記録しておき、送りありも送りなしもどちらも先頭に最近使用したものがくるようにします。
  - これはddskkに合わせています。


読み込む際は送りありなしのコメント行は無視しているので単に先に出てくるものが最近使用したものとして解釈します。

## Before/Afterのイメージ

### Before

```
;; -*- mode: fundamental; coding: utf-8 -*-
(送り仮名ありなし混合のエントリ。Dictionaryを列挙した順)
```

### After

```
;; -*- mode: fundamental; coding: utf-8 -*-
;; okuri-ari entries.
(送り仮名ありのエントリ。最近使用したものが上にくる)
;; okuri-nashi entries.
(送り仮名なしのエントリ。最近使用したものが上にくる)
```