### PR TITLE
設定画面でツールバーとボディが被ることがあるのを修正

### DIFF
--- a/macSKK/View/SettingsWindow.swift
+++ b/macSKK/View/SettingsWindow.swift
@@ -10,7 +10,6 @@ class SettingsWindow: NSWindow {
         let viewController = NSHostingController(rootView: rootView)
         super.init(contentRect: .zero, styleMask: [.titled, .closable, .fullSizeContentView, .unifiedTitleAndToolbar], backing: .buffered, defer: true)
         contentViewController = viewController
-        titlebarAppearsTransparent = true
         isExcludedFromWindowsMenu = true
         center()
     }


### PR DESCRIPTION
設定画面はタイトルバーを透過しないほうがよさそうなので修正。

| before | after |
| :-: | :-: |
| <img width="640" alt="before" src="https://github.com/mtgto/macSKK/assets/1213991/d98cfacf-73ed-440f-9a68-e136cdaa603f"> | <img width="640" alt="after" src="https://github.com/mtgto/macSKK/assets/1213991/907e48fb-d073-4b74-bea4-b4ecd181ea96"> |
