### PR TITLE
テスト実行時にApp SandboxのData Containerにアクセスしている箇所を修正

### DIFF
--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -55,14 +55,14 @@ class UserDict: NSObject, DictProtocol {
             try FileManager.default.createDirectory(at: dictionariesDirectoryURL, withIntermediateDirectories: true)
         }
         userDictFileURL = dictionariesDirectoryURL.appending(path: Self.userDictFilename)
-        if !FileManager.default.fileExists(atPath: userDictFileURL.path()) {
-            logger.log("ユーザー辞書ファイルがないため作成します")
-            try Data().write(to: userDictFileURL, options: .withoutOverwriting)
-        }
         if let userDictEntries {
             self.userDict = MemoryDict(entries: userDictEntries, readonly: true)
             entryCountSubject.send(userDictEntries.count)
         } else {
+            if !FileManager.default.fileExists(atPath: userDictFileURL.path()) {
+                logger.log("ユーザー辞書ファイルがないため作成します")
+                try Data().write(to: userDictFileURL, options: .withoutOverwriting)
+            }
             let userDict = try FileDict(contentsOf: userDictFileURL, encoding: .utf8, readonly: false)
             self.userDict = userDict
             entryCountSubject.send(userDict.dict.entries.count)


### PR DESCRIPTION
macOS 14 SonomaからApp SandboxのData Containerにはオーナーアプリと異なるアプリからアクセスしようとするとダイアログが出るようになりました。

![warning-ja](https://github.com/mtgto/macSKK/assets/1213991/f64254e5-a52d-4993-82a8-9d40e2e39380)

ユニットテストでアプリのビルドが発生するたびにこのダイアログが出てしまうのは困ります。

前にユニットテスト実行時にはユーザー辞書を読まないようにしていたつもりだったのですが、いつのまにかその制御がなくなっていたので再びユニットテスト実行時にはSandbox内の辞書を読まないように修正します。