### PR TITLE
未確定のローマ字のみ入力時に右矢印やC-aやC-e入力でカーソルが移動しなくなるバグの修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -494,6 +494,10 @@ class StateMachine {
             if okuri == nil { // 一度変換候補選択に遷移してからキャンセルで戻ると送り仮名ありになっている
                 if romaji.isEmpty {
                     state.inputMethod = .composing(composing.moveCursorRight())
+                } else if text.isEmpty {
+                    // 未確定ローマ字しかないときは入力前に戻す (.cancelと同じ)
+                    // AquaSKKとほぼ同じだがAquaSKKはカーソル移動も機能するのでreturn falseになってそう
+                    state.inputMethod = .normal
                 } else {
                     state.inputMethod = .composing(ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: ""))
                 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -508,6 +508,10 @@ class StateMachine {
             if okuri == nil { // 一度変換候補選択に遷移してからキャンセルで戻ると送り仮名ありになっている
                 if romaji.isEmpty {
                     state.inputMethod = .composing(composing.moveCursorFirst())
+                } else if text.isEmpty {
+                    // 未確定ローマ字しかないときは入力前に戻す (.cancelと同じ)
+                    // AquaSKKとほぼ同じだがAquaSKKはカーソル移動も機能するのでreturn falseになってそう
+                    state.inputMethod = .normal
                 } else {
                     // 未確定ローマ字があるときはローマ字を消す (AquaSKKと同じ)
                     state.inputMethod = .composing(ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: ""))
@@ -519,6 +523,10 @@ class StateMachine {
             if okuri == nil { // 一度変換候補選択に遷移してからキャンセルで戻ると送り仮名ありになっている
                 if romaji.isEmpty {
                     state.inputMethod = .composing(composing.moveCursorLast())
+                } else if text.isEmpty {
+                    // 未確定ローマ字しかないときは入力前に戻す (.cancelと同じ)
+                    // AquaSKKとほぼ同じだがAquaSKKはカーソル移動も機能するのでreturn falseになってそう
+                    state.inputMethod = .normal
                 } else {
                     state.inputMethod = .composing(ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: ""))
                 }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1155,6 +1155,27 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleComposingRightRomajiOnly() {
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(5).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("k")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.plain("s")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.plain("sh")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで右矢印キーが押されたら未入力に戻す")
+        XCTAssertFalse(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "h")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal)
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleComposingLeftOkuri() {
         dictionary.setEntries(["あs": [Word("褪")]])
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1134,14 +1134,17 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testHandleComposingLeftRomajiOnly() {
+    func testHandleComposingCursorRomajiOnly() {
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(5).sink { events in
+        stateMachine.inputMethodEvent.collect(8).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.plain("k")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.plain("s")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.plain("sh")])))
-            XCTAssertEqual(events[4], .markedText(MarkedText([])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.plain("t")])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([])))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.plain("n")])))
+            XCTAssertEqual(events[7], .markedText(MarkedText([])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
@@ -1149,32 +1152,14 @@ final class StateMachineTests: XCTestCase {
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで左矢印キーが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "h")))
-        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(stateMachine.state.inputMethod, .normal)
-        wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testHandleComposingRomajiOnly() {
-        let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(6).sink { events in
-            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("k")])))
-            XCTAssertEqual(events[1], .markedText(MarkedText([])))
-            XCTAssertEqual(events[2], .markedText(MarkedText([.plain("s")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([])))
-            XCTAssertEqual(events[4], .markedText(MarkedText([.plain("t")])))
-            XCTAssertEqual(events[5], .markedText(MarkedText([])))
-            expectation.fulfill()
-        }.store(in: &cancellables)
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで右矢印キーが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlA, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Aが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .ctrlA, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlE, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Eが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .ctrlE, originalEvent: nil, cursorPosition: .zero)))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1155,14 +1155,15 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testHandleComposingRightRomajiOnly() {
+    func testHandleComposingRomajiOnly() {
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(5).sink { events in
+        stateMachine.inputMethodEvent.collect(6).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.plain("k")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.plain("s")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.plain("sh")])))
-            XCTAssertEqual(events[4], .markedText(MarkedText([])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.plain("t")])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
@@ -1170,9 +1171,13 @@ final class StateMachineTests: XCTestCase {
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで右矢印キーが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "h")))
-        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .right, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(stateMachine.state.inputMethod, .normal)
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlA, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Aが押されたら未入力に戻す")
+        XCTAssertFalse(stateMachine.handle(Action(keyEvent: .ctrlA, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlE, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Eが押されたら未入力に戻す")
+        XCTAssertFalse(stateMachine.handle(Action(keyEvent: .ctrlE, originalEvent: nil, cursorPosition: .zero)))
         wait(for: [expectation], timeout: 1.0)
     }
 


### PR DESCRIPTION
普段使いをしていて、次の不具合に気付いたので修正します。#65 #63 のシリーズ。
ちらっとStateMachineのhandleComposing見た感じ、ローマ字のみ入力のときに未確定入力を終了し忘れているのはこれで全部だと思います。

#### 再現手順

1. ローマ字の一文字目を入力する (下線つきでmarkedTextが表示される)
2. 右キー or C-a or C-eを入力する (下線つきのローマ字が消失する)
3. カーソル移動などを行う

#### 想定される挙動

3の操作でカーソルが移動する

#### 実際の挙動

カーソルが移動しない。Backspaceすると動かせるようになる