### PR TITLE
注釈非表示のとき変換候補の表示位置のY座標が上にずれるバグを修正

### DIFF
--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -70,7 +70,6 @@ struct CandidatesView: View {
                     }
                     .frame(width: candidates.minWidth, height: Self.footerHeight)
                     .background()
-                    Spacer()
                 }
                 if candidates.popoverIsPresented && !candidates.displayPopoverInLeft {
                     AnnotationView(


### PR DESCRIPTION
#105 で変換候補画面をいじった際に不要なSpacerをVStackに入れてしまっていたのを削除。