### PR TITLE
macOS 14で設定を開いたときにキーウィンドウにしてフォーカスを当てる

### DIFF
--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -252,7 +252,7 @@ struct macSKKApp: App {
     private func setupSettingsNotification() {
         Task {
             for await notification in NotificationCenter.default.notifications(named: notificationNameOpenSettings) {
-                settingsWindowController.showWindow(notification.object)
+                settingsWindowController.window?.makeKeyAndOrderFront(notification.object)
             }
         }
     }


### PR DESCRIPTION
macOS 14で入力メニューから設定を開く方法をSwiftUIのSettingsからNSWindowController + NSWindowに変えました。
設定ウィンドウの表示には `NSWindowController#showWindow` を使っていましたが、それだとフロントに来てくれないようなので違和感がありました。
`NSWindow#makeAndOrderFront` を使うようにします。