### PR TITLE
英数・かなキーを打つとエディタに文字が入力されるバグを修正

### DIFF
--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -47,6 +47,10 @@ struct Action {
         case ctrlE
         /// Ctrl-Y. 登録モードでのみクリップボードからのペースト用
         case ctrlY
+        /// 英数キー
+        case eisu
+        /// かなキー
+        case kana
     }
 
     func shiftIsPressed() -> Bool {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -354,6 +354,10 @@ class InputController: IMKInputController {
             return .backspace
         } else if keyCode == 53 {  // ESC
             return .cancel
+        } else if keyCode == 102 { // 英数キー
+            return .eisu
+        } else if keyCode == 104 { // かなキー
+            return .kana
         } else if event.characters == " " {
             return .space
         } else if event.characters == ";" {

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -230,6 +230,9 @@ class StateMachine {
             } else {
                 return false
             }
+        case .eisu, .kana:
+            // 何もしない (OSがIMEの切り替えはしてくれる)
+            return true
         }
     }
 
@@ -537,7 +540,7 @@ class StateMachine {
                 updateMarkedText()
             }
             return true
-        case .up, .down, .ctrlY:
+        case .up, .down, .ctrlY, .eisu, .kana:
             return true
         }
     }
@@ -935,7 +938,7 @@ class StateMachine {
                 updateMarkedText()
             }
             return true
-        case .ctrlY:
+        case .ctrlY, .eisu, .kana:
             return true
         }
     }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -78,6 +78,12 @@ final class StateMachineTests: XCTestCase {
         XCTAssertFalse(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
     }
 
+    func testHandleNormalEisuKana() throws {
+        // Normal時は英数キー、かなキーは無視する
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .eisu, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .kana, originalEvent: nil, cursorPosition: .zero)))
+    }
+
     func testHandleNormalSpecialSymbol() throws {
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(18).sink { events in


### PR DESCRIPTION
#91 英数キー、かなキーを入力するとテキスト入力欄によってスペースだったり (Slack) 0x10だったり (VSCode) 文字が入力されてしまうバグがありました。
macSKK側で握り潰すようにします (なにも入力しなかった扱い)。

キー入力を握り潰してもmacOS側で自体は入力モードを切り替えてくれるようだったので多分これでよさそう。