### PR TITLE
カーソル位置が未確定文字列の先頭のときバックスペースで末尾から削除されるバグを修正

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -153,7 +153,7 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
 
     /**
      * 入力中の文字列をカーソル位置から一文字削除する。
-     * 0文字で削除できないときやローマ字一文字だけのときはnilを返す
+     * カーソルより前が0文字で削除できないときやローマ字一文字だけのときはnilを返す
      */
     func dropLast() -> Self? {
         if !romaji.isEmpty {
@@ -168,10 +168,14 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
                 cursor: cursor)
         } else if text.isEmpty {
             return nil
-        } else if let cursor = cursor, cursor > 0 {
-            var newText = text
-            newText.remove(at: cursor - 1)
-            return ComposingState(isShift: isShift, text: newText, okuri: okuri, romaji: romaji, cursor: cursor - 1)
+        } else if let cursor = cursor {
+            if cursor > 0 {
+                var newText = text
+                newText.remove(at: cursor - 1)
+                return ComposingState(isShift: isShift, text: newText, okuri: okuri, romaji: romaji, cursor: cursor - 1)
+            } else {
+                return self
+            }
         } else {
             return ComposingState(isShift: isShift, text: text.dropLast(), okuri: okuri, romaji: romaji, cursor: cursor)
         }

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -57,9 +57,12 @@ final class StateTests: XCTestCase {
     }
 
     func testComposingStateDropLastCursor() {
-        let state = ComposingState(
+        var state = ComposingState(
             isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: 1)
         XCTAssertEqual(state.dropLast()?.text, ["い"])
+        state = ComposingState(
+            isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: 0)
+        XCTAssertEqual(state.dropLast()?.text, ["あ", "い"], "カーソル位置が先頭のときはなにも削除しない")
     }
 
     func testComposingStateSubText() {


### PR DESCRIPTION
未確定文字列の入力中にバックスペースでカーソル位置から一文字削除しますが、カーソルが先頭にあるときの判定が間違っており未確定文字列の末尾から削除する挙動になっていました。
このバグを修正します。