### PR TITLE
ユーザー辞書を保存後に読み込み直していたバグを修正

### DIFF
--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -43,11 +43,11 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         self.version = NSFileVersion.currentVersionOfItem(at: fileURL)
         self.readonly = readonly
         super.init()
-        try load(fileURL)
+        try load()
         NSFileCoordinator.addFilePresenter(self)
     }
 
-    func load(_ url: URL) throws {
+    func load() throws {
         var coordinationError: NSError?
         var readingError: NSError?
         let fileCoordinator = NSFileCoordinator(filePresenter: self)
@@ -183,13 +183,13 @@ extension FileDict: NSFilePresenter {
             logger.log("辞書 \(self.id, privacy: .public) のバージョンが自分自身に更新されたため何もしません")
         } else {
             logger.log("辞書 \(self.id, privacy: .public) のバージョンが更新されたので読み込みます")
-            try? load(fileURL)
+            try? load()
         }
     }
 
     func presentedItemDidLose(_ version: NSFileVersion) {
         logger.log("辞書 \(self.id, privacy: .public) が更新されたので読み込みます (バージョン情報が消失)")
-        try? load(fileURL)
+        try? load()
     }
 
     // NOTE: save() で保存した場合はバージョンが必ず更新されるのでこのメソッドは呼ばれない
@@ -202,6 +202,6 @@ extension FileDict: NSFilePresenter {
         } else {
             logger.log("辞書 \(self.id, privacy: .public) が変更されたので読み込みます")
         }
-        try? load(fileURL)
+        try? load()
     }
 }

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -54,10 +54,10 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         fileCoordinator.coordinate(readingItemAt: fileURL, error: &coordinationError) { [weak self] newURL in
             if let self {
                 do {
-                    let source = try self.loadString(url)
+                    let source = try self.loadString(newURL)
                     let memoryDict = MemoryDict(dictId: self.id, source: source, readonly: readonly)
                     self.dict = memoryDict
-                    self.version = NSFileVersion.currentVersionOfItem(at: url)
+                    self.version = NSFileVersion.currentVersionOfItem(at: newURL)
                     logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")
                 } catch {
                     logger.error("辞書 \(self.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -51,13 +51,13 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         var coordinationError: NSError?
         var readingError: NSError?
         let fileCoordinator = NSFileCoordinator(filePresenter: self)
-        fileCoordinator.coordinate(readingItemAt: fileURL, error: &coordinationError) { [weak self] newURL in
+        fileCoordinator.coordinate(readingItemAt: fileURL, error: &coordinationError) { [weak self] url in
             if let self {
                 do {
-                    let source = try self.loadString(newURL)
+                    let source = try self.loadString(url)
                     let memoryDict = MemoryDict(dictId: self.id, source: source, readonly: readonly)
                     self.dict = memoryDict
-                    self.version = NSFileVersion.currentVersionOfItem(at: newURL)
+                    self.version = NSFileVersion.currentVersionOfItem(at: url)
                     logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")
                 } catch {
                     logger.error("辞書 \(self.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")


### PR DESCRIPTION
#27 でNSFilePresenterを使ったファイル監視を導入しましたが、読み込み時に使用している `coordinate(readingItemAt:options:error:byAccessor:)` の使い方に誤りがあり、ユーザー辞書を保存したあとに必ず読み直すようになってしまっていました。

readerの説明に「ブロックに渡されるURLを使うこと」とあるのを読み飛ばしていました。
> A Block object containing the file operations you want to perform in a coordinated manner. This block receives an NSURL object containing the URL of the item and returns no value. Always use the URL passed into the block instead of the value in the url parameter.
https://developer.apple.com/documentation/foundation/nsfilecoordinator/1407416-coordinate

このバグを修正します。