### PR TITLE
アプリのログを設定画面で見れるようにする

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		CE40D9A32A6D0C3900D44799 /* SystemDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE40D9A22A6D0C3900D44799 /* SystemDict.swift */; };
 		CE485A882A8FA195008271EF /* Release+UNNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE485A872A8FA195008271EF /* Release+UNNotification.swift */; };
 		CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE485A892A8FA5C6008271EF /* UserNotificationDelegate.swift */; };
+		CE496C8C2B43968A001C623C /* LogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE496C8B2B43968A001C623C /* LogView.swift */; };
 		CE4CB5CC2AD557D90046FA34 /* NumberEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */; };
 		CE4CB5CE2AD55DF90046FA34 /* NumberEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4CB5CD2AD55DF90046FA34 /* NumberEntryTests.swift */; };
 		CE5EB6AD2AAC0DE000389B98 /* FileDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5EB6AC2AAC0DE000389B98 /* FileDict.swift */; };
@@ -124,6 +125,7 @@
 		CE40D9A22A6D0C3900D44799 /* SystemDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemDict.swift; sourceTree = "<group>"; };
 		CE485A872A8FA195008271EF /* Release+UNNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Release+UNNotification.swift"; sourceTree = "<group>"; };
 		CE485A892A8FA5C6008271EF /* UserNotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationDelegate.swift; sourceTree = "<group>"; };
+		CE496C8B2B43968A001C623C /* LogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogView.swift; sourceTree = "<group>"; };
 		CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberEntry.swift; sourceTree = "<group>"; };
 		CE4CB5CD2AD55DF90046FA34 /* NumberEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberEntryTests.swift; sourceTree = "<group>"; };
 		CE5EB6AC2AAC0DE000389B98 /* FileDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDict.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 				CEB141712A87D16C005E7252 /* DictionaryView.swift */,
 				CE97887A2A9B93EB00F9B196 /* DirectModeView.swift */,
 				CEE3717429653112000DB2C3 /* SoftwareUpdateView.swift */,
+				CE496C8B2B43968A001C623C /* LogView.swift */,
 				CEC376EA2965211200D9C432 /* KeyEventView.swift */,
 				CE40D9A02A6D0C2F00D44799 /* SystemDictView.swift */,
 				CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */,
@@ -579,6 +582,7 @@
 				CEB088902A7F73B400EFD1E3 /* Pasteboard.swift in Sources */,
 				CEADA44F2B1357090026E2BD /* GeneralView.swift in Sources */,
 				CE84A3DC2957174D009394C4 /* State.swift in Sources */,
+				CE496C8C2B43968A001C623C /* LogView.swift in Sources */,
 				CEE3717529653112000DB2C3 /* SoftwareUpdateView.swift in Sources */,
 				CE39DB212A8DFD8F00BC619F /* MarkedText.swift in Sources */,
 				CE40D9A32A6D0C3900D44799 /* SystemDict.swift in Sources */,

--- a/macSKK/Settings/LogView.swift
+++ b/macSKK/Settings/LogView.swift
@@ -24,10 +24,10 @@ struct LogView: View {
         .task {
             do {
                 let logStore = try OSLogStore(scope: .currentProcessIdentifier)
-                let entries = try logStore.getEntries()
+                let predicate = NSPredicate(format: "subsystem == %@", Bundle.main.bundleIdentifier!)
+                let entries = try logStore.getEntries(matching: predicate)
                     .compactMap { entry -> OSLogEntryLog? in
                         guard let entry = entry as? OSLogEntryLog else { return nil }
-                        guard entry.subsystem == Bundle.main.bundleIdentifier! else { return nil }
                         return entry
                     }
                 let format = Date.ISO8601FormatStyle.iso8601Date(timeZone: TimeZone.current)

--- a/macSKK/Settings/LogView.swift
+++ b/macSKK/Settings/LogView.swift
@@ -12,34 +12,29 @@ struct LogView: View {
         Form {
             TextEditor(text: .constant(log))
             Spacer()
-            Button {
-                let pasteboard = NSPasteboard.general
-                pasteboard.clearContents()
-                pasteboard.setString(log, forType: .string)
-            } label: {
-                Text("Copy")
+            HStack {
+                if loading {
+                    ProgressView().controlSize(.small)
+                }
+                Spacer()
+                Button {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(log, forType: .string)
+                } label: {
+                    Text("Copy")
+                }
+                .disabled(loading)
             }
-            .disabled(loading)
 
         }
         .padding()
         .task {
             loading = true
-            do {
-                let logStore = try OSLogStore(scope: .currentProcessIdentifier)
-                let predicate = NSPredicate(format: "subsystem == %@", Bundle.main.bundleIdentifier!)
-                let logs = try logStore.getEntries(matching: predicate).compactMap { $0 as? OSLogEntryLog }
-                let format = Date.ISO8601FormatStyle.iso8601Date(timeZone: TimeZone.current)
-                    .dateTimeSeparator(.space)
-                    .time(includingFractionalSeconds: true)
-                self.log = logs.map { entry in
-                    [
-                        "[\(entry.date.formatted(format))]",
-                        "[\(levelDescription(level: entry.level))]",
-                        "\(entry.composedMessage)",
-                    ].joined(separator: " ")
-                }.joined(separator: "\n")
-            } catch {
+            switch await load().result {
+            case .success(let log):
+                self.log = log
+            case .failure(let error):
                 self.log = "アプリケーションログが取得できません: \(error)"
                 logger.error("アプリケーションログが取得できません: \(error)")
             }
@@ -47,27 +42,44 @@ struct LogView: View {
         }
     }
 
-    private func levelDescription(level: OSLogEntryLog.Level) -> String {
-        switch level {
-        case .undefined:
-            return "undefined"
-        case .debug:
-            return "debug"
-        case .info:
-            return "info"
-        case .notice:
-            return "notice"
-        case .error:
-            return "error"
-        case .fault:
-            return "fault"
-        @unknown default:
-            logger.error("未知のログレベル \(level.rawValue) が使用されました")
-            return "unknown"
+    private func load() async -> Task<String, Error> {
+        Task { () -> String in
+            func levelDescription(level: OSLogEntryLog.Level) -> String {
+                switch level {
+                case .undefined:
+                    return "undefined"
+                case .debug:
+                    return "debug"
+                case .info:
+                    return "info"
+                case .notice:
+                    return "notice"
+                case .error:
+                    return "error"
+                case .fault:
+                    return "fault"
+                @unknown default:
+                    logger.error("未知のログレベル \(level.rawValue) が使用されました")
+                    return "unknown"
+                }
+            }
+            let logStore = try OSLogStore(scope: .currentProcessIdentifier)
+            let predicate = NSPredicate(format: "subsystem == %@", Bundle.main.bundleIdentifier!)
+            let logs = try logStore.getEntries(matching: predicate).compactMap { $0 as? OSLogEntryLog }
+            let format = Date.ISO8601FormatStyle.iso8601Date(timeZone: TimeZone.current)
+                .dateTimeSeparator(.space)
+                .time(includingFractionalSeconds: true)
+            return logs.map { entry in
+                [
+                    "[\(entry.date.formatted(format))]",
+                    "[\(levelDescription(level: entry.level))]",
+                    "\(entry.composedMessage)",
+                ].joined(separator: " ")
+            }.joined(separator: "\n")
         }
     }
 }
 
 #Preview {
-    LogView(log: ["12:34:56 ほげほげがほげほげしました", "12:34:56 ふがふががふがふがしました"].joined(separator: "\n"))
+    LogView(log: ["[2024-01-01 12:34:56.789] [info] ほげほげがほげほげしました", "[2024-01-01 12:34:56.789] [info]  ふがふががふがふがしました"].joined(separator: "\n"))
 }

--- a/macSKK/Settings/LogView.swift
+++ b/macSKK/Settings/LogView.swift
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import OSLog
+import SwiftUI
+
+struct LogView: View {
+    @State var log: String
+
+    var body: some View {
+        Form {
+            Text(log)
+                .textSelection(.enabled)
+            Spacer()
+            Button {
+                
+            } label: {
+                Text("クリップボードにコピー")
+            }
+
+        }
+        .padding()
+        .onAppear(perform: {
+            do {
+                let logStore = try OSLogStore(scope: .currentProcessIdentifier)
+                let entries = try logStore.getEntries()
+                self.log = entries.map { $0.composedMessage }.joined(separator: "\n")
+            } catch {
+                self.log = "アプリケーションログが取得できません: \(error)"
+                logger.error("アプリケーションログが取得できません: \(error)")
+            }
+        })
+    }
+}
+
+#Preview {
+    LogView(log: ["12:34:56 ほげほげがほげほげしました", "12:34:56 ふがふががふがふがしました"].joined(separator: "\n"))
+}

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
         case dictionaries = "SettingsNameDictionaries"
         case softwareUpdate = "SettingsNameSoftwareUpdate"
         case directMode = "SettingsNameDirectMode"
+        case log = "SettingsNameLog"
         #if DEBUG
         case keyEvent = "SettingsNameKeyEvent"
         case systemDict = "SettingsNameSystemDict"
@@ -35,6 +36,8 @@ struct SettingsView: View {
                         Label(section.localizedStringKey, systemImage: "gear.badge")
                     case .directMode:
                         Label(section.localizedStringKey, systemImage: "hand.raised.app")
+                    case .log:
+                        Label(section.localizedStringKey, systemImage: "doc.plaintext")
                     #if DEBUG
                     case .keyEvent:
                         Label(section.localizedStringKey, systemImage: "keyboard")
@@ -61,6 +64,8 @@ struct SettingsView: View {
             case .directMode:
                 DirectModeView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
+            case .log:
+                LogView(log: "")
             #if DEBUG
             case .keyEvent:
                 KeyEventView()

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -65,7 +65,7 @@ struct SettingsView: View {
                 DirectModeView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
             case .log:
-                LogView(log: "")
+                LogView(log: NSLocalizedString("LoadingStatusLoading", comment: "Loading…"))
             #if DEBUG
             case .keyEvent:
                 KeyEventView()

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -66,6 +66,7 @@ struct SettingsView: View {
                     .navigationTitle(selectedSection.localizedStringKey)
             case .log:
                 LogView(log: NSLocalizedString("LoadingStatusLoading", comment: "Loading…"))
+                    .navigationTitle(selectedSection.localizedStringKey)
             #if DEBUG
             case .keyEvent:
                 KeyEventView()

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameSoftwareUpdate" = "Software Update";
 "SettingsNameDirectMode" = "Direct Mode";
+"SettingsNameLog" = "Log";
 "SettingsNameKeyEvent" = "Key Event";
 "SettingsNameSystemDict" = "System Dict";
 "SettingsNameUserDictTitle" = "User Dictionary";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -37,3 +37,4 @@
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keybaord Layout";
 "Show Annotation" = "Show the annotation of the candidate in current";
+"Copy" = "Copy";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "SettingsNameDictionaries" = "辞書";
 "SettingsNameSoftwareUpdate" = "ソフトウェアアップデート";
 "SettingsNameDirectMode" = "直接入力";
+"SettingsNameLog" = "ログ";
 "SettingsNameKeyEvent" = "キーイベント";
 "SettingsNameSystemDict" = "システム辞書";
 "SettingsNameUserDictTitle" = "ユーザー辞書";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -37,3 +37,4 @@
 "Open Release Page" = "リリースページを開く";
 "Keyboard Layout" = "キー配列";
 "Show Annotation" = "現在の変換候補の注釈を表示";
+"Copy" = "コピー";


### PR DESCRIPTION
OSLogStoreを使って起動後のアプリケーションのログを設定画面から見れるようにします。
同じことはConsole.appでもできますが、クリップボードへのコピーボタンを用意して異常時に何が起きたかを連絡しやすくするのが狙いです。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/947aacee-3536-4707-b289-c5aeb0da3740">

