### PR TITLE
起動時に独自のローマ字変換ルールファイルがあっても使われないバグを修正

### DIFF
--- a/macSKK/SettingsWatcher.swift
+++ b/macSKK/SettingsWatcher.swift
@@ -41,7 +41,7 @@ class SettingsWatcher: NSObject {
         do {
             if try url.isReadable() {
                 kanaRule = try Romaji(contentsOf: url)
-                logger.log("ローマ字かな変換ルールを更新しました")
+                logger.log("独自のローマ字かな変換ルールを適用しました")
             } else {
                 logger.log("ローマ字かなルールファイルとして不適合なファイルであるため読み込みできませんでした")
             }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -66,7 +66,9 @@ struct macSKKApp: App {
             settingsWatcher = try SettingsWatcher(kanaRuleFileName: "kana-rule.conf")
             let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule", withExtension: "conf")!
             defaultKanaRule = try Romaji(contentsOf: kanaRuleFileURL)
-            kanaRule = defaultKanaRule
+            if kanaRule == nil {
+                kanaRule = defaultKanaRule
+            }
         } catch {
             fatalError("ローマ字かな変換ルールの読み込みでエラーが発生しました: \(error)")
         }


### PR DESCRIPTION
Issue: #93 
#98 の作業漏れでmacSKKの起動時に独自のローマ字変換ルールファイルがあってもデフォルトのルールが優先されてしまうバグを修正します。