### PR TITLE
注釈を表示するかの設定項目を追加

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA292AAC171B00E80E5E /* FileDictTests.swift */; };
 		CE06CA2D2AAC172F00E80E5E /* empty.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE06CA2C2AAC172F00E80E5E /* empty.txt */; };
 		CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */; };
+		CE2157662B2EA985006E4C41 /* UserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */; };
 		CE313A1F2AF5213700A49142 /* Candidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE313A1E2AF5213700A49142 /* Candidate.swift */; };
 		CE39DB212A8DFD8F00BC619F /* MarkedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39DB202A8DFD8F00BC619F /* MarkedText.swift */; };
 		CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE40D9A02A6D0C2F00D44799 /* SystemDictView.swift */; };
@@ -116,6 +117,7 @@
 		CE06CA292AAC171B00E80E5E /* FileDictTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDictTests.swift; sourceTree = "<group>"; };
 		CE06CA2C2AAC172F00E80E5E /* empty.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
 		CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDict+Utilities.swift"; sourceTree = "<group>"; };
+		CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKeys.swift; sourceTree = "<group>"; };
 		CE313A1E2AF5213700A49142 /* Candidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Candidate.swift; sourceTree = "<group>"; };
 		CE39DB202A8DFD8F00BC619F /* MarkedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkedText.swift; sourceTree = "<group>"; };
 		CE40D9A02A6D0C2F00D44799 /* SystemDictView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemDictView.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 				CEE3717429653112000DB2C3 /* SoftwareUpdateView.swift */,
 				CEC376EA2965211200D9C432 /* KeyEventView.swift */,
 				CE40D9A02A6D0C2F00D44799 /* SystemDictView.swift */,
+				CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -549,6 +552,7 @@
 				CE5EB6AF2AAC0DEB00389B98 /* MemoryDict.swift in Sources */,
 				CEA78FAC2960401F00B67E25 /* String+Transform.swift in Sources */,
 				CED7F51F2AB5F4A7007FC6BD /* Character+Additions.swift in Sources */,
+				CE2157662B2EA985006E4C41 /* UserDefaultsKeys.swift in Sources */,
 				CE84A3B929570C37009394C4 /* InputController.swift in Sources */,
 				CE6599DC2ADBF2630052F8C0 /* SettingsWindow.swift in Sources */,
 				CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */,

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -34,7 +34,7 @@ class InputController: IMKInputController {
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         inputModePanel = InputModePanel()
-        candidatesPanel = CandidatesPanel(showAnnotationPopover: UserDefaults.standard.bool(forKey: "showAnnotation"))
+        candidatesPanel = CandidatesPanel(showAnnotationPopover: UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation))
         completionPanel = CompletionPanel()
         super.init(server: server, delegate: delegate, client: inputClient)
 
@@ -89,7 +89,7 @@ class InputController: IMKInputController {
         }.store(in: &cancellables)
         stateMachine.candidateEvent.sink { [weak self] candidates in
             if let self {
-                let showAnnotation = UserDefaults.standard.bool(forKey: "showAnnotation")
+                let showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
                 self.candidatesPanel.setShowAnnotationPopover(showAnnotation)
                 if let candidates {
                     // 下線のスタイルがthickのときに被らないように1ピクセル下に余白を設ける
@@ -128,7 +128,7 @@ class InputController: IMKInputController {
             self?.stateMachine.didDoubleSelectCandidate(doubleSelected)
         }.store(in: &cancellables)
         selectedWord.removeDuplicates().compactMap({ $0 }).sink { [weak self] word in
-            if UserDefaults.standard.bool(forKey: "showAnnotation") {
+            if UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation) {
                 if let systemAnnotation = SystemDict.lookup(word), !systemAnnotation.isEmpty {
                     self?.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
                     self?.candidatesPanel.show()
@@ -368,7 +368,7 @@ class InputController: IMKInputController {
 
     // キー配列を設定する
     private func setCustomInputSource(textInput: IMKTextInput) {
-        if let inputSourceID = UserDefaults.standard.string(forKey: InputSource.selectedInputSourceKey) {
+        if let inputSourceID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputSource) {
             logger.info("InputSourceIDを \(inputSourceID, privacy: .public) に設定します")
             textInput.overrideKeyboard(withKeyboardNamed: inputSourceID)
         } else {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -34,7 +34,7 @@ class InputController: IMKInputController {
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         inputModePanel = InputModePanel()
-        candidatesPanel = CandidatesPanel()
+        candidatesPanel = CandidatesPanel(showAnnotationPopover: UserDefaults.standard.bool(forKey: "showAnnotation"))
         completionPanel = CompletionPanel()
         super.init(server: server, delegate: delegate, client: inputClient)
 
@@ -89,6 +89,8 @@ class InputController: IMKInputController {
         }.store(in: &cancellables)
         stateMachine.candidateEvent.sink { [weak self] candidates in
             if let self {
+                let showAnnotation = UserDefaults.standard.bool(forKey: "showAnnotation")
+                self.candidatesPanel.setShowAnnotationPopover(showAnnotation)
                 if let candidates {
                     // 下線のスタイルがthickのときに被らないように1ピクセル下に余白を設ける
                     var cursorPosition = candidates.cursorPosition.offsetBy(dx: 0, dy: -1)
@@ -102,7 +104,7 @@ class InputController: IMKInputController {
                         self.candidatesPanel.setCandidates(currentCandidates, selected: candidates.selected)
                         self.candidatesPanel.show()
                     } else {
-                        if candidates.selected.annotations.isEmpty {
+                        if candidates.selected.annotations.isEmpty || !showAnnotation {
                             self.candidatesPanel.orderOut(nil)
                         } else {
                             self.candidatesPanel.show()
@@ -126,9 +128,11 @@ class InputController: IMKInputController {
             self?.stateMachine.didDoubleSelectCandidate(doubleSelected)
         }.store(in: &cancellables)
         selectedWord.removeDuplicates().compactMap({ $0 }).sink { [weak self] word in
-            if let systemAnnotation = SystemDict.lookup(word), !systemAnnotation.isEmpty {
-                self?.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
-                self?.candidatesPanel.show()
+            if UserDefaults.standard.bool(forKey: "showAnnotation") {
+                if let systemAnnotation = SystemDict.lookup(word), !systemAnnotation.isEmpty {
+                    self?.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
+                    self?.candidatesPanel.show()
+                }
             }
         }.store(in: &cancellables)
         directModeBundleIdentifiers.sink { [weak self] bundleIdentifiers in

--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -9,8 +9,6 @@ struct InputSource: Hashable, Identifiable {
     // inputSourceID
     let id: String
     let localizedName: String
-    // 選択中のinputSourceIDをUserDefaultsに保存するときのキー
-    static let selectedInputSourceKey = "selectedInputSource"
     // 初期値はQWERTY
     static let defaultInputSourceId = "com.apple.keylayout.ABC"
 

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -14,6 +14,9 @@ struct GeneralView: View {
                         Text(inputSource.localizedName)
                     }
                 }
+                Toggle(isOn: $settingsViewModel.showAnnotation, label: {
+                    Text("Show Annotation")
+                })
             }
             .formStyle(.grouped)
         }.onAppear {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -109,6 +109,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var inputSources: [InputSource] = []
     /// 選択しているキー配列
     @Published var selectedInputSourceId: InputSource.ID
+    /// 注釈を表示するかどうか
+    @Published var showAnnotation: Bool
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
     // バックグラウンドでの辞書を読み込みで読み込み状態が変わったときに通知される
@@ -125,6 +127,7 @@ final class SettingsViewModel: ObservableObject {
         } else {
             selectedInputSourceId = InputSource.defaultInputSourceId
         }
+        self.showAnnotation = UserDefaults.standard.bool(forKey: "showAnnotation")
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -206,6 +209,10 @@ final class SettingsViewModel: ObservableObject {
                 logger.error("キー配列 \(selectedInputSourceId, privacy: .public) が見つかりませんでした")
             }
         }.store(in: &cancellables)
+
+        $showAnnotation.sink { showAnnotation in
+            UserDefaults.standard.set(showAnnotation, forKey: "showAnnotation")
+        }.store(in: &cancellables)
     }
 
     // PreviewProvider用
@@ -217,6 +224,7 @@ final class SettingsViewModel: ObservableObject {
             create: false
         ).appendingPathComponent("Dictionaries")
         selectedInputSourceId = InputSource.defaultInputSourceId
+        showAnnotation = true
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -122,12 +122,12 @@ final class SettingsViewModel: ObservableObject {
         if let bundleIdentifiers = UserDefaults.standard.array(forKey: "directModeBundleIdentifiers") as? [String] {
             directModeApplications = bundleIdentifiers.map { DirectModeApplication(bundleIdentifier: $0) }
         }
-        if let selectedInputSourceId = UserDefaults.standard.string(forKey: InputSource.selectedInputSourceKey) {
+        if let selectedInputSourceId = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputSource) {
             self.selectedInputSourceId = selectedInputSourceId
         } else {
             selectedInputSourceId = InputSource.defaultInputSourceId
         }
-        self.showAnnotation = UserDefaults.standard.bool(forKey: "showAnnotation")
+        self.showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -204,14 +204,14 @@ final class SettingsViewModel: ObservableObject {
         $selectedInputSourceId.sink { [weak self] selectedInputSourceId in
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {
                 logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) (\(selectedInputSourceId, privacy: .public)) に設定しました")
-                UserDefaults.standard.set(selectedInputSource.id, forKey: InputSource.selectedInputSourceKey)
+                UserDefaults.standard.set(selectedInputSource.id, forKey: UserDefaultsKeys.selectedInputSource)
             } else {
                 logger.error("キー配列 \(selectedInputSourceId, privacy: .public) が見つかりませんでした")
             }
         }.store(in: &cancellables)
 
         $showAnnotation.sink { showAnnotation in
-            UserDefaults.standard.set(showAnnotation, forKey: "showAnnotation")
+            UserDefaults.standard.set(showAnnotation, forKey: UserDefaultsKeys.showAnnotation)
         }.store(in: &cancellables)
     }
 

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+struct UserDefaultsKeys {
+    static let dictionaries = "dictionaries"
+    static let directModeBundleIdentifiers = "directModeBundleIdentifiers"
+    // 選択中のinputSourceID
+    static let selectedInputSource = "selectedInputSource"
+    static let showAnnotation = "showAnnotation"
+}

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -10,8 +10,15 @@ final class CandidatesPanel: NSPanel {
     let viewModel: CandidatesViewModel
     var cursorPosition: NSRect = .zero
 
-    init() {
-        viewModel = CandidatesViewModel(candidates: [], currentPage: 0, totalPageCount: 0)
+    /**
+     * - Parameters:
+     *   - showAnnotationPopover: パネル表示時に注釈を表示するかどうか
+     */
+    init(showAnnotationPopover: Bool) {
+        viewModel = CandidatesViewModel(candidates: [],
+                                        currentPage: 0,
+                                        totalPageCount: 0,
+                                        showAnnotationPopover: showAnnotationPopover)
         let rootView = CandidatesView(candidates: self.viewModel)
         let viewController = NSHostingController(rootView: rootView)
         super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
@@ -29,6 +36,10 @@ final class CandidatesPanel: NSPanel {
 
     func setCursorPosition(_ cursorPosition: NSRect) {
         self.cursorPosition = cursorPosition
+    }
+
+    func setShowAnnotationPopover(_ showAnnotationPopover: Bool) {
+        self.viewModel.showAnnotationPopover = showAnnotationPopover
     }
 
     /**

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -92,14 +92,21 @@ struct CandidatesView_Previews: PreviewProvider {
     }
 
     private static func pageViewModel() -> CandidatesViewModel {
-        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3)
+        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3, showAnnotationPopover: true)
+        viewModel.selected = words.first
+        viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 10)]
+        return viewModel
+    }
+
+    private static func pageWithoutPopoverViewModel() -> CandidatesViewModel {
+        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3, showAnnotationPopover: false)
         viewModel.selected = words.first
         viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 10)]
         return viewModel
     }
 
     private static func inlineViewModel() -> CandidatesViewModel {
-        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3)
+        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3, showAnnotationPopover: true)
         viewModel.candidates = .inline
         viewModel.selected = words.first
         viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 10)]
@@ -109,6 +116,8 @@ struct CandidatesView_Previews: PreviewProvider {
     static var previews: some View {
         CandidatesView(candidates: pageViewModel())
             .previewDisplayName("パネル表示")
+        CandidatesView(candidates: pageWithoutPopoverViewModel())
+            .previewDisplayName("パネル表示 (注釈なし)")
         CandidatesView(candidates: inlineViewModel())
             .previewDisplayName("インライン表示")
     }

--- a/macSKK/View/CandidatesViewModel.swift
+++ b/macSKK/View/CandidatesViewModel.swift
@@ -57,12 +57,5 @@ final class CandidatesViewModel: ObservableObject {
             }
         }
         .store(in: &cancellables)
-
-        $showAnnotationPopover.removeDuplicates().sink { [weak self] showAnnotationPopover in
-            if !showAnnotationPopover {
-                self?.popoverIsPresented = false
-            }
-        }
-        .store(in: &cancellables)
     }
 }

--- a/macSKK/View/CandidatesViewModel.swift
+++ b/macSKK/View/CandidatesViewModel.swift
@@ -31,24 +31,36 @@ final class CandidatesViewModel: ObservableObject {
     @Published var selectedIndex: Int?
     @Published var selectedSystemAnnotation: String?
     @Published var selectedAnnotations: [Annotation] = []
+    /// パネル表示時に注釈を表示するかどうか
+    @Published var showAnnotationPopover: Bool
     private var cancellables: Set<AnyCancellable> = []
 
-    init(candidates: [Candidate], currentPage: Int, totalPageCount: Int) {
-        self.candidates = .panel(words: candidates, currentPage: currentPage, totalPageCount: totalPageCount)
+    init(candidates: [Candidate], currentPage: Int, totalPageCount: Int, showAnnotationPopover: Bool) {
+        self.candidates = .panel(words: candidates,
+                                 currentPage: currentPage,
+                                 totalPageCount: totalPageCount)
+        self.showAnnotationPopover = showAnnotationPopover
         if let first = candidates.first {
             self.selected = first
         }
 
         $selected.combineLatest($systemAnnotations).sink { [weak self] (selected, systemAnnotations) in
-            if let selected {
-                self?.selectedAnnotations = selected.annotations
-                if case let .panel(words, _, _) = self?.candidates {
-                    self?.selectedIndex = words.firstIndex(of: selected)
+            if let selected, let self {
+                self.selectedAnnotations = selected.annotations
+                if case let .panel(words, _, _) = self.candidates {
+                    self.selectedIndex = words.firstIndex(of: selected)
                 } else {
-                    self?.selectedIndex = nil
+                    self.selectedIndex = nil
                 }
-                self?.selectedSystemAnnotation = systemAnnotations[selected.word]
-                self?.popoverIsPresented = self?.selectedAnnotations != [] || self?.selectedSystemAnnotation != nil
+                self.selectedSystemAnnotation = systemAnnotations[selected.word]
+                self.popoverIsPresented = self.showAnnotationPopover && (self.selectedAnnotations != [] || self.selectedSystemAnnotation != nil)
+            }
+        }
+        .store(in: &cancellables)
+
+        $showAnnotationPopover.removeDuplicates().sink { [weak self] showAnnotationPopover in
+            if !showAnnotationPopover {
+                self?.popoverIsPresented = false
             }
         }
         .store(in: &cancellables)

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -35,4 +35,4 @@
 "Check For Update" = "Check For Update…";
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keybaord Layout";
-"Show Annotation" = "Show Annotation";
+"Show Annotation" = "Show the annotation of the candidate in current";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -35,3 +35,4 @@
 "Check For Update" = "Check For Update…";
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keybaord Layout";
+"Show Annotation" = "Show Annotation";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -35,3 +35,4 @@
 "Check For Update" = "アップデートを確認…";
 "Open Release Page" = "リリースページを開く";
 "Keyboard Layout" = "キー配列";
+"Show Annotation" = "注釈を表示";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -35,4 +35,4 @@
 "Check For Update" = "アップデートを確認…";
 "Open Release Page" = "リリースページを開く";
 "Keyboard Layout" = "キー配列";
-"Show Annotation" = "注釈を表示";
+"Show Annotation" = "現在の変換候補の注釈を表示";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -150,12 +150,12 @@ struct macSKKApp: App {
 
     private func setupUserDefaults() {
         UserDefaults.standard.register(defaults: [
-            "dictionaries": [
+            UserDefaultsKeys.dictionaries: [
                 DictSetting(filename: "SKK-JISYO.L", enabled: true, encoding: .japaneseEUC).encode()
             ],
-            "directModeBundleIdentifiers": [String](),
-            InputSource.selectedInputSourceKey: InputSource.defaultInputSourceId,
-            "showAnnotation": true,
+            UserDefaultsKeys.directModeBundleIdentifiers: [String](),
+            UserDefaultsKeys.selectedInputSource: InputSource.defaultInputSourceId,
+            UserDefaultsKeys.showAnnotation: true,
         ])
     }
 

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -36,7 +36,7 @@ struct macSKKApp: App {
     private let userNotificationDelegate = UserNotificationDelegate()
     @State private var fetchReleaseTask: Task<Void, Error>?
     #if DEBUG
-    private let candidatesPanel: CandidatesPanel = CandidatesPanel()
+    private let candidatesPanel: CandidatesPanel = CandidatesPanel(showAnnotationPopover: true)
     private let inputModePanel = InputModePanel()
     #endif
 

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -155,6 +155,7 @@ struct macSKKApp: App {
             ],
             "directModeBundleIdentifiers": [String](),
             InputSource.selectedInputSourceKey: InputSource.defaultInputSourceId,
+            "showAnnotation": true,
         ])
     }
 


### PR DESCRIPTION
インライン変換中および変換候補リスト表示中に選択中の変換候補の注釈を自動で表示する機能があります。
これまで常に有効になっていましたが、設定画面の「現在の変換候補の注釈を表示」から切り替えられるようにします。
デフォルト値はこれまでに合わせて「有効」にしています。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/ca427131-f41b-44f8-aeaf-474ae95c0a64">


Pull Request作成時の実装はだいぶ荒削りなので少しリファクタしてからマージしたい。