### PR TITLE
ローマ字一文字だけ入力時、バックスペースで未入力に戻す

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -151,11 +151,17 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
         return ComposingState(isShift: isShift, text: newText, okuri: okuri, romaji: romaji, cursor: newCursor)
     }
 
-    /// 入力中の文字列をカーソル位置から一文字削除する。0文字で削除できないときはnilを返す
+    /**
+     * 入力中の文字列をカーソル位置から一文字削除する。
+     * 0文字で削除できないときやローマ字一文字だけのときはnilを返す
+     */
     func dropLast() -> Self? {
         if !romaji.isEmpty {
-            return ComposingState(
-                isShift: isShift, text: text, okuri: okuri, romaji: String(romaji.dropLast()), cursor: cursor)
+            let newRomaji = romaji.dropLast()
+            if newRomaji.isEmpty && text.isEmpty {
+                return nil
+            }
+            return ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: String(newRomaji), cursor: cursor)
         } else if let okuri {
             return ComposingState(
                 isShift: isShift, text: text, okuri: okuri.isEmpty ? nil : okuri.dropLast(), romaji: romaji,

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1134,9 +1134,9 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testHandleComposingCursorRomajiOnly() {
+    func testHandleComposingRomajiOnly() {
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(8).sink { events in
+        stateMachine.inputMethodEvent.collect(10).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.plain("k")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.plain("s")])))
@@ -1145,6 +1145,8 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[5], .markedText(MarkedText([])))
             XCTAssertEqual(events[6], .markedText(MarkedText([.plain("n")])))
             XCTAssertEqual(events[7], .markedText(MarkedText([])))
+            XCTAssertEqual(events[8], .markedText(MarkedText([.plain("b")])))
+            XCTAssertEqual(events[9], .markedText(MarkedText([])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
@@ -1163,6 +1165,10 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .ctrlE, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Eが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .ctrlE, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "b")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでBackspaceが押されたら未入力に戻す")
+        XCTAssertFalse(stateMachine.handle(Action(keyEvent: .backspace, originalEvent: nil, cursorPosition: .zero)))
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -33,14 +33,21 @@ final class StateTests: XCTestCase {
     }
 
     func testComposingStateDropLastEmpty() {
-        let state = ComposingState(isShift: true, text: [], okuri: nil, romaji: "", cursor: nil)
+        var state = ComposingState(isShift: true, text: [], okuri: nil, romaji: "", cursor: nil)
         XCTAssertNil(state.dropLast())
+        state = ComposingState(isShift: true, text: [], okuri: nil, romaji: "k", cursor: nil)
+        XCTAssertNil(state.dropLast())
+        state = ComposingState(isShift: true, text: ["あ"], okuri: nil, romaji: "", cursor: nil)
+        XCTAssertNotNil(state.dropLast())
     }
 
     func testComposingStateDropLastTextAndRomaji() {
         let state = ComposingState(isShift: true, text: ["あ"], okuri: nil, romaji: "k", cursor: nil)
         let state2 = state.dropLast()
         XCTAssertEqual(state2?.romaji, "")
+        let state3 = state2?.dropLast()
+        XCTAssertNotNil(state3)
+        XCTAssertNil(state3?.dropLast())
     }
 
     func testComposingStateDropLastTextAndOkuri() {


### PR DESCRIPTION
未確定文字列の入力中、ローマ字しかない状態でバックスペースでローマ字を消したとき、本来は未入力状態に戻さないといけないところ、未確定文字列入力状態のままになっていました。

#67 に近いけどバックスペースはカーソル移動と違う処理なので見落としていました。

#### 再現手順

1. ローマ字の一文字目を入力する (下線つきでmarkedTextが表示される)
2. Backspaceを入力する (下線つきのローマ字が消失する)
3. カーソル移動などを行う

#### 想定される挙動

3の操作でカーソルが移動する

#### 実際の挙動

カーソルが移動しない。Backspaceすると動かせるようになる