### PR TITLE
振り仮名入力中にqを押すと入力文字列が消えるバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -598,7 +598,8 @@ class StateMachine {
                 // 送り仮名があるときはローマ字部分をリセットする
                 state.inputMethod = .composing(
                     ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: ""))
-                return false
+                updateMarkedText()
+                return true
             }
         } else if input == "l" && converted.kakutei == nil {
             // 入力済みを確定してからlを打ったのと同じ処理をする

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -922,6 +922,24 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleComposingOkuriQ() {
+        dictionary.setEntries(["おu": [Word("追")]])
+
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(4).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("お")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("お*k")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("お*")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("追う")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleComposingOkuriCursor() {
         dictionary.setEntries(["あu": [Word("会")]])
 


### PR DESCRIPTION
振り仮名を入力中 (ローマ字) にqを入力すると未確定文字列が表示されなくなるバグを修正します。

#### 再現手順

1. ローマ字の一文字目を入力する (下線つきでmarkedTextが表示される)
2. qを入力する
3. ローマ字を入力する

#### 想定される挙動

- 2の段階では "あいうえお*" のようにローマ字部分がリセットされる
- 3の操作で送り仮名の一文字目から入力となる

#### 実際の挙動

- 2の段階で未確定文字列が消える
- 3の段階で未確定文字列が復活する