### PR TITLE
環境設定の初期値が設定される前に読み込まれるバグを修正

### DIFF
--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -48,6 +48,8 @@ struct macSKKApp: App {
     #endif
 
     init() {
+        // 環境設定の初期値をSettingsViewModelより先に行う
+        Self.setupUserDefaults()
         do {
             dictionary = try UserDict(dicts: [], privateMode: privateMode)
             dictionariesDirectoryUrl = try FileManager.default.url(
@@ -89,7 +91,6 @@ struct macSKKApp: App {
         } else {
             server = nil
         }
-        setupUserDefaults()
         if !isTest() {
             do {
                 try setupDictionaries()
@@ -171,7 +172,7 @@ struct macSKKApp: App {
         }
     }
 
-    private func setupUserDefaults() {
+    private static func setupUserDefaults() {
         UserDefaults.standard.register(defaults: [
             UserDefaultsKeys.dictionaries: [
                 DictSetting(filename: "SKK-JISYO.L", enabled: true, encoding: .japaneseEUC).encode()


### PR DESCRIPTION
Appのコンストラクタ内でUserDefaultsの初期値を登録する前にSettingsViewModelを初期化していたため、SettingsViewModelでUserDefaultsから整数を読み込もうとすると0が帰ってくる問題がありました。

これはUserDefaultsから真偽値を取得する処理でも同様に初期値が設定される前に読み込むとfalseが返るため、 #74 で追加した「注釈を表示するかどうか」の設定では「デフォルトをtrue」にするつもりでしたが、実際は設定画面ではfalseになっているように表示されていました。

初期値の登録をAppコンストラクタの最初に移動することでこのバグを修正します。