### PR TITLE
単語登録画面でタブキーで入力文字列を補完する設定を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -63,6 +63,8 @@ import Combine
     static var ignoreLeadingSpacesWhenRegistering = true
     /// 単語登録中に空文字列で前候補キーもしくはバックスペースキーで候補選択に戻るか
     static var backToSelectingFromRegistering = false
+    /// 辞書登録時にタブキーで読みの文字列を補完するか
+    static var yomiCompletionByTabInRegistering = false
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -54,6 +54,9 @@ struct GeneralView: View {
                 Toggle(isOn: $settingsViewModel.backToSelectingFromRegistering, label: {
                     Text("Back to selecting candidates from empty word registration")
                 })
+                Toggle(isOn: $settingsViewModel.yomiCompletionByTabInRegistering, label: {
+                    Text("Complete yomi by Tab key in word registration")
+                })
                 Toggle(isOn: $settingsViewModel.showInputIconModal, label: {
                     Text("Show Input Mode Modal")
                 })

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -243,6 +243,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var ignoreLeadingSpacesWhenRegistering: Bool
     /// 単語登録中に空文字列で前候補キーもしくはバックスペースキーで候補選択に戻るか
     @Published var backToSelectingFromRegistering: Bool
+    /// 辞書登録時にタブキーで読みの文字列を補完するか
+    @Published var yomiCompletionByTabInRegistering: Bool
     /// 利用可能なフォントファミリー名
     @Published var availableFontFamilies: [String] = []
     /// 利用可能なローマ字かな変換ルール
@@ -338,6 +340,7 @@ final class SettingsViewModel: ObservableObject {
         registerKatakana = UserDefaults.app.bool(forKey: UserDefaultsKeys.registerKatakana)
         ignoreLeadingSpacesWhenRegistering = UserDefaults.app.bool(forKey: UserDefaultsKeys.ignoreLeadingSpacesWhenRegistering)
         backToSelectingFromRegistering = UserDefaults.app.bool(forKey: UserDefaultsKeys.backToSelectingFromRegistering)
+        yomiCompletionByTabInRegistering = UserDefaults.app.bool(forKey: UserDefaultsKeys.yomiCompletionByTabInRegistering)
         selectingBackspace = SelectingBackspace(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.selectingBackspace)) ?? SelectingBackspace.default
         comma = Punctuation.Comma(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
         period = Punctuation.Period(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
@@ -396,6 +399,7 @@ final class SettingsViewModel: ObservableObject {
         Global.registerKatakana = registerKatakana
         Global.ignoreLeadingSpacesWhenRegistering = ignoreLeadingSpacesWhenRegistering
         Global.backToSelectingFromRegistering = backToSelectingFromRegistering
+        Global.yomiCompletionByTabInRegistering = yomiCompletionByTabInRegistering
         Global.inputModePanel.updateColorSets(inputModeColorSets)
         Global.showMarkedTextMarker = showMarkedTextMarker
 
@@ -830,6 +834,12 @@ final class SettingsViewModel: ObservableObject {
             Global.backToSelectingFromRegistering = backToSelectingFromRegistering
         }.store(in: &cancellables)
 
+        $yomiCompletionByTabInRegistering.dropFirst().sink { yomiCompletionByTabInRegistering in
+            UserDefaults.app.set(yomiCompletionByTabInRegistering, forKey: UserDefaultsKeys.yomiCompletionByTabInRegistering)
+            logger.log("辞書登録時にタブキーで読みを補完する設定を\(yomiCompletionByTabInRegistering ? "有効" : "無効", privacy: .public)に変更しました")
+            Global.yomiCompletionByTabInRegistering = yomiCompletionByTabInRegistering
+        }.store(in: &cancellables)
+
         $selectedKanaRule.dropFirst().sink { [weak self] selectedKanaRule in
             guard let self else { return }
             if selectedKanaRule.isEmpty {
@@ -909,6 +919,7 @@ final class SettingsViewModel: ObservableObject {
         registerKatakana = false
         ignoreLeadingSpacesWhenRegistering = true
         backToSelectingFromRegistering = false
+        yomiCompletionByTabInRegistering = false
         systemDict = .daijirin
         selectingBackspace = SelectingBackspace.default
         comma = Punctuation.default.comma

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -78,4 +78,6 @@ struct UserDefaultsKeys {
     static let inputModePanel = "inputModePanel"
     // skkservへの接続エラーが何回連続したら自動無効化するか
     static let skkservAutoDisableThreshold = "skkservAutoDisableThreshold"
+    // 単語登録中にタブキーで読みを補完する
+    static let yomiCompletionByTabInRegistering = "yomiCompletionByTabInRegistering"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -314,9 +314,11 @@ final class StateMachine {
                 return false
             }
         case .tab:
-            if case .register(let registerState, _) = state.specialState, Global.yomiCompletionByTabInRegistering {
-                state.inputMethod = .composing(registerState.prev.composing)
-                updateMarkedText()
+            if case .register(let registerState, _) = state.specialState {
+                if Global.yomiCompletionByTabInRegistering, registerState.text.isEmpty {
+                    state.inputMethod = .composing(registerState.prev.composing)
+                    updateMarkedText()
+                }
                 return true
             }
             return false

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -314,7 +314,7 @@ final class StateMachine {
                 return false
             }
         case .tab:
-            if case .register(let registerState, _) = state.specialState {
+            if case .register(let registerState, _) = state.specialState, Global.yomiCompletionByTabInRegistering {
                 state.inputMethod = .composing(registerState.prev.composing)
                 updateMarkedText()
                 return true

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -314,6 +314,11 @@ final class StateMachine {
                 return false
             }
         case .tab:
+            if case .register(let registerState, _) = state.specialState {
+                state.inputMethod = .composing(registerState.prev.composing)
+                updateMarkedText()
+                return true
+            }
             return false
         case .stickyShift:
             switch state.inputMode {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -95,6 +95,7 @@
 "Register fixed katakana word to dict" = "Register fixed katakana word to dict";
 "Ignore leading spaces when registering a word" = "Ignore leading spaces when registering a word";
 "Back to selecting candidates from empty word registration" = "Back to selecting candidates from registration using the backward candidate or backspace key";
+"Complete yomi by Tab key in word registration" = "Complete yomi by Tab key in word registration";
 "Direction of candidate list" = "Direction of candidate list";
 "Enter Key confirms a candidate and sends a newline" = "Enter Key confirms a candidate and sends a newline";
 "Show Completion" = "Show Completion";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -95,6 +95,7 @@
 "Register fixed katakana word to dict" = "カタカナで確定した単語を辞書に登録する";
 "Ignore leading spaces when registering a word" = "単語登録中に先頭スペースを無視する";
 "Back to selecting candidates from empty word registration" = "単語登録中に前候補キーもしくはバックスペースキーで候補選択に戻る";
+"Complete yomi by Tab key in word registration" = "単語登録中にTabで読みを入力する";
 "Direction of candidate list" = "変換候補リストの表示方向";
 "Enter Key confirms a candidate and sends a newline" = "Enterキーで変換候補確定後に改行を入力";
 "Show Completion" = "補完候補を表示";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -256,6 +256,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.registerKatakana: false,
             UserDefaultsKeys.ignoreLeadingSpacesWhenRegistering: true,
             UserDefaultsKeys.backToSelectingFromRegistering: false,
+            UserDefaultsKeys.yomiCompletionByTabInRegistering: false,
             UserDefaultsKeys.candidatesFontFamily: "", // 空文字列はSystem Font
             UserDefaultsKeys.overridesCandidatesBackgroundColor: false,
             UserDefaultsKeys.candidatesBackgroundColor: "#FFFFFF",

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -3187,6 +3187,39 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleRegisteringTab() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(12).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[2], .modeChanged(.hiragana))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.plain("[登録：あい]")])))
+            // 単語登録で空文字列のときにTabキーを押すと単語登録までの読みが補完される
+            XCTAssertEqual(events[4], .markedText(MarkedText([.plain("[登録：あい]"), .markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([.plain("[登録：あい]"), .markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.plain("[登録：あい]")])))
+            XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[8], .markedText(MarkedText([.markerCompose, .plain("あい*k")])))
+            XCTAssertEqual(events[9], .modeChanged(.hiragana))
+            XCTAssertEqual(events[10], .markedText(MarkedText([.plain("[登録：あい*く]")])))
+            XCTAssertEqual(events[11], .markedText(MarkedText([.plain("[登録：あい*く]"), .markerCompose, .plain("あい*く")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(tabAction))
+        XCTAssertTrue(stateMachine.handle(tabAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
+        XCTAssertTrue(stateMachine.handle(tabAction))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleSelectingEnter() {
         Global.dictionary.setEntries(["と": [Word("戸")]])
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -24,6 +24,7 @@ final class StateMachineTests: XCTestCase {
         Global.keyBinding = KeyBindingSet.defaultKeyBindingSet
         Global.ignoreLeadingSpacesWhenRegistering = true
         Global.backToSelectingFromRegistering = false
+        Global.yomiCompletionByTabInRegistering = false
     }
 
     @MainActor func testHandleNormalSimple() {
@@ -3189,6 +3190,7 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testHandleRegisteringTab() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.yomiCompletionByTabInRegistering = true
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(12).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -3192,27 +3192,32 @@ final class StateMachineTests: XCTestCase {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         Global.yomiCompletionByTabInRegistering = true
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(12).sink { events in
+        stateMachine.inputMethodEvent.collect(14).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
             XCTAssertEqual(events[2], .modeChanged(.hiragana))
             XCTAssertEqual(events[3], .markedText(MarkedText([.plain("[登録：あい]")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.plain("[登録：あい]"), .plain("う")])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([.plain("[登録：あい]")])))
             // 単語登録で空文字列のときにTabキーを押すと単語登録までの読みが補完される
-            XCTAssertEqual(events[4], .markedText(MarkedText([.plain("[登録：あい]"), .markerCompose, .plain("あい")])))
-            XCTAssertEqual(events[5], .markedText(MarkedText([.plain("[登録：あい]"), .markerCompose, .plain("あ")])))
-            XCTAssertEqual(events[6], .markedText(MarkedText([.plain("[登録：あい]")])))
-            XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("あい")])))
-            XCTAssertEqual(events[8], .markedText(MarkedText([.markerCompose, .plain("あい*k")])))
-            XCTAssertEqual(events[9], .modeChanged(.hiragana))
-            XCTAssertEqual(events[10], .markedText(MarkedText([.plain("[登録：あい*く]")])))
-            XCTAssertEqual(events[11], .markedText(MarkedText([.plain("[登録：あい*く]"), .markerCompose, .plain("あい*く")])))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.plain("[登録：あい]"), .markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[7], .markedText(MarkedText([.plain("[登録：あい]"), .markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[8], .markedText(MarkedText([.plain("[登録：あい]")])))
+            XCTAssertEqual(events[9], .markedText(MarkedText([.markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[10], .markedText(MarkedText([.markerCompose, .plain("あい*k")])))
+            XCTAssertEqual(events[11], .modeChanged(.hiragana))
+            XCTAssertEqual(events[12], .markedText(MarkedText([.plain("[登録：あい*く]")])))
+            XCTAssertEqual(events[13], .markedText(MarkedText([.plain("[登録：あい*く]"), .markerCompose, .plain("あい*く")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(tabAction))
-        XCTAssertTrue(stateMachine.handle(tabAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
+        XCTAssertTrue(stateMachine.handle(tabAction)) // 単語登録モードで文字が入力されているので補完されない
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(tabAction)) // 単語登録モードで文字が入力されていないので補完される
+        XCTAssertTrue(stateMachine.handle(tabAction)) // 補完済みなら何も起きない
         XCTAssertTrue(stateMachine.handle(backspaceAction))
         XCTAssertTrue(stateMachine.handle(cancelAction))
         XCTAssertTrue(stateMachine.handle(cancelAction))


### PR DESCRIPTION

<img width="640" height="532" alt="image" src="https://github.com/user-attachments/assets/e086b96e-9143-407d-9137-4042c77b7eba" />


単語登録画面でTabキーを打つことで単語登録画面に入る前に入力した読み部分が自動入力される設定「単語登録中にTabで読みを入力する」を追加します。
デフォルトは無効です。

### 例

`▽あいうえ` と打ってスペースを入力すると `[登録：あいうえ]` と表示される。
その状態でタブキーを入力すると `[登録：あいうえ]▽あいうえ` のように未登録の読みである「あいうえ」を入力している状態になる。

## 実装した目的

2つの単語からなる言葉、たとえば「にほんとういつ」という読みを持つエントリを登録したいとき、

1. にほんとういつと打ってスペース
2. 単語登録モードに入る
3. タブキーを打つと「にほんとういつ」が入力されるので、4回バックスペースを押してスペースで変換し「日本」を確定
4. もう一度タブキーを押して4回左キーを押して3回バックスペースを押して4回右キーを押してスペースで変換し「統一」を確定

のように単語登録時に読みの一部を使えると便利かもしれないなと思うことがたまにあったため。

送り仮名があるときにはたとえば `[登録：あいう*え]` の状態でタブキーを入力すると `[登録：あいう*え]▽あいう*え` のように送り仮名つきで自動入力されます。送り仮名は不要な気もするのでここは将来変えるかもしれません。