### PR TITLE
通知センターのメッセージのハンドリングで完了メソッドを呼んでなかったのを修正

### DIFF
--- a/macSKK/UserNotificationDelegate.swift
+++ b/macSKK/UserNotificationDelegate.swift
@@ -14,7 +14,10 @@ class UserNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
                 if !NSWorkspace.shared.open(url) {
                     logger.warning("新しいバージョンの通知をタップしたがリリースページを開くことができませんでした。")
                 }
+            } else {
+                logger.error("通知メッセージにリリースページの情報が含まれていません。バグの可能性が高いです")
             }
         }
+        completionHandler()
     }
 }


### PR DESCRIPTION
通知センターに出している新規バージョンリリースのメッセージをクリックしたときの処理で、↓APIドキュメントで処理完了後に必ず呼ぶべきcompletionHandlerを呼んでなかったのを修正します。
これをやらないと通知をクリックしても通知がでっぱなしになったりするのかと思ったけどmacOS 14.2.1ではそんなことはなさそう。
https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter