### PR TITLE
未確定のローマ字が入力されたあとでC-gが呼ばれたら入力前状態に戻す

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -448,7 +448,7 @@ class StateMachine {
             inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
             return true
         case .cancel:
-            if romaji.isEmpty {
+            if text.isEmpty || romaji.isEmpty {
                 // 下線テキストをリセットする
                 state.inputMethod = .normal
             } else {


### PR DESCRIPTION
普段使いをしていて、次の不具合に気付いたので修正します。

#### 再現手順

1. ローマ字の一文字目を入力する (下線つきでmarkedTextが表示される)
2. C-gでキャンセルする (下線つきのローマ字が消失する)
3. カーソル移動などを行う

#### 想定される挙動

カーソルが移動する

#### 実際の挙動

カーソルが移動しない。Backspaceすると動かせるようになる