### PR TITLE
GitHub Actionsでのxcodebuildの出力をxcprettyに渡す & actions/checkoutのバージョンアップ

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
     - name: Select Xcode version
       run: sudo xcode-select -s '/Applications/Xcode_15.0.1.app/Contents/Developer'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: test
       run: |
-        xcodebuild -target macSKKTests -scheme macSKK -resultBundlePath TestResults DEVELOPMENT_TEAM= test
+        xcodebuild -target macSKKTests -scheme macSKK -resultBundlePath TestResults DEVELOPMENT_TEAM= test | xcpretty
     - uses: kishikawakatsumi/xcresulttool@v1
       with:
         path: TestResults.xcresult

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,5 @@ jobs:
     - uses: kishikawakatsumi/xcresulttool@v1
       with:
         path: TestResults.xcresult
+        show-passed-tests: false
       if: success() || failure()


### PR DESCRIPTION
GitHub Actionsでのテスト実行時に警告がでていました。

<img width="642" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/78dbe55c-9afa-44fb-b0a5-9e88172a630f">

textがなんなのかよくわかってないんですが、xcodebuildの出力かなあと思ったのでxcprettyを通してみます。
→ kishikawakatsumi/xcresulttool で結果ページを作るときの限界に達していたので通過したテストは表示しないオプションを有効にします。すでに制限にひっかかっていたのでテスト結果が最後ちょんぎれていた。

おまけで actions/checkoutを v3 から v4にバージョンアップします。