### PR TITLE
インラインで表示する変換候補の数を設定できるようにする

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -154,6 +154,14 @@ class InputController: IMKInputController {
                 }
             }
         }.store(in: &cancellables)
+
+        stateMachine.inlineCandidateCount = UserDefaults.standard.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
+        NotificationCenter.default.publisher(for: notificationNameInlineCandidateCount)
+            .sink { [weak self] notification in
+                if let inlineCandidateCount = notification.object as? Int, inlineCandidateCount >= 0 {
+                    self?.stateMachine.inlineCandidateCount = inlineCandidateCount
+                }
+            }.store(in: &cancellables)
     }
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -17,6 +17,13 @@ struct GeneralView: View {
                 Toggle(isOn: $settingsViewModel.showAnnotation, label: {
                     Text("Show Annotation")
                 })
+                Section {
+                    Picker("Number of inline candidates", selection: $settingsViewModel.inlineCandidateCount) {
+                        ForEach(0..<10) { count in
+                            Text("\(count)")
+                        }
+                    }
+                }
             }
             .formStyle(.grouped)
         }.onAppear {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -212,6 +212,8 @@ final class SettingsViewModel: ObservableObject {
 
         $inlineCandidateCount.sink { inlineCandidateCount in
             UserDefaults.standard.set(inlineCandidateCount, forKey: UserDefaultsKeys.inlineCandidateCount)
+            NotificationCenter.default.post(name: notificationNameInlineCandidateCount, object: inlineCandidateCount)
+            logger.log("インラインで表示する変換候補の数を\(inlineCandidateCount)個に変更しました")
         }.store(in: &cancellables)
     }
 

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -102,6 +102,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var selectedInputSourceId: InputSource.ID
     /// 注釈を表示するかどうか
     @Published var showAnnotation: Bool
+    /// インラインで表示する変換候補の数。
+    @Published var inlineCandidateCount: Int
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
     // バックグラウンドでの辞書を読み込みで読み込み状態が変わったときに通知される
@@ -119,6 +121,7 @@ final class SettingsViewModel: ObservableObject {
             selectedInputSourceId = InputSource.defaultInputSourceId
         }
         self.showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
+        inlineCandidateCount = UserDefaults.standard.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -206,6 +209,10 @@ final class SettingsViewModel: ObservableObject {
         $showAnnotation.sink { showAnnotation in
             UserDefaults.standard.set(showAnnotation, forKey: UserDefaultsKeys.showAnnotation)
         }.store(in: &cancellables)
+
+        $inlineCandidateCount.sink { inlineCandidateCount in
+            UserDefaults.standard.set(inlineCandidateCount, forKey: UserDefaultsKeys.inlineCandidateCount)
+        }.store(in: &cancellables)
     }
 
     // PreviewProvider用
@@ -218,6 +225,7 @@ final class SettingsViewModel: ObservableObject {
         ).appendingPathComponent("Dictionaries")
         selectedInputSourceId = InputSource.defaultInputSourceId
         showAnnotation = true
+        inlineCandidateCount = 3
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -120,7 +120,7 @@ final class SettingsViewModel: ObservableObject {
         } else {
             selectedInputSourceId = InputSource.defaultInputSourceId
         }
-        self.showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
+        showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
         inlineCandidateCount = UserDefaults.standard.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
@@ -164,7 +164,7 @@ final class SettingsViewModel: ObservableObject {
             self.dictLoadingStatuses[id] = status
         }.store(in: &cancellables)
 
-        $directModeApplications.sink { applications in
+        $directModeApplications.dropFirst().sink { applications in
             let bundleIdentifiers = applications.map { $0.bundleIdentifier }
             UserDefaults.standard.set(bundleIdentifiers, forKey: "directModeBundleIdentifiers")
             directModeBundleIdentifiers.send(bundleIdentifiers)
@@ -206,11 +206,12 @@ final class SettingsViewModel: ObservableObject {
             }
         }.store(in: &cancellables)
 
-        $showAnnotation.sink { showAnnotation in
+        $showAnnotation.dropFirst().sink { showAnnotation in
             UserDefaults.standard.set(showAnnotation, forKey: UserDefaultsKeys.showAnnotation)
+            logger.log("注釈表示を\(showAnnotation ? "表示" : "非表示", privacy: .public)に変更しました")
         }.store(in: &cancellables)
 
-        $inlineCandidateCount.sink { inlineCandidateCount in
+        $inlineCandidateCount.dropFirst().sink { inlineCandidateCount in
             UserDefaults.standard.set(inlineCandidateCount, forKey: UserDefaultsKeys.inlineCandidateCount)
             NotificationCenter.default.post(name: notificationNameInlineCandidateCount, object: inlineCandidateCount)
             logger.log("インラインで表示する変換候補の数を\(inlineCandidateCount)個に変更しました")

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -9,4 +9,5 @@ struct UserDefaultsKeys {
     // 選択中のinputSourceID
     static let selectedInputSource = "selectedInputSource"
     static let showAnnotation = "showAnnotation"
+    static let inlineCandidateCount = "inlineCandidateCount"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -34,7 +34,7 @@ class StateMachine {
     /// 読みの一部と補完結果(読み)のペア
     var completion: (String, String)? = nil
 
-    // TODO: inlineCandidateCount, displayCandidateCountを環境設定にするかも
+    // TODO: displayCandidateCountを環境設定にするかも
     /// 変換候補パネルを表示するまで表示する変換候補の数
     var inlineCandidateCount: Int
     /// 変換候補パネルに一度に表示する変換候補の数

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -36,15 +36,16 @@ class StateMachine {
 
     // TODO: inlineCandidateCount, displayCandidateCountを環境設定にするかも
     /// 変換候補パネルを表示するまで表示する変換候補の数
-    let inlineCandidateCount = 3
+    var inlineCandidateCount: Int
     /// 変換候補パネルに一度に表示する変換候補の数
     let displayCandidateCount = 9
 
-    init(initialState: IMEState = IMEState()) {
+    init(initialState: IMEState = IMEState(), inlineCandidateCount: Int = 3) {
         state = initialState
         inputMethodEvent = inputMethodEventSubject.eraseToAnyPublisher()
         candidateEvent = candidateEventSubject.removeDuplicates().eraseToAnyPublisher()
         yomiEvent = yomiEventSubject.removeDuplicates().eraseToAnyPublisher()
+        self.inlineCandidateCount = inlineCandidateCount
     }
 
     func handle(_ action: Action) -> Bool {

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -38,6 +38,9 @@ final class CandidatesPanel: NSPanel {
 
     func setCursorPosition(_ cursorPosition: NSRect) {
         self.cursorPosition = cursorPosition
+        if let mainScreen = NSScreen.main {
+            viewModel.maxWidth = mainScreen.visibleFrame.size.width - cursorPosition.origin.x
+        }
     }
 
     func setShowAnnotationPopover(_ showAnnotationPopover: Bool) {
@@ -61,7 +64,7 @@ final class CandidatesPanel: NSPanel {
         print("preferredContentSize = \(viewController.preferredContentSize)")
         print("sizeThatFits = \(viewController.sizeThatFits(in: CGSize(width: 10000, height: 10000)))")
         #endif
-        let width = viewController.rootView.minWidth()
+        let width = viewModel.showAnnotationPopover ? viewModel.minWidth + CandidatesView.annotationPopupWidth : viewModel.minWidth
         let height: CGFloat
         if case let .panel(words, _, _) = viewModel.candidates {
             height = CGFloat(words.count) * CandidatesView.lineHeight + CandidatesView.footerHeight
@@ -71,6 +74,9 @@ final class CandidatesPanel: NSPanel {
         }
         setContentSize(NSSize(width: width, height: height))
         var origin = cursorPosition.origin
+        if viewModel.displayPopoverInLeft {
+            origin.x = origin.x - CandidatesView.annotationPopupWidth - CandidatesView.annotationMargin
+        }
         if let mainScreen = NSScreen.main {
             if origin.x + width > mainScreen.visibleFrame.size.width {
                 origin.x = mainScreen.frame.size.width - width

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -21,7 +21,8 @@ final class CandidatesPanel: NSPanel {
                                         showAnnotationPopover: showAnnotationPopover)
         let rootView = CandidatesView(candidates: self.viewModel)
         let viewController = NSHostingController(rootView: rootView)
-        super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
+        // borderlessにしないとdeactivateServerが呼ばれてしまう
+        super.init(contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: true)
         contentViewController = viewController
     }
 

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -64,20 +64,23 @@ final class CandidatesPanel: NSPanel {
         print("preferredContentSize = \(viewController.preferredContentSize)")
         print("sizeThatFits = \(viewController.sizeThatFits(in: CGSize(width: 10000, height: 10000)))")
         #endif
-        let width = viewModel.showAnnotationPopover ? viewModel.minWidth + CandidatesView.annotationPopupWidth : viewModel.minWidth
+        var origin = cursorPosition.origin
+        let width: CGFloat
         let height: CGFloat
         if case let .panel(words, _, _) = viewModel.candidates {
+            width = viewModel.showAnnotationPopover ? viewModel.minWidth + CandidatesView.annotationPopupWidth : viewModel.minWidth
             height = CGFloat(words.count) * CandidatesView.lineHeight + CandidatesView.footerHeight
+            if viewModel.displayPopoverInLeft {
+                origin.x = origin.x - CandidatesView.annotationPopupWidth - CandidatesView.annotationMargin
+            }
         } else {
             // FIXME: 短い文のときにはそれに合わせて高さを縮める
+            width = viewModel.minWidth
             height = 200
         }
         setContentSize(NSSize(width: width, height: height))
-        var origin = cursorPosition.origin
-        if viewModel.displayPopoverInLeft {
-            origin.x = origin.x - CandidatesView.annotationPopupWidth - CandidatesView.annotationMargin
-        }
         if let mainScreen = NSScreen.main {
+            // スクリーン右にはみ出す場合はスクリーン右端に接するように表示する
             if origin.x + width > mainScreen.visibleFrame.size.width {
                 origin.x = mainScreen.frame.size.width - width
             }

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -28,8 +28,8 @@ final class CandidatesPanel: NSPanel {
     }
 
     func setCandidates(_ candidates: CurrentCandidates, selected: Candidate?) {
-        viewModel.candidates = candidates
         viewModel.selected = selected
+        viewModel.candidates = candidates
     }
 
     func setSystemAnnotation(_ systemAnnotation: String, for word: Word.Word) {

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -23,6 +23,7 @@ final class CandidatesPanel: NSPanel {
         let viewController = NSHostingController(rootView: rootView)
         // borderlessにしないとdeactivateServerが呼ばれてしまう
         super.init(contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: true)
+        backgroundColor = .clear
         contentViewController = viewController
     }
 

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -59,21 +59,9 @@ struct CandidatesView: View {
                         systemAnnotation: $candidates.selectedSystemAnnotation
                     )
                     .frame(width: 300, alignment: .topLeading)
-                    .padding()
-                    .background(.regularMaterial)
-
-                    // 吹き出し風。Shapeで作るほうが適切そうなのでコメントアウト
-//                    .padding(EdgeInsets(top: 10, leading: 24, bottom: 10, trailing: 18))
-//                    .background {
-//                        Path { path in
-//                            let y = CGFloat((candidates.selectedIndex ?? 0)) * Self.lineHeight + Self.lineHeight / 2
-//                            path.move(to: CGPoint(x: 0, y: y))
-//                            path.addLine(to: CGPoint(x: Self.annotationMargin, y: y - 5))
-//                            path.addLine(to: CGPoint(x: Self.annotationMargin, y: y + 5))
-//                            path.addRoundedRect(in: CGRect(x: Self.annotationMargin, y: 0, width: 300, height: 200), cornerSize: CGSize(width: 5, height: 5))
-//                        }
-//                        .fill(.thickMaterial)
-//                    }
+                    .padding(EdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 4))
+                    //.background(.ultraThickMaterial, in: RoundedRectangle(cornerSize: CGSize(width: 16, height: 10)))
+                    .background(.regularMaterial, in: AnnotationBalloon(y: CGFloat((candidates.selectedIndex ?? 0) * 2 + 1) * Self.lineHeight / 2, tail: Self.annotationMargin))
                 }
             }
             .background(Color.clear)
@@ -96,6 +84,23 @@ struct CandidatesView: View {
         } else {
             return 300
         }
+    }
+}
+
+// 吹き出しの形
+struct AnnotationBalloon: Shape {
+    let y: CGFloat
+    let tail: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        let path = Path { path in
+            // 吹き出しの位置は固定で、角丸矩形のサイズは親サイズに合わせる
+            path.move(to: CGPoint(x: 0, y: y))
+            path.addLine(to: CGPoint(x: tail + 3, y: y - 5))
+            path.addLine(to: CGPoint(x: tail + 3, y: y + 5))
+            path.addRoundedRect(in: CGRect(x: tail, y: 0, width: rect.width, height: rect.height), cornerSize: CGSize(width: 10, height: 10))
+        }
+        return path
     }
 }
 

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -22,6 +22,7 @@ struct CandidatesView: View {
             AnnotationView(annotations: $candidates.selectedAnnotations, systemAnnotation: $candidates.selectedSystemAnnotation)
                 .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))
                 .frame(width: 300, height: 200)
+                .background()
         case let .panel(words, currentPage, totalPageCount):
             HStack(alignment: .top, spacing: Self.annotationMargin) {
                 if candidates.displayPopoverInLeft {
@@ -30,9 +31,10 @@ struct CandidatesView: View {
                             annotations: $candidates.selectedAnnotations,
                             systemAnnotation: $candidates.selectedSystemAnnotation
                         )
-                        .padding(EdgeInsets(top: 16, leading: 12, bottom: 16, trailing: 16))
+                        .padding(EdgeInsets(top: 16, leading: 12, bottom: 16, trailing: 8))
                         .frame(width: Self.annotationPopupWidth, alignment: .topLeading)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxHeight: 200)
+                        .fixedSize(horizontal: false, vertical: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
                         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
                         .opacity(0.9)
                     } else {
@@ -77,7 +79,8 @@ struct CandidatesView: View {
                     )
                     .padding(EdgeInsets(top: 16, leading: 28, bottom: 16, trailing: 4))
                     .frame(width: Self.annotationPopupWidth, alignment: .topLeading)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxHeight: 200)
+                    .fixedSize(horizontal: false, vertical: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
                     .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
                     .opacity(0.9)
                 }
@@ -98,6 +101,15 @@ struct CandidatesView_Previews: PreviewProvider {
         let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3, showAnnotationPopover: true)
         viewModel.selected = words.first
         viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 20)]
+        viewModel.maxWidth = 1000
+        return viewModel
+    }
+
+    private static func pageViewModelLeftPopover() -> CandidatesViewModel {
+        let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3, showAnnotationPopover: true)
+        viewModel.selected = words.first
+        viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 20)]
+        viewModel.maxWidth = 1
         return viewModel
     }
 
@@ -120,6 +132,9 @@ struct CandidatesView_Previews: PreviewProvider {
         CandidatesView(candidates: pageViewModel())
             .background(Color.cyan)
             .previewDisplayName("パネル表示")
+        CandidatesView(candidates: pageViewModelLeftPopover())
+            .background(Color.cyan)
+            .previewDisplayName("パネル表示 (注釈左)")
         CandidatesView(candidates: pageWithoutPopoverViewModel())
             .previewDisplayName("パネル表示 (注釈なし)")
         CandidatesView(candidates: inlineViewModel())

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -73,7 +73,7 @@ struct CandidatesView: View {
     // 最長のテキストを表示するために必要なビューのサイズを返す
     func minWidth() -> CGFloat {
         if case let .panel(words, _, _) = candidates.candidates {
-            let width = words.map { candidate -> CGFloat in
+            let listWidth = words.map { candidate -> CGFloat in
                 let size = candidate.word.boundingRect(
                     with: CGSize(width: .greatestFiniteMagnitude, height: Self.lineHeight),
                     options: .usesLineFragmentOrigin,
@@ -81,8 +81,8 @@ struct CandidatesView: View {
                 // 未解決の余白(8px) + 添字(16px) + 余白(4px) + テキスト + 余白(4px) + 未解決の余白(22px)
                 // @see https://forums.swift.org/t/swiftui-list-horizontal-insets-macos/52985/5
                 return 16 + 4 + size.width + 4 + 22
-            }.max()
-            return width ?? 0
+            }.max() ?? 0
+            return listWidth
         } else {
             return 300
         }
@@ -95,14 +95,14 @@ struct AnnotationBalloon: Shape {
     let tail: CGFloat
 
     func path(in rect: CGRect) -> Path {
-        let path = Path { path in
+        Path { path in
             // 吹き出しの位置は固定で、角丸矩形のサイズは親サイズに合わせる
             path.move(to: CGPoint(x: 0, y: y))
             path.addLine(to: CGPoint(x: tail + 3, y: y - 5))
             path.addLine(to: CGPoint(x: tail + 3, y: y + 5))
-            path.addRoundedRect(in: CGRect(x: tail, y: 0, width: rect.width - tail, height: rect.height), cornerSize: CGSize(width: 10, height: 10))
+            path.addRoundedRect(in: CGRect(x: tail, y: 0, width: rect.width - tail, height: rect.height),
+                                cornerSize: CGSize(width: 10, height: 10))
         }
-        return path
     }
 }
 

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -60,10 +60,12 @@ struct CandidatesView: View {
                     )
                     .frame(width: 300, alignment: .topLeading)
                     .padding(EdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 4))
-                    //.background(.ultraThickMaterial, in: RoundedRectangle(cornerSize: CGSize(width: 16, height: 10)))
+                    .fixedSize(horizontal: false, vertical: true)
                     .background(.regularMaterial, in: AnnotationBalloon(y: CGFloat((candidates.selectedIndex ?? 0) * 2 + 1) * Self.lineHeight / 2, tail: Self.annotationMargin))
+                    .opacity(0.9)
                 }
             }
+            .frame(maxHeight: 300, alignment: .topLeading)
             .background(Color.clear)
         }
     }
@@ -98,7 +100,7 @@ struct AnnotationBalloon: Shape {
             path.move(to: CGPoint(x: 0, y: y))
             path.addLine(to: CGPoint(x: tail + 3, y: y - 5))
             path.addLine(to: CGPoint(x: tail + 3, y: y + 5))
-            path.addRoundedRect(in: CGRect(x: tail, y: 0, width: rect.width, height: rect.height), cornerSize: CGSize(width: 10, height: 10))
+            path.addRoundedRect(in: CGRect(x: tail, y: 0, width: rect.width - tail, height: rect.height), cornerSize: CGSize(width: 10, height: 10))
         }
         return path
     }
@@ -113,7 +115,7 @@ struct CandidatesView_Previews: PreviewProvider {
     private static func pageViewModel() -> CandidatesViewModel {
         let viewModel = CandidatesViewModel(candidates: words, currentPage: 0, totalPageCount: 3, showAnnotationPopover: true)
         viewModel.selected = words.first
-        viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 10)]
+        viewModel.systemAnnotations = [words.first!.word: String(repeating: "これはシステム辞書の注釈です。", count: 20)]
         return viewModel
     }
 

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -24,16 +24,20 @@ struct CandidatesView: View {
                 .frame(width: 300, height: 200)
         case let .panel(words, currentPage, totalPageCount):
             HStack(alignment: .top, spacing: Self.annotationMargin) {
-                if candidates.popoverIsPresented && candidates.displayPopoverInLeft {
-                    AnnotationView(
-                        annotations: $candidates.selectedAnnotations,
-                        systemAnnotation: $candidates.selectedSystemAnnotation
-                    )
-                    .padding(EdgeInsets(top: 16, leading: 12, bottom: 16, trailing: 16))
-                    .frame(width: Self.annotationPopupWidth, alignment: .topLeading)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-                    .opacity(0.9)
+                if candidates.displayPopoverInLeft {
+                    if candidates.popoverIsPresented {
+                        AnnotationView(
+                            annotations: $candidates.selectedAnnotations,
+                            systemAnnotation: $candidates.selectedSystemAnnotation
+                        )
+                        .padding(EdgeInsets(top: 16, leading: 12, bottom: 16, trailing: 16))
+                        .frame(width: Self.annotationPopupWidth, alignment: .topLeading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+                        .opacity(0.9)
+                    } else {
+                        Spacer(minLength: Self.annotationPopupWidth)
+                    }
                 }
                 VStack(spacing: 0) {
                     List(Array(words.enumerated()), id: \.element, selection: $candidates.selected) { index, candidate in

--- a/macSKK/View/CandidatesViewModel.swift
+++ b/macSKK/View/CandidatesViewModel.swift
@@ -36,7 +36,7 @@ final class CandidatesViewModel: ObservableObject {
     @Published var showAnnotationPopover: Bool
     /// 表示座標から右方向に取れる最大の幅。負数のときは不明なとき
     @Published var maxWidth: CGFloat = -1
-    /// 最長のテキストを表示するために必要なビューの横幅
+    /// 最長のテキストを表示するために必要なビューの横幅。パネル表示のときは注釈部分は除いたリスト部分の幅。
     @Published var minWidth: CGFloat = 0
     /// パネル表示時の注釈を左側に表示するかどうか
     @Published var displayPopoverInLeft: Bool = false
@@ -85,6 +85,10 @@ final class CandidatesViewModel: ObservableObject {
         .assign(to: &$minWidth)
 
         $maxWidth.combineLatest($minWidth, $showAnnotationPopover)
+            .filter { maxWidth, _, _ in
+                // maxWidthが0未満のときはまだスクリーンサイズがわかっていない
+                maxWidth >= 0
+            }
             .map { maxWidth, minWidth, showAnnotationPopover in
                 showAnnotationPopover &&
                 minWidth + CandidatesView.annotationPopupWidth + CandidatesView.annotationMargin >= maxWidth

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -39,3 +39,4 @@
 "Keyboard Layout" = "Keybaord Layout";
 "Show Annotation" = "Show the annotation of the candidate in current";
 "Copy" = "Copy";
+"Number of inline candidates" = "Number of inline candidates";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -39,3 +39,4 @@
 "Keyboard Layout" = "キー配列";
 "Show Annotation" = "現在の変換候補の注釈を表示";
 "Copy" = "コピー";
+"Number of inline candidates" = "インラインで表示する変換候補の数";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -177,6 +177,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.directModeBundleIdentifiers: [String](),
             UserDefaultsKeys.selectedInputSource: InputSource.defaultInputSourceId,
             UserDefaultsKeys.showAnnotation: true,
+            UserDefaultsKeys.inlineCandidateCount: 3,
         ])
     }
 

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -22,6 +22,8 @@ let directModeBundleIdentifiers = CurrentValueSubject<[String], Never>([])
 let notificationNameToggleDirectMode = Notification.Name("toggleDirectMode")
 // 設定画面を開きたいときに通知される通知の名前
 let notificationNameOpenSettings = Notification.Name("openSettings")
+// インラインで表示する変換候補の数を変更したときに通知される通知の名前
+let notificationNameInlineCandidateCount = Notification.Name("inlineCandidateCount")
 
 func isTest() -> Bool {
     return ProcessInfo.processInfo.environment["MACSKK_IS_TEST"] == "1"


### PR DESCRIPTION
#104 変換候補パネルを出すまでにインラインで変換表示を有効にしていますが、このインラインでの変換表示の回数を設定可能にします。
デフォルト値は3 (v0.16.1現在の値) です。(4つ目の変換候補からリスト表示する)
あまり意味はないけどとりあえず最大値を9としました。AquaSKKはNSStepperを使っているので上限なさそう?

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/653da4bb-fa58-497e-b60a-83c53b19e5d6">

注釈表示を有効にしてインライン変換表示をなしにすると、注釈が一瞬ポップオーバーで表示されてすぐに注釈と変換候補が隠れてしまう不具合がありそうなのでこのあと修正する予定です(必ずではなく高確率で起きる)。
IMKInputControllerのdeactivateServerが呼び出されているようだったので、注釈のポップオーバー部分のせいでおかしくなってしまうみたい。原因は不明。

NSPopoverを使わずにSwiftUIのpopoverモディファイアで表示している注釈の制御が難しくなってきたのでpopoverを使わずに注釈を表示するように変更しようかなと考えています。

とりあえずpopoverをやめてみたもの。

<img width="414" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/a77bebd4-e99a-42f2-8358-b40d23b6fa9f">

吹き出し風にしたもの

<img width="413" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/601e4c92-b6d2-4eb5-aa00-814c5a961885">

画面右端のときには注釈は左に出るようにしたもの。
左側に出すと吹き出しと角丸矩形の重なったところが透明になってしまう (XOR) になっているようだったので吹き出しのさきっちょつけるのをやめました。
macOS 14+ならShapeのunionが使えるようになるので将来macOS 13を切ったら吹き出し復活させるかも。

<img width="383" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/36406eb2-1303-4850-b812-230cc2e1328b">

このPull RequestによるUIの差分としてわかっているもの

- 表示位置のY座標 (縦方向の位置) が選択中の変換候補の横に出ていたのが変換候補リスト最上部に常に揃うようになる
- 吹き出しのさきっちょ (とがったところ) がなくなる