### PR TITLE
未確定文字列の末尾がnのときStickyShift入力で「ん」に確定させる

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -420,7 +420,7 @@ class StateMachine {
                     action: action,
                     composing: composing,
                     specialState: specialState)
-            } else if let okuri {
+            } else if okuri != nil {
                 // 送り仮名入力中は無視する
                 // AquaSKKは送り仮名の末尾に"；"をつけて変換処理もしくは単語登録に遷移
                 return true
@@ -430,8 +430,20 @@ class StateMachine {
                     state.inputMethod = .normal
                     addFixedText("；")
                 } else {
-                    state.inputMethod = .composing(
-                        ComposingState(isShift: true, text: text, okuri: [], romaji: romaji))
+                    // ローマ字がnのときは「ん」と確定する
+                    if romaji == "n" {
+                        state.inputMethod = .composing(
+                            ComposingState(isShift: true,
+                                           text: text + [Romaji.n.kana],
+                                           okuri: [],
+                                           romaji: ""))
+                    } else {
+                        state.inputMethod = .composing(
+                            ComposingState(isShift: true,
+                                           text: text,
+                                           okuri: [],
+                                           romaji: romaji))
+                    }
                     updateMarkedText()
                 }
                 return true


### PR DESCRIPTION
#108 で報告された問題を修正します。
 "Kan;ji" のようにStickyShiftの前にnだけの入力のときに「ん」として確定してから送り仮名の入力に切り替えるようにします。