### PR TITLE
インストール終了時に古いプロセスを終了する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CREDENTIALS_PROFILE := macSKK
 VERSION := $(shell xcodebuild -project macSKK.xcodeproj -target macSKK -showBuildSettings -json | jq -r '.[0].buildSettings.MARKETING_VERSION')
 
 WORKDIR := script/work
+SCRIPTSDIR := script/scripts
 XCARCHIVE := $(WORKDIR)/macSKK-$(VERSION).xcarchive
 APP := "$(WORKDIR)/export/macSKK.app"
 DSYMS := $(XCARCHIVE)/dSYMs
@@ -54,7 +55,7 @@ $(DICT_PKG): $(DICT)
 $(APP_PKG): $(APP)
 	mkdir -p $(WORKDIR)/app/Library/Input\ Methods
 	cp -r $< $(WORKDIR)/app/Library/Input\ Methods
-	pkgbuild --root $(WORKDIR)/app --component-plist script/app.plist --identifier $(APP_PKG_ID) --version $(VERSION) --install-location / $(APP_PKG)
+	pkgbuild --root $(WORKDIR)/app --component-plist script/app.plist --identifier $(APP_PKG_ID) --version $(VERSION) --install-location / --scripts $(SCRIPTSDIR) $(APP_PKG)
 
 $(INSTALLER_PKG): $(APP_PKG) $(DICT_PKG)
 	mkdir -p $(WORKDIR)/pkg

--- a/script/scripts/postinstall
+++ b/script/scripts/postinstall
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+asns=$(/usr/bin/lsappinfo find bundleID=net.mtgto.inputmethod.macSKK)
+if [[ "$asns" = ASN* ]]; then
+  osascript -e 'tell application id "net.mtgto.inputmethod.macSKK" to quit'
+fi


### PR DESCRIPTION
インストーラでバージョンアップした際、古いバージョンが終了しない限り新しいバージョンに変わりません。

この修正ではインストーラのpostinstallスクリプトを追加し、インストールの終了後に古いバージョンを終了するようにします。

kill/pkillでシグナル送信する形式では、通常のアプリケーション終了時に行っているユーザー辞書の永続化の処理が呼ばれないようだったので、osascript (AppleScript) を使って終了するようにしています。
osascriptなしでシェルスクリプトから正常終了する方法ありそうな気もするのですが見つからなかったので見送りました。

AppleScriptで `application id "net.mtgto.inputmethod.macSKK` のようにBundleIDを指定して書く場合、アプリケーションがみつからない場合、

```
❯ osascript -e 'tell application id "net.mtgto.inputmethod.macSKK2" to quit'
5:51: syntax error: application id "net.mtgto.inputmethod.macSKK2"を取り出すことはできません。 (-1728)
```

のように終了コード1で死んでしまうので、lsappinfoで起動中か確認するようにしています。
ユーザーが見るところではないので、 `osascript ... || true` で握り潰しちゃってもいいんだけど。