### PR TITLE
C-qで半角カナにならないのを修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -254,6 +254,8 @@ class InputController: IMKInputController {
                     return .ctrlJ
                 case "g":
                     return .cancel
+                case "q":
+                    return .ctrlQ
                 case "h":
                     return .backspace
                 case "b":


### PR DESCRIPTION
多分ずっと前からCtrl-qで半角カナモードに遷移できてなかったのを修正。

InputControllerにユニットテストを書いてエンバグを防いでもいいかもしれないけど、結局入力のNSEventを作ってあげないといけないのが面倒でひとまず実装だけ直しました。