### PR TITLE
Shift-Qで見出し語へ遷移するように修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -233,21 +233,27 @@ class StateMachine {
         }
     }
 
-    /// 状態がnormalのときのprintableイベントのhandle
+    /**
+     * 状態がnormalのときのprintableイベントのhandle
+     *
+     * - Parameters:
+     *   - input: ``Action/KeyEvent/printable(_:)`` の引数であるcharacterIgnoringModifiersな文字列
+     *   - specialState: 単語登録モードや単語登録解除モード
+     */
     func handleNormalPrintable(input: String, action: Action, specialState: SpecialState?) -> Bool {
-        if input.lowercased() == "q" {
+        if input == "q" {
             if action.shiftIsPressed() {
                 // 見出し語入力へ遷移する
                 switch state.inputMode {
                 case .hiragana, .katakana, .hankaku:
                     state.inputMethod = .composing(ComposingState(isShift: true, text: [], okuri: nil, romaji: ""))
                     updateMarkedText()
+                    return true
                 case .eisu:
-                    addFixedText("Ｑ")
+                    break
                 case .direct:
-                    addFixedText("Q")
+                    break
                 }
-                return true
             } else {
                 switch state.inputMode {
                 case .hiragana:
@@ -258,13 +264,11 @@ class StateMachine {
                     state.inputMode = .hiragana
                     inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
                     return true
-                case .eisu:
-                    break
-                case .direct:
+                case .eisu, .direct:
                     break
                 }
             }
-        } else if input.lowercased() == "l" {
+        } else if input == "l" {
             switch state.inputMode {
             case .hiragana, .katakana, .hankaku:
                 if action.shiftIsPressed() {
@@ -455,7 +459,7 @@ class StateMachine {
         case .printable(let input):
             return handleComposingPrintable(
                 input: input,
-                converted: Romaji.convert(romaji + input.lowercased()),
+                converted: Romaji.convert(romaji + input),
                 action: action,
                 composing: composing,
                 specialState: specialState)
@@ -549,7 +553,7 @@ class StateMachine {
         let text = composing.text
         let okuri = composing.okuri
 
-        if input.lowercased() == "q" && converted.kakutei == nil {
+        if input == "q" && converted.kakutei == nil {
             if okuri == nil {
                 // AquaSKKの挙動に合わせてShift-Qのときは送り無視で確定、次の入力へ進む
                 if action.shiftIsPressed() {
@@ -599,7 +603,7 @@ class StateMachine {
                     ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: ""))
                 return false
             }
-        } else if input.lowercased() == "l" && converted.kakutei == nil {
+        } else if input == "l" && converted.kakutei == nil {
             // 入力済みを確定してからlを打ったのと同じ処理をする
             if okuri == nil {
                 switch state.inputMode {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -259,7 +259,6 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[3], .modeChanged(.hiragana, .zero))
             expectation.fulfill()
         }.store(in: &cancellables)
-
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlQ, originalEvent: nil, cursorPosition: .zero)))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -266,6 +266,22 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleNormalShiftQ() {
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(4).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[2], .fixedText("あ"))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)), "二回目は何も起きない")
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleNormalCtrlQ() {
         let expectation = XCTestExpectation()
         stateMachine = StateMachine(initialState: IMEState(inputMode: .direct))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -259,6 +259,7 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[3], .modeChanged(.hiragana, .zero))
             expectation.fulfill()
         }.store(in: &cancellables)
+
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlQ, originalEvent: nil, cursorPosition: .zero)))
@@ -268,13 +269,28 @@ final class StateMachineTests: XCTestCase {
 
     func testHandleNormalShiftQ() {
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(4).sink { events in
-            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose])))
-            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あ")])))
-            XCTAssertEqual(events[2], .fixedText("あ"))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose])))
+        stateMachine.inputMethodEvent.collect(10).sink { events in
+            XCTAssertEqual(events[0], .modeChanged(.direct, .zero))
+            XCTAssertEqual(events[1], .fixedText("Q"))
+            XCTAssertEqual(events[2], .modeChanged(.hiragana, .zero))
+            XCTAssertEqual(events[3], .modeChanged(.eisu, .zero))
+            XCTAssertEqual(events[4], .fixedText("Ｑ"))
+            XCTAssertEqual(events[5], .modeChanged(.hiragana, .zero))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.markerCompose])))
+            XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[8], .fixedText("あ"))
+            XCTAssertEqual(events[9], .markedText(MarkedText([.markerCompose])))
             expectation.fulfill()
         }.store(in: &cancellables)
+        // 直接入力
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "l")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
+        // 英数入力
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlJ, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "l", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
+        // ひらがな入力
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlJ, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)), "二回目は何も起きない")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))


### PR DESCRIPTION
AquaSKKやddskkではShift-Qで▽モードに入るようだったのでそれに合わせて修正します。