### PR TITLE
未確定のローマ字のみ入力時に左矢印キーが入力されたら未入力状態に戻す

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -479,6 +479,10 @@ class StateMachine {
             if okuri == nil { // 一度変換候補選択に遷移してからキャンセルで戻ると送り仮名ありになっている
                 if romaji.isEmpty {
                     state.inputMethod = .composing(composing.moveCursorLeft())
+                } else if text.isEmpty {
+                    // 未確定ローマ字しかないときは入力前に戻す (.cancelと同じ)
+                    // AquaSKKとほぼ同じだがAquaSKKはカーソル移動も機能するのでreturn falseになってそう
+                    state.inputMethod = .normal
                 } else {
                     // 未確定ローマ字があるときはローマ字を消す (AquaSKKと同じ)
                     state.inputMethod = .composing(ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: ""))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1086,6 +1086,27 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleComposingLeftRomajiOnly() {
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(5).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("k")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.plain("s")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.plain("sh")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで左矢印キーが押されたら未入力に戻す")
+        XCTAssertFalse(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "h")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal)
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleComposingLeftOkuri() {
         dictionary.setEntries(["あs": [Word("褪")]])
 


### PR DESCRIPTION
普段使いをしていて、次の不具合に気付いたので修正します。
TextEdit.appでは発生せず、Slackの入力ボックスで発生するのでアプリ側の実装とも関係がありそう。
#63 とほぼ同じ理由でした。

#### 再現手順

1. ローマ字の一文字目を入力する (下線つきでmarkedTextが表示される)
2. 左キーを入力する (下線つきのローマ字が消失する)
3. カーソル移動などを行う

#### 想定される挙動

3の操作でカーソルが移動する

2の操作でカーソルを動かすべきかはどっちがいいんだろう。AquaSKKはカーソル移動も機能しているようにみえるけど個人的にはローマ字入力の取消だけにしたほうがいいかなと思ってそうしています。

#### 実際の挙動

カーソルが移動しない。Backspaceすると動かせるようになる