### PR TITLE
直接入力設定でアプリアイコンが読み込みしても更新されないバグを修正

### DIFF
--- a/macSKK/Settings/DirectModeView.swift
+++ b/macSKK/Settings/DirectModeView.swift
@@ -4,9 +4,10 @@
 import SwiftUI
 
 struct DirectModeView: View {
-    @Binding var applications: [DirectModeApplication]
+    @StateObject var settingsViewModel: SettingsViewModel
 
     var body: some View {
+        let applications = settingsViewModel.directModeApplications
         VStack {
             Form {
                 if applications.isEmpty {
@@ -28,7 +29,7 @@ struct DirectModeView: View {
                                 Button {
                                     if let index = applications.firstIndex(of: application) {
                                         logger.log("Bundle Identifier \"\(applications[index].bundleIdentifier, privacy: .public)\" の直接入力が解除されました。")
-                                        applications.remove(at: index)
+                                        settingsViewModel.directModeApplications.remove(at: index)
                                     }
                                 } label: {
                                     Text("Delete")
@@ -40,8 +41,7 @@ struct DirectModeView: View {
                                     let workspace = NSWorkspace.shared
                                     if let index = applications.firstIndex(of: application),
                                        let appUrl = workspace.urlForApplication(withBundleIdentifier: application.bundleIdentifier) {
-                                        applications[index].displayName = FileManager.default.displayName(atPath: appUrl.path(percentEncoded: false))
-                                        applications[index].icon = workspace.icon(forFile: appUrl.path(percentEncoded: false))
+                                        settingsViewModel.updateDirectModeApplication(index: index, displayName: FileManager.default.displayName(atPath: appUrl.path(percentEncoded: false)), icon: workspace.icon(forFile: appUrl.path(percentEncoded: false)))
                                     }
                                 }
                             }
@@ -60,10 +60,10 @@ struct DirectModeView: View {
 
 struct DirectModeView_Previews: PreviewProvider {
     static var previews: some View {
-        DirectModeView(applications: .constant([
+        DirectModeView(settingsViewModel: try! SettingsViewModel(directModeApplications: [
             DirectModeApplication(bundleIdentifier: "net.mtgto.inputmethod.macSKK", icon: nil, displayName: nil),
         ]))
-        DirectModeView(applications: .constant([]))
+        DirectModeView(settingsViewModel: try! SettingsViewModel(directModeApplications: []))
             .previewDisplayName("空のとき")
     }
 }

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -53,7 +53,7 @@ struct SettingsView: View {
                 SoftwareUpdateView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
             case .directMode:
-                DirectModeView(applications: $settingsViewModel.directModeApplications)
+                DirectModeView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
             #if DEBUG
             case .keyEvent:

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -191,14 +191,25 @@ final class SettingsViewModel: ObservableObject {
     }
 
     // PreviewProvider用
-    internal init(dictSettings: [DictSetting]) throws {
+    internal init() throws {
         dictionariesDirectoryUrl = try FileManager.default.url(
             for: .documentDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
             create: false
         ).appendingPathComponent("Dictionaries")
+    }
+
+    // DictionaryViewのPreviewProvider用
+    internal convenience init(dictSettings: [DictSetting]) throws {
+        try self.init()
         self.dictSettings = dictSettings
+    }
+
+    // DirectModeViewのPreviewProvider用
+    internal convenience init(directModeApplications: [DirectModeApplication]) throws {
+        try self.init()
+        self.directModeApplications = directModeApplications
     }
 
     /**
@@ -249,5 +260,10 @@ final class SettingsViewModel: ObservableObject {
         let release = try await LatestReleaseFetcher.shared.fetch()
         latestRelease = release
         return release
+    }
+
+    func updateDirectModeApplication(index: Int, displayName: String, icon: NSImage) {
+        directModeApplications[index].displayName = displayName
+        directModeApplications[index].icon = icon
     }
 }

--- a/macSKK/Settings/SoftwareUpdateView.swift
+++ b/macSKK/Settings/SoftwareUpdateView.swift
@@ -11,16 +11,16 @@ struct SoftwareUpdateView: View {
         VStack {
             Form {
                 Section {
-                    LabeledContent("現在のバージョン:") {
+                    LabeledContent("Current Version:") {
                         Text(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String)
                         if let latestRelease = settingsViewModel.latestRelease {
-                            Text("(最新バージョン: \(latestRelease.version.description))")
+                            Text("Latest Version: \(latestRelease.version.description)")
                                 .padding(.leading)
                         }
                     }
                     HStack {
                         Spacer()
-                        Button("アップデートを確認…") {
+                        Button("Check For Update") {
                             fetchReleases()
                         }
                         .disabled(settingsViewModel.fetchingRelease)
@@ -32,7 +32,7 @@ struct SoftwareUpdateView: View {
                         }
                     }
                 } footer: {
-                    Button("リリースページを開く") {
+                    Button("Open Release Page") {
                         if let url = URL(string: "https://github.com/mtgto/macSKK/releases") {
                             openURL(url)
                         }

--- a/macSKK/View/AnnotationView.swift
+++ b/macSKK/View/AnnotationView.swift
@@ -15,7 +15,7 @@ struct AnnotationView: View {
                 if let systemAnnotation {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading) {
-                            Text("システム辞書")
+                            Text("System Dict")
                                 .font(.headline)
                             Text(systemAnnotation)
                                 .textSelection(.enabled)

--- a/macSKK/View/CompletionView.swift
+++ b/macSKK/View/CompletionView.swift
@@ -11,7 +11,7 @@ struct CompletionView: View {
         VStack {
             Text(viewModel.completion)
                 .font(.body)
-            Text("Tabで補完")
+            Text("Tab Completion")
                 .font(.caption)
                 .frame(maxWidth: .infinity)
         }

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -27,3 +27,9 @@
 "User Dictionary" = "User Dictionary";
 "Delete" = "Delete";
 "Unregistered" = "Unregistered";
+"Tab Completion" = "Tab Completion";
+"System Dict" = "System Dict";
+"Current Version:" = "Current Version";
+"Latest Version: %@" = "(Latest Verssion: %@)";
+"Check For Update" = "Check For Update…";
+"Open Release Page" = "Open Release Page";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -27,3 +27,9 @@
 "User Dictionary" = "ユーザー辞書";
 "Delete" = "削除";
 "Unregistered" = "未登録です";
+"Tab Completion" = "Tabで補完";
+"System Dict" = "システム辞書";
+"Current Version:" = "現在のバージョン:";
+"Latest Version: %@" = "(最新バージョン: %@)";
+"Check For Update" = "アップデートを確認…";
+"Open Release Page" = "リリースページを開く";


### PR DESCRIPTION
直接入力の設定画面のonAppearで登録されているアプリの名前やアイコンを取得しますが、一度他の設定を切り替えないと更新されないことに気付いたので修正します。
あとLocalizable.stringsに書いてなかった設定画面の文字列を追加します。