### PR TITLE
ユーザー独自の注釈を表すアスタリスクつきの注釈に対応

### DIFF
--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -41,7 +41,14 @@ struct MemoryDict: DictProtocol {
             }
             let words = wordsText.split(separator: Character("/")).map { word -> Word in
                 let words = word.split(separator: Character(";"), maxSplits: 1)
-                let annotation = words.count == 2 ? Annotation(dictId: dictId, text: Self.decode(String(words[1]))) : nil
+                let annotation: Annotation?
+                if words.count == 2 {
+                    // 注釈の先頭に "*" がついていたらユーザー独自の注釈を表す
+                    let annotationText = words[1].first == "*" ? String(words[1].suffix(from: words[1].startIndex + 1)) : String(words[1])
+                    annotation = Annotation(dictId: dictId, text: Self.decode(annotationText))
+                } else {
+                    annotation = nil
+                }
                 return Word(Self.decode(String(words[0])), annotation: annotation)
             }
             dict[yomi] = words

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -44,6 +44,16 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.okuriNashiYomis, ["GPL", "ao"], "abbrev辞書の読みは末尾がアルファベットだが送り無し扱い")
     }
 
+    func testParseIncludingUserAnnotation() throws {
+        // 注釈の先頭のアスタリスクはユーザー自身の注釈を表す
+        let source = """
+            いぬ /犬;*かわいい/
+
+            """
+        let dict = try MemoryDict(dictId: "testDict", source: source, readonly: false)
+        XCTAssertEqual(dict.entries["いぬ"]?.first?.annotation, Annotation(dictId: "testDict", text: "かわいい"))
+    }
+
     func testAdd() throws {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertEqual(dict.entryCount, 0)


### PR DESCRIPTION
related: #41 

ddskkではユーザー独自が注釈をつけたエントリは "*" を先頭につけるようです。(他のSKK実装は調べてない)
将来ユーザー自身が単語登録するときに注釈をつけられるようにするかもしれない && ユーザー自身でユーザー辞書を編集してアスタリスクつきの注釈で書いてもいいように、アスタリスクがついていたらアスタリスクをスキップして読み込むようにします。