### PR TITLE
エラーログにキー配列が見つからないと出力していたのを修正

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -198,12 +198,14 @@ final class SettingsViewModel: ObservableObject {
         }
         .store(in: &cancellables)
 
-        $selectedInputSourceId.sink { [weak self] selectedInputSourceId in
+        $selectedInputSourceId.removeDuplicates().sink { [weak self] selectedInputSourceId in
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {
                 logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) (\(selectedInputSourceId, privacy: .public)) に設定しました")
                 UserDefaults.standard.set(selectedInputSource.id, forKey: InputSource.selectedInputSourceKey)
             } else {
-                logger.error("キー配列 \(selectedInputSourceId, privacy: .public) が見つかりませんでした")
+                if let self, !self.inputSources.isEmpty {
+                    logger.error("キー配列 \(selectedInputSourceId, privacy: .public) が見つかりませんでした")
+                }
             }
         }.store(in: &cancellables)
     }


### PR DESCRIPTION
#71 でキー配列設定を追加しましが、SettingsViewModelで「選択したキー配列が有効じゃないときにエラーログを出力する」という処理がありますが、初回起動時はまだキー配列を読み込んでないため常にエラーログを出力してしまう問題がありました。
これを修正します。