### PR TITLE
直接入力モードでも英数・かなキーを無視してなかったのを修正 (#100)

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -158,6 +158,10 @@ class InputController: IMKInputController {
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         if directMode {
+            if let keyEvent = convert(event: event), keyEvent == .kana || keyEvent == .eisu {
+                // 英数・かなキーは握り潰さないとエディタによって空白が入ってしまう
+                return true
+            }
             return false
         }
         // 左下座標基準でwidth=1, height=(通常だとフォントサイズ)のNSRect


### PR DESCRIPTION
#100 直接入力モードで英数・かなキーを押すとエディタによって空白文字などが入力されるバグを修正します。
#94 で英数・かなキーを握り潰す対応をしましたが、直接入力モードが有効なときはその処理よりも前に無視してしまっていました。