### PR TITLE
設定画面のツールバーに戻る・進むボタンを追加

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -232,7 +232,11 @@ class InputController: IMKInputController {
     }
 
     @objc func showSettings() {
-        NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
+        if #available(macOS 14, *) {
+            NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
+        } else {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        }
     }
 
     @objc func saveDict() {

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -43,6 +43,7 @@ struct SettingsView: View {
             }
             .listStyle(.sidebar)
             .navigationSplitViewColumnWidth(215)
+            .modifier(RemoveSidebarToggle())
         } detail: {
             switch selectedSection {
             case .dictionaries:
@@ -97,8 +98,12 @@ struct SettingsView: View {
 
     // ウィンドウのスタイルの変更とツールバーからサイドバー切り替えのボタンを削除する
     func updateWindowAndToolbar() {
-        for window in NSApp.windows {
-            if let settingsWindow = window as? SettingsWindow {
+        if #unavailable(macOS 14) {
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "com_apple_SwiftUI_Settings_window" }) {
+                window.titleVisibility = .visible
+                window.titlebarAppearsTransparent = true
+                window.styleMask = [.titled, .closable, .fullSizeContentView, .unifiedTitleAndToolbar]
+                window.toolbarStyle = .unified
                 // サイドバー切り替えボタンの削除はmacOS 14からはAPIが用意されるぽい
                 // https://developer.apple.com/documentation/swiftui/view/toolbar(removing:)
                 if let toolbar = window.toolbar {
@@ -106,7 +111,16 @@ struct SettingsView: View {
                         toolbar.removeItem(at: index)
                     }
                 }
-                break
+            }
+        }
+    }
+
+    struct RemoveSidebarToggle: ViewModifier {
+        func body(content: Content) -> some View {
+            if #available(macOS 14, *) {
+                content.toolbar(removing: .sidebarToggle)
+            } else {
+                content
             }
         }
     }

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -18,6 +18,8 @@ struct SettingsView: View {
     }
     @ObservedObject var settingsViewModel: SettingsViewModel
     @State private var selectedSection: Section = .dictionaries
+    @State private var histories: [Section] = [.dictionaries]
+    @State private var historyIndex: Int = 0
 
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.all)) {
@@ -60,6 +62,31 @@ struct SettingsView: View {
                 SystemDictView()
                     .navigationTitle(selectedSection.localizedStringKey)
             #endif
+            }
+        }
+        .onChange(of: selectedSection) { newSection in
+            if newSection != histories[historyIndex] {
+                histories.removeLast(histories.count - historyIndex - 1)
+                histories.append(newSection)
+                historyIndex += 1
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .navigation) {
+                Button {
+                    historyIndex -= 1
+                    selectedSection = histories[historyIndex]
+                } label: {
+                    Image(systemName: "chevron.backward")
+                }
+                .disabled(historyIndex == 0)
+                Button {
+                    historyIndex += 1
+                    selectedSection = histories[historyIndex]
+                } label: {
+                    Image(systemName: "chevron.forward")
+                }
+                .disabled(histories.count <= historyIndex + 1)
             }
         }
         .task(id: selectedSection) {

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -86,14 +86,18 @@ struct macSKKApp: App {
             // 代わりにNSWindowControllerを使う方針に変更しました。
             // SwiftUIなmacOSアプリはSettingsを置いておかないと空のウィンドウアプリを作るのがMenuItemExtraくらいしかないので
             // 空のSettingsを置いています。
-            EmptyView()
+            if #available(macOS 14, *) {
+                EmptyView()
+            } else {
+                SettingsView(settingsViewModel: settingsViewModel)
+            }
         }
         .commands {
-            CommandGroup(replacing: .appSettings) {
+            CommandGroup(after: .appSettings) {
                 // macOS 14のAPI変更で入力メニューからアプリの設定を開きづらくなったため独自でウィンドウ表示するように変更
-                Button("Settings…") {
+                Button("Open Settings…") {
                     NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
-                }.keyboardShortcut(",")
+                }
                 Button("Save User Directory") {
                     do {
                         try dictionary.save()


### PR DESCRIPTION
macOS 14で設定画面のツールバーからmodifiler `.toolbar(removing:)` を使ってサイドバー表示切り替えを消したところツールバー自体が非表示になってしまう。
代わりに選択した設定項目の戻る・進むボタンを置いてツールバーが消えないようにします。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/f445fc2f-fa00-4503-99e6-1b11d2b4ce15">
