### PR TITLE
ユーザー辞書で読み込み/書き込みエラーが起きたとき通知センターに通知する

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		CEC061CA2ABB0A7900A11614 /* CompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC061C92ABB0A7900A11614 /* CompletionViewModel.swift */; };
 		CEC376E82965199500D9C432 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC376E72965199500D9C432 /* SettingsView.swift */; };
 		CEC376EB2965211200D9C432 /* KeyEventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC376EA2965211200D9C432 /* KeyEventView.swift */; };
+		CED0984D2B779E4700F2E844 /* UNNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED0984C2B779E4700F2E844 /* UNNotifier.swift */; };
 		CED7CA2C2A8394F7004EF988 /* FetchUpdateServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA2B2A8394F7004EF988 /* FetchUpdateServiceProtocol.swift */; };
 		CED7CA2E2A8394F7004EF988 /* FetchUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA2D2A8394F7004EF988 /* FetchUpdateService.swift */; };
 		CED7CA302A8394F7004EF988 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA2F2A8394F7004EF988 /* main.swift */; };
@@ -195,6 +196,7 @@
 		CEC061C92ABB0A7900A11614 /* CompletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionViewModel.swift; sourceTree = "<group>"; };
 		CEC376E72965199500D9C432 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		CEC376EA2965211200D9C432 /* KeyEventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyEventView.swift; sourceTree = "<group>"; };
+		CED0984C2B779E4700F2E844 /* UNNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNNotifier.swift; sourceTree = "<group>"; };
 		CED7CA292A8394F7004EF988 /* FetchUpdateService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = FetchUpdateService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED7CA2B2A8394F7004EF988 /* FetchUpdateServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdateServiceProtocol.swift; sourceTree = "<group>"; };
 		CED7CA2D2A8394F7004EF988 /* FetchUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdateService.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				CE485A872A8FA195008271EF /* Release+UNNotification.swift */,
 				CE6DBAAF2A85AA1200F5A227 /* LatestReleaseFetcher.swift */,
 				CED7CA3B2A839603004EF988 /* UpdateChecker.swift */,
+				CED0984C2B779E4700F2E844 /* UNNotifier.swift */,
 				CEA78FAB2960401F00B67E25 /* String+Transform.swift */,
 				CED7F51E2AB5F4A7007FC6BD /* Character+Additions.swift */,
 				CE496C902B440892001C623C /* URL+Additions.swift */,
@@ -603,6 +606,7 @@
 				CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */,
 				CEADA4512B1358D40026E2BD /* InputSource.swift in Sources */,
 				CE84A3E7295DA4DA009394C4 /* Romaji.swift in Sources */,
+				CED0984D2B779E4700F2E844 /* UNNotifier.swift in Sources */,
 				CE7F9AD92AADEBF9001B1877 /* AppDelegate.swift in Sources */,
 				CEF0825B296D8FF000646366 /* CandidatesView.swift in Sources */,
 				CE84A3E0295717CB009394C4 /* StateMachine.swift in Sources */,

--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -23,6 +23,12 @@ enum DictLoadStatus {
     case fail(Error)
 }
 
+/// 辞書の読み込み状態の通知オブジェクト
+struct DictLoadEvent {
+    let id: FileDict.ID
+    let status: DictLoadStatus
+}
+
 protocol DictProtocol {
     /**
      * 辞書を引き変換候補順に返す

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -156,17 +156,17 @@ final class SettingsViewModel: ObservableObject {
                 }
             }
             dictionary.dicts = enabledDicts
-            UserDefaults.standard.set(self.dictSettings.map { $0.encode() }, forKey: "dictionaries")
+            UserDefaults.standard.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
         }
         .store(in: &cancellables)
 
-        loadStatusPublisher.receive(on: RunLoop.main).sink { (id, status) in
-            self.dictLoadingStatuses[id] = status
+        loadStatusPublisher.receive(on: RunLoop.main).sink { [weak self] (id, status) in
+            self?.dictLoadingStatuses[id] = status
         }.store(in: &cancellables)
 
         $directModeApplications.dropFirst().sink { applications in
             let bundleIdentifiers = applications.map { $0.bundleIdentifier }
-            UserDefaults.standard.set(bundleIdentifiers, forKey: "directModeBundleIdentifiers")
+            UserDefaults.standard.set(bundleIdentifiers, forKey: UserDefaultsKeys.directModeBundleIdentifiers)
             directModeBundleIdentifiers.send(bundleIdentifiers)
         }
         .store(in: &cancellables)

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -190,10 +190,9 @@ final class SettingsViewModel: ObservableObject {
             self?.setupNotification()
         }.store(in: &cancellables)
 
-        dictionary.loadStatus.sink { [weak self] loadStatus in
-            self?.userDictLoadingStatus = loadStatus
+        if let userDict = dictionary.userDict as? FileDict {
+            userDict.loadStatus.assign(to: &$userDictLoadingStatus)
         }
-        .store(in: &cancellables)
 
         $selectedInputSourceId.removeDuplicates().sink { [weak self] selectedInputSourceId in
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -106,8 +106,6 @@ final class SettingsViewModel: ObservableObject {
     @Published var inlineCandidateCount: Int
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
-    // バックグラウンドでの辞書を読み込みで読み込み状態が変わったときに通知される
-    private let loadStatusPublisher = PassthroughSubject<(DictSetting.ID, DictLoadStatus), Never>()
     private var cancellables = Set<AnyCancellable>()
 
     init(dictionariesDirectoryUrl: URL) throws {
@@ -133,13 +131,10 @@ final class SettingsViewModel: ObservableObject {
                         let fileURL = dictionariesDirectoryUrl.appendingPathComponent(dictSetting.filename)
                         do {
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
-                            self.loadStatusPublisher.send((dictSetting.id, .loading))
                             let fileDict = try FileDict(contentsOf: fileURL, encoding: dictSetting.encoding, readonly: true)
-                            self.loadStatusPublisher.send((dictSetting.id, .loaded(success: fileDict.entryCount, failure: fileDict.failedEntryCount)))
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
                             return fileDict
                         } catch {
-                            self.loadStatusPublisher.send((dictSetting.id, .fail(error)))
                             dictSetting.enabled = false
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の読み込みに失敗しました!: \(error)")
                             return nil
@@ -150,7 +145,6 @@ final class SettingsViewModel: ObservableObject {
                 } else {
                     if dict != nil {
                         logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を無効化します")
-                        self.loadStatusPublisher.send((dictSetting.id, .disabled))
                     }
                     return nil
                 }
@@ -159,10 +153,6 @@ final class SettingsViewModel: ObservableObject {
             UserDefaults.standard.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
         }
         .store(in: &cancellables)
-
-        loadStatusPublisher.receive(on: RunLoop.main).sink { [weak self] (id, status) in
-            self?.dictLoadingStatuses[id] = status
-        }.store(in: &cancellables)
 
         $directModeApplications.dropFirst().sink { applications in
             let bundleIdentifiers = applications.map { $0.bundleIdentifier }
@@ -190,10 +180,6 @@ final class SettingsViewModel: ObservableObject {
             self?.setupNotification()
         }.store(in: &cancellables)
 
-        if let userDict = dictionary.userDict as? FileDict {
-            userDict.loadStatus.assign(to: &$userDictLoadingStatus)
-        }
-
         $selectedInputSourceId.removeDuplicates().sink { [weak self] selectedInputSourceId in
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {
                 logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) (\(selectedInputSourceId, privacy: .public)) に設定しました")
@@ -215,6 +201,22 @@ final class SettingsViewModel: ObservableObject {
             NotificationCenter.default.post(name: notificationNameInlineCandidateCount, object: inlineCandidateCount)
             logger.log("インラインで表示する変換候補の数を\(inlineCandidateCount)個に変更しました")
         }.store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { [weak self] notification in
+            if let loadEvent = notification.object as? DictLoadEvent, let self {
+                if let userDict = dictionary.userDict as? FileDict, userDict.id == loadEvent.id {
+                    self.userDictLoadingStatus = loadEvent.status
+                    if case .fail(let error) = loadEvent.status {
+                        UNNotifier.sendNotificationForUserDict(readError: error)
+                    } else if case .loaded(_, let failureCount) = loadEvent.status, failureCount > 0 {
+                        UNNotifier.sendNotificationForUserDict(failureEntryCount: failureCount)
+                    }
+                } else {
+                    self.dictLoadingStatuses[loadEvent.id] = loadEvent.status
+                }
+            }
+        }
+        .store(in: &cancellables)
     }
 
     // PreviewProvider用

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -202,7 +202,7 @@ final class SettingsViewModel: ObservableObject {
             logger.log("インラインで表示する変換候補の数を\(inlineCandidateCount)個に変更しました")
         }.store(in: &cancellables)
 
-        NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { [weak self] notification in
+        NotificationCenter.default.publisher(for: notificationNameDictLoad).receive(on: RunLoop.main).sink { [weak self] notification in
             if let loadEvent = notification.object as? DictLoadEvent, let self {
                 if let userDict = dictionary.userDict as? FileDict, userDict.id == loadEvent.id {
                     self.userDictLoadingStatus = loadEvent.status

--- a/macSKK/UNNotifier.swift
+++ b/macSKK/UNNotifier.swift
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import UserNotifications
+
+/// 通知センターへの通知処理
+struct UNNotifier {
+    // ユーザー辞書の読み込みエラーの通知センター用通知のID
+    static let userNotificationReadErrorIdentifier = "net.mtgto.inputmethod.macSKK.userNotification.userDictReadError"
+    // ユーザー辞書の書き込みエラーの通知センター用通知のID
+    static let userNotificationWriteErrorIdentifier = "net.mtgto.inputmethod.macSKK.userNotification.userDictWriteError"
+
+    static func sendNotificationForUserDict(readError: Error) {
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("UNUserDictReadErrorTitle", comment: "エラー")
+        content.body = NSLocalizedString("UNUserDictReadErrorBody", comment: "ユーザー辞書の読み込みに失敗しました")
+
+        let request = UNNotificationRequest(identifier: Self.userNotificationReadErrorIdentifier, content: content, trigger: nil)
+        sendUserNotification(request: request)
+    }
+
+    static func sendNotificationForUserDict(failureEntryCount: Int) {
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("UNUserDictReadFailureEntryTitle", comment: "エラー")
+        content.body = String(format: NSLocalizedString("UNUserDictReadFailureEntryBody", comment: ""), failureEntryCount)
+
+        let request = UNNotificationRequest(identifier: Self.userNotificationReadErrorIdentifier, content: content, trigger: nil)
+        sendUserNotification(request: request)
+    }
+
+    static func sendNotificationForUserDict(writeError: Error) {
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("UNUserDictWriteErrorTitle", comment: "エラー")
+        content.body = NSLocalizedString("UNUserDictWriteErrorBody", comment: "ユーザー辞書の永続化に失敗しました")
+
+        let request = UNNotificationRequest(identifier: Self.userNotificationWriteErrorIdentifier, content: content, trigger: nil)
+        sendUserNotification(request: request)
+    }
+
+    private static func sendUserNotification(request: UNNotificationRequest) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization { granted, error in
+            if let error {
+                logger.log("通知センターへの通知ができない状態です:\(error)")
+                return
+            }
+            if !granted {
+                logger.log("通知センターへの通知がユーザーに拒否されています")
+                return
+            }
+            center.add(request) { error in
+                if let error {
+                    logger.error("通知センターへの通知に失敗しました: \(error)")
+                }
+            }
+        }
+    }
+}

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -3,7 +3,6 @@
 
 import Combine
 import Foundation
-import UserNotifications
 
 /// ユーザー辞書。マイ辞書 (単語登録対象。ファイル名固定) とファイル辞書 をまとめて参照することができる。
 ///

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -27,6 +27,10 @@
 "Encoding" = "Encoding";
 "UNNewVersionTitle" = "A new version is available";
 "UNNewVersionBody" = "macSKK %@ is now available.";
+"UNUserDictReadErrorTitle" = "Error";
+"UNUserDictReadErrorBody" = "Failed to load the user dictionary";
+"UNUserDictReadFailureEntryTitle" = "Error";
+"UNUserDictReadFailureEntryBody" = "Failed to load %d entries of the user dictionary";
 "User Dictionary" = "User Dictionary";
 "Delete" = "Delete";
 "Unregistered" = "Unregistered";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -31,6 +31,8 @@
 "UNUserDictReadErrorBody" = "Failed to load the user dictionary";
 "UNUserDictReadFailureEntryTitle" = "Error";
 "UNUserDictReadFailureEntryBody" = "Failed to load %d entries of the user dictionary";
+"UNUserDictWriteErrorTitle" = "Error";
+"UNUserDictWriteErrorBody" = "Failed to save the user dictionary";
 "User Dictionary" = "User Dictionary";
 "Delete" = "Delete";
 "Unregistered" = "Unregistered";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -27,6 +27,10 @@
 "Encoding" = "エンコーディング";
 "UNNewVersionTitle" = "新しいバージョンがあります";
 "UNNewVersionBody" = "macSKKの新しいバージョン %@ がリリースされています。";
+"UNUserDictReadErrorTitle" = "エラー";
+"UNUserDictReadErrorBody" = "ユーザー辞書の読み込みに失敗しました";
+"UNUserDictReadFailureEntryTitle" = "エラー";
+"UNUserDictReadFailureEntryBody" = "ユーザー辞書の読み込みで %dエントリの読み込みに失敗しました";
 "User Dictionary" = "ユーザー辞書";
 "Delete" = "削除";
 "Unregistered" = "未登録です";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -31,6 +31,8 @@
 "UNUserDictReadErrorBody" = "ユーザー辞書の読み込みに失敗しました";
 "UNUserDictReadFailureEntryTitle" = "エラー";
 "UNUserDictReadFailureEntryBody" = "ユーザー辞書の読み込みで %dエントリの読み込みに失敗しました";
+"UNUserDictWriteErrorTitle" = "エラー";
+"UNUserDictWriteErrorBody" = "ユーザー辞書の永続化に失敗しました";
 "User Dictionary" = "ユーザー辞書";
 "Delete" = "削除";
 "Unregistered" = "未登録です";


### PR DESCRIPTION
ユーザー辞書は自身で編集できるため、読み込みできない行があってもその行はスキップして読み込みが続けられます。
ただ読み込めなかったことがわかりにくいため、通知センターに通知するようにしてみます。

<img width="366" alt="notification" src="https://github.com/mtgto/macSKK/assets/1213991/82695517-60d4-4556-bc16-e085f17124e0">

また永続化の際に書き込みエラーが発生したときにも通知センターに通知するようにします。
スクショはファイルパーミッションを400にして作成。他にはディスクフルの場合にも発生しそう。

<img width="357" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/c5d5965f-f048-40da-953d-55d1789fa397">
