### PR TITLE
macOS 14 Sonomaで設定画面のサイドバー切り替えボタンを非表示にするAPIが使えるようになったので対応

### DIFF
--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -65,6 +65,7 @@ struct SettingsView: View {
         .task(id: selectedSection) {
             updateWindowAndToolbar()
         }
+        .modifier(RemoveSidebarToggle())
         .frame(minWidth: 640, minHeight: 360)
     }
 
@@ -81,6 +82,16 @@ struct SettingsView: View {
                 if let index = toolbar.items.firstIndex(where: { $0.itemIdentifier.rawValue == "com.apple.SwiftUI.navigationSplitView.toggleSidebar" }) {
                     toolbar.removeItem(at: index)
                 }
+            }
+        }
+    }
+
+    struct RemoveSidebarToggle: ViewModifier {
+        func body(content: Content) -> some View {
+            if #available(macOS 14, *) {
+                content.toolbar(removing: .sidebarToggle)
+            } else {
+                content
             }
         }
     }

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 "MenuItemPreference" = "Preferences…";
 "MenuItemSaveDict" = "Save User Dictionary";
-"MenuPrivateMode" = "Private mode";
+"MenuItemPrivateMode" = "Private mode";
 "MenuItemDirectInput" = "Direct input from \"%@\"";
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameSoftwareUpdate" = "Software Update";


### PR DESCRIPTION
おまけで、英語表記でプライベートモードへの切り替えのメニューアイテムの翻訳漏れがあったので修正。