### PR TITLE
未確定文字列の入力中、カーソルが先頭のときにスペースを押すと入力前に戻す

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -383,6 +383,10 @@ class StateMachine {
                 addFixedText(" ")
                 state.inputMethod = .normal
                 return true
+            } else if composing.cursor == 0 {
+                state.inputMethod = .normal
+                updateMarkedText()
+                return true
             } else {
                 return handleComposingStartConvert(action, composing: composing, specialState: specialState)
             }


### PR DESCRIPTION
未確定文字列の入力中、カーソルが先頭にあるときにスペースで変換しようとすると空文字列で変換開始しようとして `[登録：]` のように空文字列のための単語登録が開始されるようになるバグがありました。

スペースキーの入力を無視する、カーソルが末尾にあるとみなして変換する、なども考えましたがAquaSKK, ddskkに合わせて未確定文字列を入力していなかった状態に戻すようにします。