### PR TITLE
MemoryDictのコンストラクタでtryが不要になってたので除去

### DIFF
--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -55,7 +55,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
             if let self {
                 do {
                     let source = try String(contentsOf: url, encoding: self.encoding)
-                    let memoryDict = try MemoryDict(dictId: self.id, source: source, readonly: readonly)
+                    let memoryDict = MemoryDict(dictId: self.id, source: source, readonly: readonly)
                     self.dict = memoryDict
                     self.version = NSFileVersion.currentVersionOfItem(at: url)
                     logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -25,7 +25,7 @@ struct MemoryDict: DictProtocol {
     /// 送りありの読みの配列。最近変換したものが後に登場する。
     private(set) var okuriAriYomis: [String] = []
 
-    init(dictId: FileDict.ID, source: String, readonly: Bool) throws {
+    init(dictId: FileDict.ID, source: String, readonly: Bool) {
         self.readonly = readonly
         var dict: [String: [Word]] = [:]
         var okuriNashiYomis: [String] = []

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -23,7 +23,7 @@ class MemoryDictTests: XCTestCase {
             いt /[った/行/言/]/
 
             """
-        let dict = try MemoryDict(dictId: "testDict", source: source, readonly: false)
+        let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
         XCTAssertEqual(dict.entries["あg"]?.map { $0.word }, ["挙", "揚", "上"])
         XCTAssertEqual(dict.entries["あb"]?.map { $0.word }, ["浴"])
         XCTAssertEqual(dict.entries["あ"]?.map { $0.word }, ["阿", "唖", "亜", "娃"])
@@ -40,7 +40,7 @@ class MemoryDictTests: XCTestCase {
             GPL /GNU General Public License;(concat "http:\\057\\057www.gnu.org\\057licenses\\057gpl.ja.html")/
 
             """
-        let dict = try MemoryDict(dictId: "testDict", source: source, readonly: false)
+        let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
         XCTAssertEqual(dict.entries["わi"]?.map { $0.word }, ["湧", "沸", "涌"])
         XCTAssertEqual(dict.entries["ao"]?.map { $0.word }, ["and/or"])
         XCTAssertEqual(dict.entries["GPL"]?.map { $0.annotation?.text }, ["http://www.gnu.org/licenses/gpl.ja.html"])
@@ -54,7 +54,7 @@ class MemoryDictTests: XCTestCase {
             あお /碧/
 
             """
-        let dict = try MemoryDict(dictId: "testDict", source: source, readonly: false)
+        let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
         XCTAssertEqual(dict.entries["あお"]?.map { $0.word }, ["青", "蒼", "碧"])
     }
 
@@ -64,7 +64,7 @@ class MemoryDictTests: XCTestCase {
             いぬ /犬;*かわいい/
 
             """
-        let dict = try MemoryDict(dictId: "testDict", source: source, readonly: false)
+        let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
         XCTAssertEqual(dict.entries["いぬ"]?.first?.annotation, Annotation(dictId: "testDict", text: "かわいい"))
     }
 


### PR DESCRIPTION
リファクタ。
#69 でSKK辞書の読み込みを正規表現を使っていたのを止めたのでMemoryDictのコンストラクタでthrowsが不要になりました。