### PR TITLE
キー配列の設定画面

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		CEA78FB229646CA100B67E25 /* UserDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FB129646CA100B67E25 /* UserDictTests.swift */; };
 		CEADA44B2B025A0F0026E2BD /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEADA44A2B025A0F0026E2BD /* Entry.swift */; };
 		CEADA44D2B025A8A0026E2BD /* EntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEADA44C2B025A8A0026E2BD /* EntryTests.swift */; };
+		CEADA44F2B1357090026E2BD /* GeneralView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEADA44E2B1357090026E2BD /* GeneralView.swift */; };
+		CEADA4512B1358D40026E2BD /* InputSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEADA4502B1358D40026E2BD /* InputSource.swift */; };
 		CEB0888C2A7F342000EFD1E3 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = CEB0888B2A7F342000EFD1E3 /* Credits.rtf */; };
 		CEB0888E2A7F393600EFD1E3 /* AnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0888D2A7F393600EFD1E3 /* AnnotationView.swift */; };
 		CEB088902A7F73B400EFD1E3 /* Pasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */; };
@@ -159,6 +161,8 @@
 		CEA78FB129646CA100B67E25 /* UserDictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDictTests.swift; sourceTree = "<group>"; };
 		CEADA44A2B025A0F0026E2BD /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		CEADA44C2B025A8A0026E2BD /* EntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTests.swift; sourceTree = "<group>"; };
+		CEADA44E2B1357090026E2BD /* GeneralView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralView.swift; sourceTree = "<group>"; };
+		CEADA4502B1358D40026E2BD /* InputSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSource.swift; sourceTree = "<group>"; };
 		CEB0888B2A7F342000EFD1E3 /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		CEB0888D2A7F393600EFD1E3 /* AnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationView.swift; sourceTree = "<group>"; };
 		CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pasteboard.swift; sourceTree = "<group>"; };
@@ -252,6 +256,7 @@
 				CE84A3DF295717CB009394C4 /* StateMachine.swift */,
 				CEE2D9762A99FE1B00A4CD76 /* Word.swift */,
 				CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */,
+				CE313A1E2AF5213700A49142 /* Candidate.swift */,
 				CE84A3EA295DA715009394C4 /* Dict.swift */,
 				CE5EB6AC2AAC0DE000389B98 /* FileDict.swift */,
 				CE5EB6AE2AAC0DEB00389B98 /* MemoryDict.swift */,
@@ -260,6 +265,7 @@
 				CE84A3E6295DA4DA009394C4 /* Romaji.swift */,
 				CE40D9A22A6D0C3900D44799 /* SystemDict.swift */,
 				CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */,
+				CEADA4502B1358D40026E2BD /* InputSource.swift */,
 				CE6DBA8C2A845CE400F5A227 /* Release.swift */,
 				CE6DBA8E2A845E8B00F5A227 /* ReleaseVersion.swift */,
 				CE485A872A8FA195008271EF /* Release+UNNotification.swift */,
@@ -279,7 +285,6 @@
 				CE6DBAC62A85BF3E00F5A227 /* Localizable.strings */,
 				CEB0888B2A7F342000EFD1E3 /* Credits.rtf */,
 				CE5ECF3B2957034D00E7BE7D /* Preview Content */,
-				CE313A1E2AF5213700A49142 /* Candidate.swift */,
 			);
 			path = macSKK;
 			sourceTree = "<group>";
@@ -335,6 +340,7 @@
 			children = (
 				CED7CA5A2A83DE7F004EF988 /* SettingsViewModel.swift */,
 				CEC376E72965199500D9C432 /* SettingsView.swift */,
+				CEADA44E2B1357090026E2BD /* GeneralView.swift */,
 				CE6DBACC2A864A3B00F5A227 /* DictionariesView.swift */,
 				CEB141712A87D16C005E7252 /* DictionaryView.swift */,
 				CE97887A2A9B93EB00F9B196 /* DirectModeView.swift */,
@@ -548,6 +554,7 @@
 				CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */,
 				CE84A3EB295DA715009394C4 /* Dict.swift in Sources */,
 				CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */,
+				CEADA4512B1358D40026E2BD /* InputSource.swift in Sources */,
 				CE84A3E7295DA4DA009394C4 /* Romaji.swift in Sources */,
 				CE7F9AD92AADEBF9001B1877 /* AppDelegate.swift in Sources */,
 				CEF0825B296D8FF000646366 /* CandidatesView.swift in Sources */,
@@ -566,6 +573,7 @@
 				CE313A1F2AF5213700A49142 /* Candidate.swift in Sources */,
 				CE6DBA8F2A845E8B00F5A227 /* ReleaseVersion.swift in Sources */,
 				CEB088902A7F73B400EFD1E3 /* Pasteboard.swift in Sources */,
+				CEADA44F2B1357090026E2BD /* GeneralView.swift in Sources */,
 				CE84A3DC2957174D009394C4 /* State.swift in Sources */,
 				CEE3717529653112000DB2C3 /* SoftwareUpdateView.swift in Sources */,
 				CE39DB212A8DFD8F00BC619F /* MarkedText.swift in Sources */,

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -229,6 +229,14 @@ class InputController: IMKInputController {
         if !directMode {
             inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: privateMode.value)
         }
+        // キー配列を設定する
+        if let inputSourceID = UserDefaults.standard.string(forKey: InputSource.selectedInputSourceKey) {
+            logger.info("InputSourceIDを \(inputSourceID, privacy: .public) に設定します")
+            textInput.overrideKeyboard(withKeyboardNamed: inputSourceID)
+        } else {
+            logger.info("InputSourceIDは選択されていません。デバッグとしてDvorakを設定します")
+            textInput.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.Dvorak")
+        }
     }
 
     @objc func showSettings() {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -202,6 +202,14 @@ class InputController: IMKInputController {
     }
 
     // MARK: - IMKStateSetting
+    override func activateServer(_ sender: Any!) {
+        if let textInput = sender as? IMKTextInput {
+            setCustomInputSource(textInput: textInput)
+        } else {
+            logger.warning("activateServerの引数clientがIMKTextInputではありません")
+        }
+    }
+
     override func deactivateServer(_ sender: Any!) {
         // 他の入力に切り替わるときには入力候補や補完候補は消す + 現在表示中の候補を確定させる
         candidatesPanel.orderOut(sender)
@@ -230,13 +238,7 @@ class InputController: IMKInputController {
             inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: privateMode.value)
         }
         // キー配列を設定する
-        if let inputSourceID = UserDefaults.standard.string(forKey: InputSource.selectedInputSourceKey) {
-            logger.info("InputSourceIDを \(inputSourceID, privacy: .public) に設定します")
-            textInput.overrideKeyboard(withKeyboardNamed: inputSourceID)
-        } else {
-            logger.info("InputSourceIDは選択されていません。デバッグとしてDvorakを設定します")
-            textInput.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.Dvorak")
-        }
+        setCustomInputSource(textInput: textInput)
     }
 
     @objc func showSettings() {
@@ -358,5 +360,15 @@ class InputController: IMKInputController {
             }
         }
         return nil
+    }
+
+    // キー配列を設定する
+    private func setCustomInputSource(textInput: IMKTextInput) {
+        if let inputSourceID = UserDefaults.standard.string(forKey: InputSource.selectedInputSourceKey) {
+            logger.info("InputSourceIDを \(inputSourceID, privacy: .public) に設定します")
+            textInput.overrideKeyboard(withKeyboardNamed: inputSourceID)
+        } else {
+            logger.info("InputSourceIDは選択されていません")
+        }
     }
 }

--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -14,11 +14,11 @@ struct InputSource: Hashable, Identifiable {
 
     // インストール済で利用可能なキー配列を取得する
     static func fetch() -> [InputSource]? {
-        let dict: [CFString: AnyObject] = [
+        let options: [CFString: AnyObject] = [
             kTISPropertyInputSourceType: kTISTypeKeyboardLayout,
             kTISPropertyInputSourceIsASCIICapable: kCFBooleanTrue,
         ]
-        guard let result = TISCreateInputSourceList(dict as CFDictionary, true).takeUnretainedValue() as? Array<TISInputSource> else {
+        guard let result = TISCreateInputSourceList(options as CFDictionary, true).takeUnretainedValue() as? Array<TISInputSource> else {
             return nil
         }
         return result.compactMap { inputSource -> InputSource? in

--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -10,7 +10,9 @@ struct InputSource: Hashable, Identifiable {
     let id: String
     let localizedName: String
     // 選択中のinputSourceIDをUserDefaultsに保存するときのキー
-    static let selectedInputSourceKey: String = "selectedInputSource"
+    static let selectedInputSourceKey = "selectedInputSource"
+    // 初期値はQWERTY
+    static let defaultInputSourceId = "com.apple.keylayout.ABC"
 
     // インストール済で利用可能なキー配列を取得する
     static func fetch() -> [InputSource]? {

--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import InputMethodKit
+
+/// キー配列
+struct InputSource {
+    // inputSourceID
+    let id: String
+    let localizedName: String
+
+    // インストール済で利用可能なキー配列を取得する
+    static func fetch() -> [InputSource]? {
+        let dict: [CFString: AnyObject] = [
+            kTISPropertyInputSourceType: kTISTypeKeyboardLayout,
+            kTISPropertyInputSourceIsASCIICapable: kCFBooleanTrue,
+        ]
+        guard let result = TISCreateInputSourceList(dict as CFDictionary, true).takeUnretainedValue() as? Array<TISInputSource> else {
+            return nil
+        }
+        return result.compactMap { inputSource -> InputSource? in
+            guard let id = getStringProperty(inputSource, key: kTISPropertyInputSourceID) else { return nil }
+            guard let localizedName = getStringProperty(inputSource, key: kTISPropertyLocalizedName) else { return nil }
+            return InputSource(id: id, localizedName: localizedName)
+        }
+    }
+
+    static func getStringProperty(_ tisInputSource: TISInputSource, key: NSString) -> String? {
+        guard let pointer = TISGetInputSourceProperty(tisInputSource, key) else { return nil }
+        return String(Unmanaged<NSString>.fromOpaque(pointer).takeUnretainedValue())
+    }
+}

--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -5,7 +5,7 @@ import Foundation
 import InputMethodKit
 
 /// キー配列
-struct InputSource {
+struct InputSource: Hashable, Identifiable {
     // inputSourceID
     let id: String
     let localizedName: String
@@ -22,12 +22,21 @@ struct InputSource {
         return result.compactMap { inputSource -> InputSource? in
             guard let id = getStringProperty(inputSource, key: kTISPropertyInputSourceID) else { return nil }
             guard let localizedName = getStringProperty(inputSource, key: kTISPropertyLocalizedName) else { return nil }
+            // 第一言語が英語じゃないものは弾く
+            if let languagesPointer = TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceLanguages),
+               let languages = Unmanaged<CFArray>.fromOpaque(languagesPointer).takeUnretainedValue() as? Array<String> {
+                if let first = languages.first {
+                    if first != "en" {
+                        return nil
+                    }
+                }
+            }
             return InputSource(id: id, localizedName: localizedName)
         }
     }
 
     static func getStringProperty(_ tisInputSource: TISInputSource, key: NSString) -> String? {
         guard let pointer = TISGetInputSourceProperty(tisInputSource, key) else { return nil }
-        return String(Unmanaged<NSString>.fromOpaque(pointer).takeUnretainedValue())
+        return String(Unmanaged<CFString>.fromOpaque(pointer).takeUnretainedValue())
     }
 }

--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -9,6 +9,8 @@ struct InputSource: Hashable, Identifiable {
     // inputSourceID
     let id: String
     let localizedName: String
+    // 選択中のinputSourceIDをUserDefaultsに保存するときのキー
+    static let selectedInputSourceKey: String = "selectedInputSource"
 
     // インストール済で利用可能なキー配列を取得する
     static func fetch() -> [InputSource]? {

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -9,14 +9,11 @@ struct GeneralView: View {
     var body: some View {
         VStack {
             Form {
-                Picker("キー配列", selection: $settingsViewModel.selectedInputSource) {
-                    Text("未選択").tag(Optional<InputSource>.none)
+                Picker("Keyboard Layout", selection: $settingsViewModel.selectedInputSource) {
+                    Text("Not Selected").tag(Optional<InputSource>.none)
                     ForEach(settingsViewModel.inputSources) { inputSource in
                         Text(inputSource.localizedName).tag(Optional<InputSource>.some(inputSource))
                     }
-                }
-                Button("キー配列取得") {
-                    print(settingsViewModel.inputSources)
                 }
             }
             .formStyle(.grouped)

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -9,10 +9,9 @@ struct GeneralView: View {
     var body: some View {
         VStack {
             Form {
-                Picker("Keyboard Layout", selection: $settingsViewModel.selectedInputSource) {
-                    Text("Not Selected").tag(Optional<InputSource>.none)
+                Picker("Keyboard Layout", selection: $settingsViewModel.selectedInputSourceId) {
                     ForEach(settingsViewModel.inputSources) { inputSource in
-                        Text(inputSource.localizedName).tag(Optional<InputSource>.some(inputSource))
+                        Text(inputSource.localizedName)
                     }
                 }
             }

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import SwiftUI
+
+struct GeneralView: View {
+    @State var selection: String?
+
+    var body: some View {
+        VStack {
+            Form {
+                Section {
+                    Picker("キー配列", selection: $selection) {
+
+                    }
+                } header: {
+                    Text("キー配列")
+                }
+                Button("キー配列取得") {
+                    let ary = InputSource.fetch()
+                    print(ary)
+                }
+            }
+            .formStyle(.grouped)
+        }
+    }
+}
+
+#Preview {
+    GeneralView()
+}

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -16,7 +16,7 @@ struct GeneralView: View {
                     }
                 }
                 Button("キー配列取得") {
-                    print(settingsViewModel.selectedInputSource)
+                    print(settingsViewModel.inputSources)
                 }
             }
             .formStyle(.grouped)

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -4,28 +4,28 @@
 import SwiftUI
 
 struct GeneralView: View {
-    @State var selection: String?
+    @StateObject var settingsViewModel: SettingsViewModel
 
     var body: some View {
         VStack {
             Form {
-                Section {
-                    Picker("キー配列", selection: $selection) {
-
+                Picker("キー配列", selection: $settingsViewModel.selectedInputSource) {
+                    Text("未選択").tag(Optional<InputSource>.none)
+                    ForEach(settingsViewModel.inputSources) { inputSource in
+                        Text(inputSource.localizedName).tag(Optional<InputSource>.some(inputSource))
                     }
-                } header: {
-                    Text("キー配列")
                 }
                 Button("キー配列取得") {
-                    let ary = InputSource.fetch()
-                    print(ary)
+                    print(settingsViewModel.selectedInputSource)
                 }
             }
             .formStyle(.grouped)
+        }.onAppear {
+            settingsViewModel.loadInputSources()
         }
     }
 }
 
 #Preview {
-    GeneralView()
+    GeneralView(settingsViewModel: try! SettingsViewModel(inputSources: [InputSource(id: "com.example.qwerty", localizedName: "Qwerty")]))
 }

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct SettingsView: View {
     // rawValueはLocalizable.stringsのキー名
     enum Section: String, CaseIterable {
+        case general = "SettingsNameGeneral"
         case dictionaries = "SettingsNameDictionaries"
         case softwareUpdate = "SettingsNameSoftwareUpdate"
         case directMode = "SettingsNameDirectMode"
@@ -26,6 +27,8 @@ struct SettingsView: View {
             List(Section.allCases, id: \.rawValue, selection: $selectedSection) { section in
                 NavigationLink(value: section) {
                     switch section {
+                    case .general:
+                        Label(section.localizedStringKey, systemImage: "gear")
                     case .dictionaries:
                         Label(section.localizedStringKey, systemImage: "books.vertical")
                     case .softwareUpdate:
@@ -46,6 +49,9 @@ struct SettingsView: View {
             .modifier(RemoveSidebarToggle())
         } detail: {
             switch selectedSection {
+            case .general:
+                GeneralView()
+                    .navigationTitle(selectedSection.localizedStringKey)
             case .dictionaries:
                 DictionariesView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -18,8 +18,8 @@ struct SettingsView: View {
         var localizedStringKey: LocalizedStringKey { LocalizedStringKey(rawValue) }
     }
     @ObservedObject var settingsViewModel: SettingsViewModel
-    @State private var selectedSection: Section = .dictionaries
-    @State private var histories: [Section] = [.dictionaries]
+    @State private var selectedSection: Section = .general
+    @State private var histories: [Section] = [.general]
     @State private var historyIndex: Int = 0
 
     var body: some View {
@@ -50,7 +50,7 @@ struct SettingsView: View {
         } detail: {
             switch selectedSection {
             case .general:
-                GeneralView()
+                GeneralView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
             case .dictionaries:
                 DictionariesView(settingsViewModel: settingsViewModel)

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -10,7 +10,7 @@ final class DictSetting: ObservableObject, Identifiable {
     @Published var filename: String
     @Published var enabled: Bool
     @Published var encoding: String.Encoding
-    
+
     var id: String { filename }
     
     init(filename: String, enabled: Bool, encoding: String.Encoding) {
@@ -105,6 +105,10 @@ final class SettingsViewModel: ObservableObject {
     @Published var dictLoadingStatuses: [DictSetting.ID: LoadStatus] = [:]
     /// 直接入力するアプリケーションのBundle Identifier
     @Published var directModeApplications: [DirectModeApplication] = []
+    /// 選択可能なキー配列
+    @Published var inputSources: [InputSource] = []
+    /// 選択しているキー配列
+    @Published var selectedInputSource: InputSource? = nil
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
     // バックグラウンドでの辞書を読み込みで読み込み状態が変わったときに通知される
@@ -212,6 +216,12 @@ final class SettingsViewModel: ObservableObject {
         self.directModeApplications = directModeApplications
     }
 
+    // GeneralViewのPreviewProvider用
+    internal convenience init(inputSources: [InputSource]) throws {
+        try self.init()
+        self.inputSources = inputSources
+    }
+
     /**
      * 辞書ファイルが追加・削除された通知を受け取りdictSettingsを更新する処理をセットアップします。
      *
@@ -265,5 +275,12 @@ final class SettingsViewModel: ObservableObject {
     func updateDirectModeApplication(index: Int, displayName: String, icon: NSImage) {
         directModeApplications[index].displayName = displayName
         directModeApplications[index].icon = icon
+    }
+
+    /// 利用可能なキー配列を読み込む
+    func loadInputSources() {
+        if let inputSources = InputSource.fetch() {
+            self.inputSources = inputSources
+        }
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -195,7 +195,11 @@ final class SettingsViewModel: ObservableObject {
 
         $selectedInputSource.sink { selectedInputSource in
             if let selectedInputSource {
+                logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) に設定しました")
                 UserDefaults.standard.set(selectedInputSource.id, forKey: InputSource.selectedInputSourceKey)
+            } else {
+                logger.info("キー配列の設定を削除しました")
+                UserDefaults.standard.removeObject(forKey: InputSource.selectedInputSourceKey)
             }
         }.store(in: &cancellables)
     }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -192,6 +192,12 @@ final class SettingsViewModel: ObservableObject {
             self?.userDictLoadingStatus = .loaded(entryCount)
         }
         .store(in: &cancellables)
+
+        $selectedInputSource.sink { selectedInputSource in
+            if let selectedInputSource {
+                UserDefaults.standard.set(selectedInputSource.id, forKey: InputSource.selectedInputSourceKey)
+            }
+        }.store(in: &cancellables)
     }
 
     // PreviewProvider用

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -35,4 +35,3 @@
 "Check For Update" = "Check For Update…";
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keybaord Layout";
-"Not Selected" = "Not Selected";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -2,6 +2,7 @@
 "MenuItemSaveDict" = "Save User Dictionary";
 "MenuItemPrivateMode" = "Private mode";
 "MenuItemDirectInput" = "Direct input from \"%@\"";
+"SettingsNameGeneral" = "General";
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameSoftwareUpdate" = "Software Update";
 "SettingsNameDirectMode" = "Direct Mode";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -34,3 +34,5 @@
 "Latest Version: %@" = "(Latest Verssion: %@)";
 "Check For Update" = "Check For Update…";
 "Open Release Page" = "Open Release Page";
+"Keyboard Layout" = "Keybaord Layout";
+"Not Selected" = "Not Selected";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -34,3 +34,5 @@
 "Latest Version: %@" = "(最新バージョン: %@)";
 "Check For Update" = "アップデートを確認…";
 "Open Release Page" = "リリースページを開く";
+"Keyboard Layout" = "キー配列";
+"Not Selected" = "未選択";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -35,4 +35,3 @@
 "Check For Update" = "アップデートを確認…";
 "Open Release Page" = "リリースページを開く";
 "Keyboard Layout" = "キー配列";
-"Not Selected" = "未選択";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -2,6 +2,7 @@
 "MenuItemSaveDict" = "ユーザー辞書を今すぐ保存";
 "MenuItemPrivateMode" = "プライベートモード";
 "MenuItemDirectInput" = "\"%@\"では直接入力";
+"SettingsNameGeneral" = "一般";
 "SettingsNameDictionaries" = "辞書";
 "SettingsNameSoftwareUpdate" = "ソフトウェアアップデート";
 "SettingsNameDirectMode" = "直接入力";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -154,6 +154,7 @@ struct macSKKApp: App {
                 DictSetting(filename: "SKK-JISYO.L", enabled: true, encoding: .japaneseEUC).encode()
             ],
             "directModeBundleIdentifiers": [String](),
+            InputSource.selectedInputSourceKey: InputSource.defaultInputSourceId,
         ])
     }
 


### PR DESCRIPTION
キー配列をQwerty以外のDvorak, CoremakなどのOSインストール済のものから選択できるようにします。
設定画面の一般から設定可能です。
初期値は "ABC" (`com.apple.keylayout.ABC`) です。

<img width="747" alt="inputsource" src="https://github.com/mtgto/macSKK/assets/1213991/61d3a0e3-838f-4534-b188-81c04612a8a2">

英語が第一言語じゃないものはメニューから省いています。それでもカナダとかアイルランドとか表示されちゃってますがAquaSKKの選択画面よりは絞れているんじゃないかと思います。
これはいまのmacSKKがローマ字入力を使っているので、英字以外が打てるキー配列は候補に入れる必要がないと考えたためです。
(かな入力に対応するかどうかは未定)

