### PR TITLE
GitHub Actions環境をmacOS 14 + Xcode 15.2に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
     - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_15.1.app/Contents/Developer'
+      run: sudo xcode-select -s '/Applications/Xcode_15.2.app/Contents/Developer'
     - uses: actions/checkout@v4
     - name: test
       run: |


### PR DESCRIPTION
2024-01-30からmacOS 14をGitHub Actionsで使えるようになっていたので更新します。
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
ついでにXcode 15.1 → 15.2に変更します。