### PR TITLE
macSKK外で辞書が更新されたときのイベントで読み込む

### DIFF
--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -191,10 +191,10 @@ extension FileDict: NSFilePresenter {
     // BのpresentedItemDidChangeは呼び出される。
     func presentedItemDidChange() {
         if let version = NSFileVersion.currentVersionOfItem(at: fileURL), version == self.version {
-            logger.log("辞書 \(self.id, privacy: .public) が変更されましたがバージョンが変更されてないため何もしません")
+            logger.log("辞書 \(self.id, privacy: .public) がアプリ外で変更されたため読み込みます")
         } else {
             logger.log("辞書 \(self.id, privacy: .public) が変更されたので読み込みます")
-            try? load(fileURL)
         }
+        try? load(fileURL)
     }
 }


### PR DESCRIPTION
辞書ファイルを上書きしたときに発生するイベントがpresentedItemDidChangeで、バージョンも変更されてないと判定されるようでした。
このイベント以外で更新を取得することは難しそうなのでバージョン変更関係なく読み込むようにします。