### PR TITLE
macOS 14 Sonomaで入力メニューから環境設定が開けなくなった問題の暫定対応

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CE5ECF3A2957034D00E7BE7D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE5ECF392957034D00E7BE7D /* Assets.xcassets */; };
 		CE5ECF3D2957034D00E7BE7D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE5ECF3C2957034D00E7BE7D /* Preview Assets.xcassets */; };
 		CE5ECF642957077D00E7BE7D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE5ECF632957077D00E7BE7D /* InfoPlist.strings */; };
+		CE6599DC2ADBF2630052F8C0 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6599DB2ADBF2630052F8C0 /* SettingsWindow.swift */; };
 		CE6DBA8D2A845CE400F5A227 /* Release.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6DBA8C2A845CE400F5A227 /* Release.swift */; };
 		CE6DBA8F2A845E8B00F5A227 /* ReleaseVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6DBA8E2A845E8B00F5A227 /* ReleaseVersion.swift */; };
 		CE6DBA912A846C1700F5A227 /* ReleaseVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6DBA902A846C1700F5A227 /* ReleaseVersionTests.swift */; };
@@ -123,6 +124,7 @@
 		CE5ECF432957034D00E7BE7D /* macSKKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = macSKKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE5ECF612957061A00E7BE7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE5ECF632957077D00E7BE7D /* InfoPlist.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = InfoPlist.strings; sourceTree = "<group>"; };
+		CE6599DB2ADBF2630052F8C0 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		CE6DBA8C2A845CE400F5A227 /* Release.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Release.swift; sourceTree = "<group>"; };
 		CE6DBA8E2A845E8B00F5A227 /* ReleaseVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseVersion.swift; sourceTree = "<group>"; };
 		CE6DBA902A846C1700F5A227 /* ReleaseVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseVersionTests.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				CEC061C72ABB0A0100A11614 /* CompletionPanel.swift */,
 				CE7F9ADB2AB53E53001B1877 /* CompletionView.swift */,
 				CEC061C92ABB0A7900A11614 /* CompletionViewModel.swift */,
+				CE6599DB2ADBF2630052F8C0 /* SettingsWindow.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -526,6 +529,7 @@
 				CEA78FAC2960401F00B67E25 /* String+Transform.swift in Sources */,
 				CED7F51F2AB5F4A7007FC6BD /* Character+Additions.swift in Sources */,
 				CE84A3B929570C37009394C4 /* InputController.swift in Sources */,
+				CE6599DC2ADBF2630052F8C0 /* SettingsWindow.swift in Sources */,
 				CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */,
 				CE84A3EB295DA715009394C4 /* Dict.swift in Sources */,
 				CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */,

--- a/macSKK/AppDelegate.swift
+++ b/macSKK/AppDelegate.swift
@@ -5,16 +5,9 @@ import Cocoa
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    // Appの初期化処理でセットされる
-    var settingsWindowController: NSWindowController!
-
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")
         try? dictionary.save()
         return .terminateNow
-    }
-
-    func showSettingsWindow() {
-        settingsWindowController.showWindow(nil)
     }
 }

--- a/macSKK/AppDelegate.swift
+++ b/macSKK/AppDelegate.swift
@@ -3,10 +3,18 @@
 
 import Cocoa
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    // Appの初期化処理でセットされる
+    var settingsWindowController: NSWindowController!
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")
         try? dictionary.save()
         return .terminateNow
+    }
+
+    func showSettingsWindow() {
+        settingsWindowController.showWindow(nil)
     }
 }

--- a/macSKK/AppDelegate.swift
+++ b/macSKK/AppDelegate.swift
@@ -3,7 +3,6 @@
 
 import Cocoa
 
-@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -232,12 +232,18 @@ class InputController: IMKInputController {
     }
 
     @objc func showSettings() {
-        if #available(macOS 13, *) {
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        if let delegate = NSApplication.shared.delegate as? AppDelegate {
+            logger.log("設定画面を表示します")
+            delegate.showSettingsWindow()
         } else {
-            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+            logger.log("AppDelegateがみつかりません: \(NSApp.delegate.debugDescription, privacy: .public)")
         }
-        NSApp.activate(ignoringOtherApps: true)
+//        if #available(macOS 13, *) {
+//            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+//        } else {
+//            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+//        }
+//        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc func saveDict() {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -232,12 +232,7 @@ class InputController: IMKInputController {
     }
 
     @objc func showSettings() {
-        if let delegate = NSApplication.shared.delegate as? AppDelegate {
-            logger.log("設定画面を表示します")
-            delegate.showSettingsWindow()
-        } else {
-            logger.log("AppDelegateがみつかりません: \(NSApp.delegate.debugDescription, privacy: .public)")
-        }
+        NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
 //        if #available(macOS 13, *) {
 //            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
 //        } else {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -233,12 +233,6 @@ class InputController: IMKInputController {
 
     @objc func showSettings() {
         NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
-//        if #available(macOS 13, *) {
-//            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-//        } else {
-//            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-//        }
-//        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc func saveDict() {

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -65,33 +65,21 @@ struct SettingsView: View {
         .task(id: selectedSection) {
             updateWindowAndToolbar()
         }
-        .modifier(RemoveSidebarToggle())
         .frame(minWidth: 640, minHeight: 480)
     }
 
     // ウィンドウのスタイルの変更とツールバーからサイドバー切り替えのボタンを削除する
     func updateWindowAndToolbar() {
-        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "com_apple_SwiftUI_Settings_window" }) {
-            window.titleVisibility = .visible
-            window.titlebarAppearsTransparent = true
-            window.styleMask = [.titled, .closable, .fullSizeContentView, .unifiedTitleAndToolbar]
-            window.toolbarStyle = .unified
-            // サイドバー切り替えボタンの削除はmacOS 14からはAPIが用意されるぽい
-            // https://developer.apple.com/documentation/swiftui/view/toolbar(removing:)
-            if let toolbar = window.toolbar {
-                if let index = toolbar.items.firstIndex(where: { $0.itemIdentifier.rawValue == "com.apple.SwiftUI.navigationSplitView.toggleSidebar" }) {
-                    toolbar.removeItem(at: index)
+        for window in NSApp.windows {
+            if let settingsWindow = window as? SettingsWindow {
+                // サイドバー切り替えボタンの削除はmacOS 14からはAPIが用意されるぽい
+                // https://developer.apple.com/documentation/swiftui/view/toolbar(removing:)
+                if let toolbar = window.toolbar {
+                    if let index = toolbar.items.firstIndex(where: { $0.itemIdentifier.rawValue == "com.apple.SwiftUI.navigationSplitView.toggleSidebar" }) {
+                        toolbar.removeItem(at: index)
+                    }
                 }
-            }
-        }
-    }
-
-    struct RemoveSidebarToggle: ViewModifier {
-        func body(content: Content) -> some View {
-            if #available(macOS 14, *) {
-                content.toolbar(removing: .sidebarToggle)
-            } else {
-                content
+                break
             }
         }
     }

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -66,7 +66,7 @@ struct SettingsView: View {
             updateWindowAndToolbar()
         }
         .modifier(RemoveSidebarToggle())
-        .frame(minWidth: 640, minHeight: 360)
+        .frame(minWidth: 640, minHeight: 480)
     }
 
     // ウィンドウのスタイルの変更とツールバーからサイドバー切り替えのボタンを削除する

--- a/macSKK/View/SettingsWindow.swift
+++ b/macSKK/View/SettingsWindow.swift
@@ -11,5 +11,7 @@ class SettingsWindow: NSWindow {
         super.init(contentRect: .zero, styleMask: [.titled, .closable, .fullSizeContentView, .unifiedTitleAndToolbar], backing: .buffered, defer: true)
         contentViewController = viewController
         titlebarAppearsTransparent = true
+        isExcludedFromWindowsMenu = true
+        center()
     }
 }

--- a/macSKK/View/SettingsWindow.swift
+++ b/macSKK/View/SettingsWindow.swift
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Cocoa
+import SwiftUI
+
+class SettingsWindow: NSWindow {
+    init(settingsViewModel: SettingsViewModel) {
+        let rootView = SettingsView(settingsViewModel: settingsViewModel)
+        let viewController = NSHostingController(rootView: rootView)
+        super.init(contentRect: .zero, styleMask: [.titled, .closable, .fullSizeContentView, .unifiedTitleAndToolbar], backing: .buffered, defer: true)
+        contentViewController = viewController
+        titlebarAppearsTransparent = true
+    }
+
+    func show() {
+        makeKeyAndOrderFront(nil)
+    }
+}

--- a/macSKK/View/SettingsWindow.swift
+++ b/macSKK/View/SettingsWindow.swift
@@ -12,8 +12,4 @@ class SettingsWindow: NSWindow {
         contentViewController = viewController
         titlebarAppearsTransparent = true
     }
-
-    func show() {
-        makeKeyAndOrderFront(nil)
-    }
 }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -32,7 +32,6 @@ struct macSKKApp: App {
     private let dictionariesDirectoryUrl: URL
     private let userNotificationDelegate = UserNotificationDelegate()
     @State private var fetchReleaseTask: Task<Void, Error>?
-    private let settingsWindowController: NSWindowController
     #if DEBUG
     private let candidatesPanel: CandidatesPanel = CandidatesPanel()
     private let inputModePanel = InputModePanel()
@@ -48,9 +47,7 @@ struct macSKKApp: App {
                 create: false
             ).appendingPathComponent("Dictionaries")
             let settingsViewModel = try SettingsViewModel(dictionariesDirectoryUrl: dictionariesDirectoryUrl)
-            let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
             self.settingsViewModel = settingsViewModel
-            self.settingsWindowController = NSWindowController(window: settingsWindow)
         } catch {
             fatalError("辞書設定でエラーが発生しました: \(error)")
         }
@@ -63,6 +60,8 @@ struct macSKKApp: App {
         } else {
             server = nil
         }
+        let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
+        appDelegate.settingsWindowController = NSWindowController(window: settingsWindow)
         setupUserDefaults()
         if !isTest() {
             do {
@@ -101,7 +100,7 @@ struct macSKKApp: App {
                 }.keyboardShortcut("S")
                 #if DEBUG
                 Button("Show Settings") {
-                    settingsWindowController.showWindow(nil)
+                    appDelegate.settingsWindowController.showWindow(nil)
                 }
                 Button("AnnotationsPanel") {
                     let word = ReferredWord("インライン", annotations: [Annotation(dictId: "", text: String(repeating: "これはインラインのテスト用注釈です", count: 5))])

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -89,7 +89,11 @@ struct macSKKApp: App {
             EmptyView()
         }
         .commands {
-            CommandGroup(after: .appSettings) {
+            CommandGroup(replacing: .appSettings) {
+                // macOS 14のAPI変更で入力メニューからアプリの設定を開きづらくなったため独自でウィンドウ表示するように変更
+                Button("Settings…") {
+                    NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
+                }.keyboardShortcut(",")
                 Button("Save User Directory") {
                     do {
                         try dictionary.save()
@@ -98,10 +102,6 @@ struct macSKKApp: App {
                     }
                 }.keyboardShortcut("S")
                 #if DEBUG
-                Button("Show Settings") {
-                    //settingsWindowController.showWindow(nil)
-                    NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
-                }.keyboardShortcut("P")
                 Button("AnnotationsPanel") {
                     let word = ReferredWord("インライン", annotations: [Annotation(dictId: "", text: String(repeating: "これはインラインのテスト用注釈です", count: 5))])
                     candidatesPanel.setCandidates(.inline, selected: word)

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -85,7 +85,7 @@ struct macSKKApp: App {
             // macOS 14 Sonomaから入力メニュー (NSMenu) からSettingsを呼び出すやりかたが塞がれたので
             // 代わりにNSWindowControllerを使う方針に変更しました。
             // SwiftUIなmacOSアプリはSettingsを置いておかないと空のウィンドウアプリを作るのがMenuItemExtraくらいしかないので
-            // 使わないSettingsを使っています。
+            // 空のSettingsを置いています。
             EmptyView()
         }
         .commands {


### PR DESCRIPTION
#57 の暫定対応。
macOS 14 Sonomaで入力メニューから環境設定を開く非公開APIが使えなくなったので、SwiftUIのSettingsを使わずに独自でNSWindowControllerを使って設定画面を開くことにします。