### PR TITLE
数値変換エントリで変換候補の数値以外の数が読みの数値以外の数より少ないとき変換できないバグを修正

### DIFF
--- a/macSKKTests/NumberEntryTests.swift
+++ b/macSKKTests/NumberEntryTests.swift
@@ -10,6 +10,7 @@ final class NumberEntryTests: XCTestCase {
         XCTAssertNil(NumberYomi(""))
         XCTAssertNil(NumberYomi("あい"), "整数が入ってないとnil")
         XCTAssertEqual(NumberYomi("あい1うえ")?.elements, [.other("あい"), .number(1), .other("うえ")])
+        XCTAssertEqual(NumberYomi("あい-100")?.elements, [.other("あい-"), .number(100)])
         XCTAssertEqual(NumberYomi("123456789あい")?.elements, [.number(123456789), .other("あい")])
         XCTAssertEqual(NumberYomi("あ1い2う3")?.elements, [.other("あ"), .number(1), .other("い"), .number(2), .other("う"), .number(3)])
         XCTAssertEqual(NumberYomi("18446744073709551615")?.elements, [.number(18446744073709551615)], "UInt64の最大値")
@@ -20,6 +21,12 @@ final class NumberEntryTests: XCTestCase {
         XCTAssertEqual(NumberYomi("あい123う")?.toMidashiString(), "あい#う")
         XCTAssertEqual(NumberYomi("0123456789あい")?.toMidashiString(), "#あい")
         XCTAssertEqual(NumberYomi("あ1い2う3")?.toMidashiString(), "あ#い#う#")
+    }
+
+    func testNumberYomiNumberElements() {
+        XCTAssertEqual(NumberYomi("あい123う")?.numberElements, [123])
+        XCTAssertEqual(NumberYomi("0123456789あい")?.numberElements, [123456789])
+        XCTAssertEqual(NumberYomi("1あ2い3う4")?.numberElements, [1, 2, 3, 4])
     }
 
     func testNumberCandidate() throws {
@@ -52,6 +59,9 @@ final class NumberEntryTests: XCTestCase {
         XCTAssertEqual(try NumberCandidate(yomi: "#9").toString(yomi: NumberYomi("111")!), nil)
         XCTAssertEqual(try NumberCandidate(yomi: "#9").toString(yomi: NumberYomi("50")!), nil)
         XCTAssertEqual(try NumberCandidate(yomi: "#0").toString(yomi: NumberYomi("1,2")!), nil, "数値の数が合わないとnil")
+        XCTAssertEqual(try NumberCandidate(yomi: "#0/#0").toString(yomi: NumberYomi("あ1い")!), nil, "数値の数が合わないとnil")
+        XCTAssertEqual(try NumberCandidate(yomi: "#0").toString(yomi: NumberYomi("だい100かい")!), "100")
+        XCTAssertEqual(try NumberCandidate(yomi: "#0,#1").toString(yomi: NumberYomi("100と200と")!), "100,２００")
         // SKK-JISYO.Lには数値変換らしきエントリで候補に "#数字" を含まないものがある。
         // 例えば "だい#" という見出しに "第" だけが登録されている。数値を切り捨ててほしいのかな…?
         XCTAssertEqual(try NumberCandidate(yomi: "第").toString(yomi: NumberYomi("だい2")!), nil)


### PR DESCRIPTION
#55 で導入した数値変換だと、"p# /#0/" のような、読みに含まれる数値以外の部分の数が変換候補に含まれる数値以外の部分の数より多い場合にエラーとしてしまっていました。

数値部分の数が読みと変換候補で同じかどうかだけチェックして、同じときは変換候補の "#X" (Xは一桁の整数) の部分を読みの数値部分に置換するように修正します。