### PR TITLE
Xcodeからデバッグ実行しているときはユーザー辞書の永続化をスキップする

### DIFF
--- a/macSKK.xcodeproj/xcshareddata/xcschemes/macSKK.xcscheme
+++ b/macSKK.xcodeproj/xcshareddata/xcschemes/macSKK.xcscheme
@@ -33,6 +33,11 @@
             value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DISABLE_USER_DICT_SAVE"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <Testables>
          <TestableReference
@@ -79,6 +84,13 @@
             ReferencedContainer = "container:macSKK.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DISABLE_USER_DICT_SAVE"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -232,6 +232,12 @@ class UserDict: NSObject, DictProtocol {
 
     /// ユーザー辞書を永続化する
     func save() throws {
+        // XcodeのEdit Scheme…でRun時とTest時の環境変数で設定しています。
+        // 普段利用しているmacSKKプロセスの書き込みと競合するのを回避するのが目的です。
+        if ProcessInfo.processInfo.environment["DISABLE_USER_DICT_SAVE"] == "1" {
+            logger.info("Xcodeから起動している状態なのでユーザー辞書の永続化はスキップします")
+            return
+        }
         if let dict = userDict as? FileDict {
             try dict.save()
         } else {


### PR DESCRIPTION
macSKKを日本語入力システムとして使いつつXcodeからデバッグ実行するとき、macSKKプロセスが2ついることになります。
そうなると60秒ごとにユーザー辞書を永続化する処理のせいで本来のプロセスへの更新が巻き戻ってしまうことがあります。

これを回避するため、XcodeからRun / Test実行するときは環境変数 `DISABLE_USER_DICT_SAVE` に `1` をセットし、この環境変数があるときはユーザー辞書の永続化はスキップするようにします。