### PR TITLE
設定画面を入力メニューから表示するときにアクティブにする

### DIFF
--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -252,7 +252,8 @@ struct macSKKApp: App {
     private func setupSettingsNotification() {
         Task {
             for await notification in NotificationCenter.default.notifications(named: notificationNameOpenSettings) {
-                settingsWindowController.window?.makeKeyAndOrderFront(notification.object)
+                settingsWindowController.showWindow(notification.object)
+                NSApp.activate(ignoringOtherApps: true)
             }
         }
     }


### PR DESCRIPTION
#61 の対応ではmacOS 14 Sonomaで入力メニューから設定画面を開いたときにアクティブにならなかったため明示的にアクティブにする。