### PR TITLE
設定画面のサイドバーの横幅が小さくならないようにframeでwidthを設定

### DIFF
--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -48,6 +48,7 @@ struct SettingsView: View {
                 }
             }
             .listStyle(.sidebar)
+            .frame(width: 215)
             .navigationSplitViewColumnWidth(215)
             .modifier(RemoveSidebarToggle())
         } detail: {


### PR DESCRIPTION
設定画面のサイドバーがやたら狭くなってしまうようだったので試しにframeでwidthを設定してみます。

| before | after |
| :-: | :-: |
| <img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/e36cc728-27f9-4b8a-9170-923010228363"> | <img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/62fa15f5-f9eb-49d0-9ba0-4c52cdb47938"> |
 