### PR TITLE
ユーザー辞書を読み込みエラー時はnilでもつようにする

### DIFF
--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -13,6 +13,16 @@ enum DictReferringOption {
     case okuri(String)
 }
 
+/// 辞書の読み込み状態
+enum DictLoadStatus {
+    /// 正常に読み込み済み。引数は辞書がもっているエントリ数
+    case loaded(Int)
+    case loading
+    /// 無効に設定されている
+    case disabled
+    case fail(Error)
+}
+
 protocol DictProtocol {
     /**
      * 辞書を引き変換候補順に返す

--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -15,8 +15,8 @@ enum DictReferringOption {
 
 /// 辞書の読み込み状態
 enum DictLoadStatus {
-    /// 正常に読み込み済み。引数は辞書がもっているエントリ数
-    case loaded(Int)
+    /// 正常に読み込み済み。引数は読み込めたエントリ数と読み込みできなかった行数
+    case loaded(success: Int, failure: Int)
     case loading
     /// 無効に設定されている
     case disabled

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -146,7 +146,15 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         return result.joined(separator: "\n")
     }
 
+    /**
+     * 辞書がもっているエントリ数。
+     */
     var entryCount: Int { return dict.entryCount }
+
+    /**
+     * 読み込みに失敗した行数。コメント行、空行は除いた行数。
+     */
+    var failedEntryCount: Int { return dict.failedEntryCount }
 
     // MARK: DictProtocol
     func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -30,8 +30,13 @@ struct MemoryDict: DictProtocol {
         var dict: [String: [Word]] = [:]
         var okuriNashiYomis: [String] = []
         var okuriAriYomis: [String] = []
+        var lineNumber = 0
 
         source.enumerateLines { line, stop in
+            lineNumber += 1
+            if line.isEmpty || line.hasPrefix(";") {
+                return
+            }
             if let entry = Entry(line: line, dictId: dictId) {
                 if let candidates = dict[entry.yomi] {
                     dict[entry.yomi] = candidates + entry.candidates
@@ -43,6 +48,8 @@ struct MemoryDict: DictProtocol {
                 } else {
                     okuriNashiYomis.append(entry.yomi)
                 }
+            } else {
+                logger.warning("辞書 \(dictId, privacy: .public) の読み込みで \(lineNumber)行目で読み込みエラーが発生しました")
             }
         }
         entries = dict

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -16,6 +16,10 @@ struct MemoryDict: DictProtocol {
      */
     private(set) var entries: [String: [Word]]
     /**
+     * 読み込みに失敗した行数。コメント行、空行は除いた行数。
+     */
+    private(set) var failedEntryCount: Int
+    /**
      * 送りなしの読みの配列。最近変換したものが後に登場する。
      *
      * シリアライズするときはddskkに合わせて最近変換したものが前に登場するようにする。
@@ -31,6 +35,7 @@ struct MemoryDict: DictProtocol {
         var okuriNashiYomis: [String] = []
         var okuriAriYomis: [String] = []
         var lineNumber = 0
+        var failedEntryCount = 0
 
         source.enumerateLines { line, stop in
             lineNumber += 1
@@ -49,10 +54,12 @@ struct MemoryDict: DictProtocol {
                     okuriNashiYomis.append(entry.yomi)
                 }
             } else {
+                failedEntryCount += 1
                 logger.warning("辞書 \(dictId, privacy: .public) の読み込みで \(lineNumber)行目で読み込みエラーが発生しました")
             }
         }
         entries = dict
+        self.failedEntryCount = failedEntryCount
         self.okuriNashiYomis = okuriNashiYomis.reversed()
         self.okuriAriYomis = okuriAriYomis.reversed()
     }
@@ -60,6 +67,7 @@ struct MemoryDict: DictProtocol {
     init(entries: [String: [Word]], readonly: Bool) {
         self.readonly = readonly
         self.entries = entries
+        failedEntryCount = 0
         if !readonly {
             for yomi in entries.keys {
                 if yomi.isOkuriAri {

--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -81,38 +81,48 @@ struct DictionariesView: View {
             return loadingStatus(of: status)
         } else if !setting.enabled {
             // 元々無効になっていて、設定を今回の起動で切り替えてない辞書
-            return NSLocalizedString("LoadingStatusDisabled", comment: "無効")
+            return String(localized: "LoadingStatusDisabled")
         } else {
-            return NSLocalizedString("LoadingStatusUnknown", comment: "不明")
+            return String(localized: "LoadingStatusUnknown")
         }
     }
 
     private func loadingStatus(of status: DictLoadStatus) -> String {
         switch status {
-        case .loaded(let count):
-            return String(format: NSLocalizedString("LoadingStatusLoaded", comment: "%d エントリ"), count)
+        case .loaded(success: let entryCount, failure: let failureCount):
+            if failureCount == 0 {
+                return String(localized: "LoadingStatusLoaded \(entryCount)")
+            } else {
+                return String(localized: "LoadingStatusLoaded \(entryCount) WithError \(failureCount)")
+            }
         case .loading:
-            return NSLocalizedString("LoadingStatusLoading", comment: "読み込み中…")
+            return String(localized: "LoadingStatusLoading")
         case .disabled:
-            return NSLocalizedString("LoadingStatusDisabled", comment: "無効")
+            return String(localized: "LoadingStatusDisabled")
         case .fail(let error):
-            return String(format: NSLocalizedString("LoadingStatusError", comment: "エラー: %@"), error as NSError)
+            return String(localized: "LoadingStatusError \(error as NSError)")
         }
     }
 }
 
 struct DictionariesView_Previews: PreviewProvider {
+    enum DictionariesViewPreviewError: Error {
+        case dummy
+    }
+
     static var previews: some View {
         let dictSettings = [
             DictSetting(filename: "SKK-JISYO.L", enabled: true, encoding: .japaneseEUC),
             DictSetting(filename: "SKK-JISYO.sample.utf-8", enabled: false, encoding: .utf8),
             DictSetting(filename: "SKK-JISYO.dummy", enabled: true, encoding: .utf8),
+            DictSetting(filename: "SKK-JISYO.error", enabled: true, encoding: .utf8),
         ]
         let settings = try! SettingsViewModel(dictSettings: dictSettings)
         settings.dictLoadingStatuses = [
-            "SKK-JISYO.L": .loaded(123456),
+            "SKK-JISYO.L": .loaded(success: 123456, failure: 789),
             "SKK-JISYO.sample.utf-8": .disabled,
             "SKK-JISYO.dummy": .loading,
+            "SKK-JISYO.error": .fail(DictionariesViewPreviewError.dummy)
         ]
         return DictionariesView(settingsViewModel: settings)
     }

--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -87,7 +87,7 @@ struct DictionariesView: View {
         }
     }
 
-    private func loadingStatus(of status: LoadStatus) -> String {
+    private func loadingStatus(of status: DictLoadStatus) -> String {
         switch status {
         case .loaded(let count):
             return String(format: NSLocalizedString("LoadingStatusLoaded", comment: "%d エントリ"), count)

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -132,7 +132,7 @@ final class SettingsViewModel: ObservableObject {
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
                             self.loadStatusPublisher.send((dictSetting.id, .loading))
                             let fileDict = try FileDict(contentsOf: fileURL, encoding: dictSetting.encoding, readonly: true)
-                            self.loadStatusPublisher.send((dictSetting.id, .loaded(fileDict.entryCount)))
+                            self.loadStatusPublisher.send((dictSetting.id, .loaded(success: fileDict.entryCount, failure: fileDict.failedEntryCount)))
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
                             return fileDict
                         } catch {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -61,7 +61,7 @@ class UserDict: NSObject, DictProtocol {
             do {
                 let userDict = try FileDict(contentsOf: userDictFileURL, encoding: .utf8, readonly: false)
                 self.userDict = userDict
-                loadStatusSubject.send(.loaded(userDict.dict.entries.count))
+                loadStatusSubject.send(.loaded(success: userDict.entryCount, failure: userDict.failedEntryCount))
             } catch {
                 self.userDict = nil
                 loadStatusSubject.send(.fail(error))
@@ -176,7 +176,7 @@ class UserDict: NSObject, DictProtocol {
         } else if let dict = userDict as? FileDict {
             dict.add(yomi: yomi, word: word)
             savePublisher.send(())
-            loadStatusSubject.send(.loaded(dict.dict.entries.count))
+            loadStatusSubject.send(.loaded(success: dict.entryCount, failure: dict.failedEntryCount))
         }
     }
 
@@ -207,7 +207,7 @@ class UserDict: NSObject, DictProtocol {
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 savePublisher.send(())
-                loadStatusSubject.send(.loaded(dict.dict.entries.count))
+                loadStatusSubject.send(.loaded(success: dict.entryCount, failure: dict.failedEntryCount))
                 return true
             }
         }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -17,7 +17,7 @@ class UserDict: NSObject, DictProtocol {
      * 通常起動時はFileDict形式で "skk-jisyo.utf8" というファイル名。
      * ユニットテスト用に差し替え可能なMemoryDict形式も取れるようにしている。
      */
-    let userDict: DictProtocol
+    var userDict: Result<DictProtocol, Error>
     /// 有効になっている辞書。優先度が高い順。
     var dicts: [DictProtocol]
     /**
@@ -30,13 +30,8 @@ class UserDict: NSObject, DictProtocol {
     private let savePublisher = PassthroughSubject<Void, Never>()
     private let privateMode: CurrentValueSubject<Bool, Never>
     // 最新の値が読めるようにしておかないとsink時にすでにユーザー辞書読み込みが終わっていると次のイベントが流れない。
-    private let entryCountSubject = CurrentValueSubject<Int, Never>(0)
-    /**
-     * ユーザー辞書のエントリ数。
-     *
-     * プライベートモード時にも非プライベートモード時のエントリ数を返します。
-     */
-    let entryCount: AnyPublisher<Int, Never>
+    private let loadStatusSubject = CurrentValueSubject<DictLoadStatus, Never>(.loading)
+    let loadStatus: AnyPublisher<DictLoadStatus, Never>
     private var cancellables: Set<AnyCancellable> = []
 
     // MARK: NSFilePresenter
@@ -55,19 +50,23 @@ class UserDict: NSObject, DictProtocol {
             try FileManager.default.createDirectory(at: dictionariesDirectoryURL, withIntermediateDirectories: true)
         }
         userDictFileURL = dictionariesDirectoryURL.appending(path: Self.userDictFilename)
+        loadStatus = loadStatusSubject.eraseToAnyPublisher()
         if let userDictEntries {
-            self.userDict = MemoryDict(entries: userDictEntries, readonly: true)
-            entryCountSubject.send(userDictEntries.count)
+            self.userDict = .success(MemoryDict(entries: userDictEntries, readonly: true))
         } else {
             if !FileManager.default.fileExists(atPath: userDictFileURL.path()) {
                 logger.log("ユーザー辞書ファイルがないため作成します")
                 try Data().write(to: userDictFileURL, options: .withoutOverwriting)
             }
-            let userDict = try FileDict(contentsOf: userDictFileURL, encoding: .utf8, readonly: false)
-            self.userDict = userDict
-            entryCountSubject.send(userDict.dict.entries.count)
+            do {
+                let userDict = try FileDict(contentsOf: userDictFileURL, encoding: .utf8, readonly: false)
+                self.userDict = .success(userDict)
+                loadStatusSubject.send(.loaded(userDict.dict.entries.count))
+            } catch {
+                self.userDict = .failure(error)
+                loadStatusSubject.send(.fail(error))
+            }
         }
-        entryCount = entryCountSubject.removeDuplicates().eraseToAnyPublisher()
         super.init()
         NSFileCoordinator.addFilePresenter(self)
 
@@ -139,22 +138,26 @@ class UserDict: NSObject, DictProtocol {
 
     // MARK: DictProtocol
     func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {
-        var result = userDict.refer(yomi, option: option)
-        if privateMode.value {
-            privateUserDict.refer(yomi, option: option).forEach { found in
-                if !result.contains(found) {
-                    result.append(found)
+        if case .success(let userDict) = userDict {
+            var result = userDict.refer(yomi, option: option)
+            if privateMode.value {
+                privateUserDict.refer(yomi, option: option).forEach { found in
+                    if !result.contains(found) {
+                        result.append(found)
+                    }
                 }
             }
-        }
-        dicts.forEach { dict in
-            dict.refer(yomi, option: option).forEach { found in
-                if !result.contains(found) {
-                    result.append(found)
+            dicts.forEach { dict in
+                dict.refer(yomi, option: option).forEach { found in
+                    if !result.contains(found) {
+                        result.append(found)
+                    }
                 }
             }
+            return result
+        } else {
+            return []
         }
-        return result
     }
 
     /**
@@ -170,10 +173,10 @@ class UserDict: NSObject, DictProtocol {
     func add(yomi: String, word: Word) {
         if privateMode.value {
             privateUserDict.add(yomi: yomi, word: word)
-        } else if let dict = userDict as? FileDict {
+        } else if case .success(let userDict) = userDict, let dict = userDict as? FileDict {
             dict.add(yomi: yomi, word: word)
             savePublisher.send(())
-            entryCountSubject.send(dict.dict.entries.count)
+            loadStatusSubject.send(.loaded(dict.dict.entries.count))
         }
     }
 
@@ -201,10 +204,10 @@ class UserDict: NSObject, DictProtocol {
     func delete(yomi: String, word: Word.Word) -> Bool {
         if privateMode.value {
             return privateUserDict.delete(yomi: yomi, word: word)
-        } else if let dict = userDict as? FileDict {
+        } else if case .success(let userDict) = userDict, let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 savePublisher.send(())
-                entryCountSubject.send(dict.dict.entries.count)
+                loadStatusSubject.send(.loaded(dict.dict.entries.count))
                 return true
             }
         }
@@ -224,9 +227,14 @@ class UserDict: NSObject, DictProtocol {
      */
     func findCompletion(prefix: String) -> String? {
         if privateMode.value {
-            return privateUserDict.findCompletion(prefix: prefix) ?? userDict.findCompletion(prefix: prefix)
-        } else {
+            if let completion = privateUserDict.findCompletion(prefix: prefix) {
+                return completion
+            }
+        }
+        if case .success(let userDict) = userDict {
             return userDict.findCompletion(prefix: prefix)
+        } else {
+            return nil
         }
     }
 
@@ -238,11 +246,15 @@ class UserDict: NSObject, DictProtocol {
             logger.info("Xcodeから起動している状態なのでユーザー辞書の永続化はスキップします")
             return
         }
-        if let dict = userDict as? FileDict {
-            try dict.save()
+        if case .success(let userDict) = userDict {
+            if let dict = userDict as? FileDict {
+                try dict.save()
+            } else {
+                // ユニットテストなど特殊な場合のみ
+                logger.info("永続化が要求されましたが、ユーザー辞書がファイル形式でないため無視されます")
+            }
         } else {
-            // ユニットテストなど特殊な場合のみ
-            logger.info("永続化が要求されましたが、ユーザー辞書がファイル形式でないため無視されます")
+            logger.debug("ユーザー辞書を読み込みできてないため永続化はスキップします")
         }
     }
 

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -15,9 +15,10 @@
 "SettingsFileDictionariesTitle" = "Dictionary files";
 "SettingsFileDictionariesSubtitle" = "You can reorder the priorities of dictionary by drag & drop";
 "SettingsNoteDirectMode" = "Set Front-Most to target app and select \"Direct input from (AppName)\" in Input Menu.";
-"LoadingStatusLoaded" = "%d entries";
+"LoadingStatusLoaded %lld" = "%lld entries";
+"LoadingStatusLoaded %lld WithError %lld" = "%lld entries (%lld lines of parsing error)";
 "LoadingStatusLoading" = "Loading…";
-"LoadingStatusError" = "Error: %@";
+"LoadingStatusError %@" = "Error: %@";
 "LoadingStatusDisabled" = "Disabled";
 "LoadingStatusUnknown" = "Unknown";
 "Done" = "Done";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -15,9 +15,10 @@
 "SettingsFileDictionariesTitle" = "ファイル辞書";
 "SettingsFileDictionariesSubtitle" = "項目をドラッグすることで優先順位を入れ替え可能です。";
 "SettingsNoteDirectMode" = "日本語変換を行いたくないアプリが最前面の状態で、入力メニューから \"(アプリ名)では直接入力\" を選択してください。";
-"LoadingStatusLoaded" = "%d エントリ";
+"LoadingStatusLoaded %lld" = "%lld エントリ";
+"LoadingStatusLoaded %lld WithError %lld" = "%lld エントリ (%lld行の読み込みエラー)";
 "LoadingStatusLoading" = "読み込み中…";
-"LoadingStatusError" = "エラー: %@";
+"LoadingStatusError %@" = "エラー: %@";
 "LoadingStatusDisabled" = "無効";
 "LoadingStatusUnknown" = "不明";
 "Done" = "完了";

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -729,13 +729,13 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "d", withShift: true)))
-        XCTAssertEqual(try dictionary.userDict?.refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
+        XCTAssertEqual(dictionary.userDict?.refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "2")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(try dictionary.userDict?.refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
+        XCTAssertEqual(dictionary.userDict?.refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -729,13 +729,13 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "d", withShift: true)))
-        XCTAssertEqual(try dictionary.userDict.get().refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
+        XCTAssertEqual(try dictionary.userDict?.refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "2")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(try dictionary.userDict.get().refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
+        XCTAssertEqual(try dictionary.userDict?.refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -729,13 +729,13 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "d", withShift: true)))
-        XCTAssertEqual(dictionary.userDict.refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
+        XCTAssertEqual(try dictionary.userDict.get().refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "2")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.userDict.refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
+        XCTAssertEqual(try dictionary.userDict.get().refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/UserDict+Utilities.swift
+++ b/macSKKTests/UserDict+Utilities.swift
@@ -5,13 +5,13 @@
 
 extension UserDict {
     func setEntries(_ entries: [String: [Word]]) {
-        if let dict = userDict as? FileDict {
+        if case .success(let userDict) = userDict, let dict = userDict as? FileDict {
             dict.setEntries(entries, readonly: true)
         }
     }
 
     func entries() -> [String: [Word]]? {
-        if let dict = userDict as? FileDict {
+        if case .success(let userDict) = userDict, let dict = userDict as? FileDict {
             return dict.dict.entries
         }
         return nil

--- a/macSKKTests/UserDict+Utilities.swift
+++ b/macSKKTests/UserDict+Utilities.swift
@@ -5,13 +5,13 @@
 
 extension UserDict {
     func setEntries(_ entries: [String: [Word]]) {
-        if case .success(let userDict) = userDict, let dict = userDict as? FileDict {
+        if let dict = userDict as? FileDict {
             dict.setEntries(entries, readonly: true)
         }
     }
 
     func entries() -> [String: [Word]]? {
-        if case .success(let userDict) = userDict, let dict = userDict as? FileDict {
+        if let dict = userDict as? FileDict {
             return dict.dict.entries
         }
         return nil


### PR DESCRIPTION
ユーザー辞書は手で編集することが想定されるため正しくないエントリが生じることが考えられます。
そのようなエントリが正しく読めなかったことをユーザーに伝え、辞書の読み込みエラー状態を持てるようにするためにユーザー辞書の型を`FileDict`から`FileDict?`に変更します。

それに加えて設定画面の辞書の画面でどの辞書で何行読めなかった行があるかを表示するようにします(下のスクショ)。
また何行目で読み込みエラーになったかをログに出すようにします。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/0e1a1b85-5c85-4b0d-b803-a5e2d436c40c">

ほんとうはこのPull Requestで読み込みエラーになったときは正常な辞書として扱わない、としようと思ったんですが、https://skk-dev.github.io/dict/ で配布しているSKK-JISYO.Lはスラッシュで終わってないエントリがあるためこのPull Requestではロギングだけに留めて見送ります。

skk-dev/dictのmasterブランチでは直っているようですが、gh-pagesブランチに取り込まれてないのが壊れたSKK-JISYO.Lが配布されている原因みたいです。
https://github.com/skk-dev/dict/pull/43

また別の辞書でBOMありのテキストファイルのBOMを無視できてなさそうなことにも気付いたので別途対応します。