### PR TITLE
Set LSUIElement using Preprocessed Info.plist

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -506,7 +506,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ ${CONFIGURATION} = \"Release\" ]; then\n    /usr/libexec/PlistBuddy -c \"Add LSUIElement BOOL YES\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nfi\n";
+			shellScript = "if [ ${CONFIGURATION} = \"Release\" ]; then\n    /usr/libexec/PlistBuddy -c \"Add LSUIElement BOOL YES\" \"${TEMP_DIR}/Preprocessed-Info.plist\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -783,6 +783,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = macSKK/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_PREPROCESS = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Input Methods";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
リリースビルドでBuild Phaseのスクリプト実行で、Info.plistにLSUIElementを設定してDockにアイコンが表示されないようにしていました。
ところがいつからかこの設定がリリースバイナリでされなくなっていました。
軽くぐぐった感じ、Info.plistが上書きされることでまきもどってしまっているのかなと予想しました。

`INFOPLIST_PREPROCESS` を有効にして "${TEMP_DIR}/Preprocessed-Info.plist" を書き換えることにします。