### PR TITLE
ユーザー辞書へ追加するとき元の辞書の注釈は保存しない

### DIFF
--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -82,11 +82,14 @@ struct MemoryDict: DictProtocol {
     ///   - word: SKK辞書の変換候補。
     mutating func add(yomi: String, word: Word) {
         if var words = entries[yomi] {
+            let removed: Word?
             let index = words.firstIndex { $0.word == word.word }
             if let index {
-                words.remove(at: index)
+                removed = words.remove(at: index)
+            } else {
+                removed = nil
             }
-            entries[yomi] = [word] + words
+            entries[yomi] = [Word(word.word, annotation: word.annotation ?? removed?.annotation)] + words
             if !readonly {
                 if yomi.isOkuriAri {
                     if let index = okuriAriYomis.firstIndex(of: yomi) {

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -932,8 +932,8 @@ class StateMachine {
     }
 
     func addWordToUserDict(yomi: String, word referredWord: ReferredWord) {
-        // FIXME: ユーザー辞書に残す注釈は複数は載せられないので最初の1つを選択。もっといい方法があるかも? (連結するとか)
-        let word = Word(referredWord.word, annotation: referredWord.annotations.first)
+        // ユーザー辞書には使用元の辞書の注釈は載せない
+        let word = Word(referredWord.word, annotation: nil)
         dictionary.add(yomi: yomi, word: word)
     }
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -693,7 +693,7 @@ class StateMachine {
     func handleSelecting(_ action: Action, selecting: SelectingState, specialState: SpecialState?) -> Bool {
         switch action.keyEvent {
         case .enter:
-            addWordToUserDict(yomi: selecting.yomi, word: selecting.candidates[selecting.candidateIndex])
+            addWordToUserDict(yomi: selecting.yomi, word: selecting.candidates[selecting.candidateIndex].word)
             updateCandidates(selecting: nil)
             state.inputMethod = .normal
             addFixedText(selecting.fixedText())
@@ -751,7 +751,7 @@ class StateMachine {
             return true
         case .stickyShift, .ctrlJ, .ctrlQ:
             // 選択中候補で確定
-            addWordToUserDict(yomi: selecting.yomi, word: selecting.candidates[selecting.candidateIndex])
+            addWordToUserDict(yomi: selecting.yomi, word: selecting.candidates[selecting.candidateIndex].word)
             updateCandidates(selecting: nil)
             addFixedText(selecting.fixedText())
             state.inputMethod = .normal
@@ -770,7 +770,7 @@ class StateMachine {
                     let diff = index - 1 - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
                     if selecting.candidateIndex + diff < selecting.candidates.count {
                         let newSelecting = selecting.addCandidateIndex(diff: diff)
-                        addWordToUserDict(yomi: newSelecting.yomi, word: newSelecting.candidates[newSelecting.candidateIndex])
+                        addWordToUserDict(yomi: newSelecting.yomi, word: newSelecting.candidates[newSelecting.candidateIndex].word)
                         updateCandidates(selecting: nil)
                         state.inputMethod = .normal
                         addFixedText(newSelecting.fixedText())
@@ -779,7 +779,7 @@ class StateMachine {
                 }
             }
             // 選択中候補で確定
-            addWordToUserDict(yomi: selecting.yomi, word: selecting.candidates[selecting.candidateIndex])
+            addWordToUserDict(yomi: selecting.yomi, word: selecting.candidates[selecting.candidateIndex].word)
             updateCandidates(selecting: nil)
             addFixedText(selecting.fixedText())
             state.inputMethod = .normal
@@ -931,9 +931,15 @@ class StateMachine {
         return result
     }
 
-    func addWordToUserDict(yomi: String, word referredWord: ReferredWord) {
-        // ユーザー辞書には使用元の辞書の注釈は載せない
-        let word = Word(referredWord.word, annotation: nil)
+    /**
+     * ユーザー辞書にエントリを追加します。
+     *
+     * 他の辞書から選択した変換を追加する場合はその辞書の注釈は保存しないこと。
+     *
+     * FIXME: 単語登録時にユーザーが独自の注釈を登録できるようにする。
+     */
+    func addWordToUserDict(yomi: String, word: Word.Word, annotation: Annotation? = nil) {
+        let word = Word(word, annotation: annotation)
         dictionary.add(yomi: yomi, word: word)
     }
 
@@ -951,7 +957,7 @@ class StateMachine {
     /// StateMachine外で選択されている変換候補が二回選択されたときに通知される
     func didDoubleSelectCandidate(_ candidate: ReferredWord) {
         if case .selecting(let selecting) = state.inputMethod {
-            addWordToUserDict(yomi: selecting.yomi, word: candidate)
+            addWordToUserDict(yomi: selecting.yomi, word: candidate.word)
             updateCandidates(selecting: nil)
             state.inputMethod = .normal
             addFixedText(candidate.word)

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -59,6 +59,15 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.okuriNashiYomis, ["う", "い"])
         dict.add(yomi: "い", word: word1)
         XCTAssertEqual(dict.refer("い"), [word1, word2])
+        let annotation = Annotation(dictId: "test", text: "宇の注釈")
+        dict.add(yomi: "う", word: Word("宇", annotation: annotation))
+        XCTAssertEqual(dict.refer("う"), [Word("宇", annotation: annotation)])
+        // 注釈なしで登録済みのエントリを上書きしても注釈が残る
+        dict.add(yomi: "う", word: Word("宇", annotation: nil))
+        XCTAssertEqual(dict.refer("う"), [Word("宇", annotation: annotation)])
+        let annotation2 = Annotation(dictId: "test2", text: "宇の注釈の更新版")
+        dict.add(yomi: "う", word: Word("宇", annotation: annotation2))
+        XCTAssertEqual(dict.refer("う"), [Word("宇", annotation: annotation2)])
     }
 
     func testDelete() throws {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1640,9 +1640,11 @@ final class StateMachineTests: XCTestCase {
     }
 
     func testAddWordToUserDict() {
-        let referredWord = ReferredWord("あああ", annotations: [Annotation(dictId: "test", text: "test辞書の注釈")])
-        stateMachine.addWordToUserDict(yomi: "あ", word: referredWord)
-        XCTAssertEqual(dictionary.refer("あ"), [Word("あああ", annotation: nil)], "注釈は除いてユーザー辞書に追加される")
+        stateMachine.addWordToUserDict(yomi: "あ", word: "あああ")
+        XCTAssertEqual(dictionary.refer("あ"), [Word("あああ", annotation: nil)])
+        let annotation = Annotation(dictId: "test", text: "test辞書の注釈")
+        stateMachine.addWordToUserDict(yomi: "い", word: "いいい", annotation: annotation)
+        XCTAssertEqual(dictionary.refer("い"), [Word("いいい", annotation: annotation)])
     }
 
     private func nextInputMethodEvent() async -> InputMethodEvent {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1639,6 +1639,12 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testAddWordToUserDict() {
+        let referredWord = ReferredWord("あああ", annotations: [Annotation(dictId: "test", text: "test辞書の注釈")])
+        stateMachine.addWordToUserDict(yomi: "あ", word: referredWord)
+        XCTAssertEqual(dictionary.refer("あ"), [Word("あああ", annotation: nil)], "注釈は除いてユーザー辞書に追加される")
+    }
+
     private func nextInputMethodEvent() async -> InputMethodEvent {
         var cancellation: Cancellable?
         let cancel = { cancellation?.cancel() }


### PR DESCRIPTION
## 背景

注釈表示の複数辞書対応を行ったことでユーザー辞書に注釈がなくとも他の辞書にあればそれを表示できるようになりました。
なのでユーザー辞書に追加する際に他辞書の注釈を保存する必要はなくなったと考えます。

ddskkには `*` をつけることでユーザー自身が注釈をつけたものとすることができるので、それを踏襲しようと思っています。
(いまは注釈つけて単語登録できない)

> ユーザが付けたアノテーションを「ユーザアノテーション」と呼びます。ユーザアノテー ションは、次の形式で個人辞書に登録されます。
`きかん /期間/機関;*機関投資家/基幹;*基幹業務/`
上記のとおり、 ; の直後に * が自動的に振られることによってユーザが 独自に登録したアノテーションであることが分かります。
https://ddskk.readthedocs.io/ja/latest/06_apps.html#id144

## 概要

- ユーザー辞書に変換結果を追加するときに元の辞書の注釈を含めなくします。
- 辞書に追加するとき、注釈なしで変換結果を追加してもすでに注釈がある場合はその注釈は残るようにします。