### PR TITLE
カーソルより右に文字列があるときに変換を確定すると未確定だった文字列を入力済扱いにする

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -374,7 +374,11 @@ struct SelectingState: Equatable, MarkedTextProtocol {
         if let okuri = prev.composing.okuri {
             selectingText += okuri.map { $0.string(for: inputMode) }.joined()
         }
-        return [.markerSelect, .emphasized(selectingText)]
+        if let remain {
+            return [.markerSelect, .emphasized(selectingText), .cursor, .plain(remain.joined())]
+        } else {
+            return [.markerSelect, .emphasized(selectingText)]
+        }
     }
 }
 

--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -199,6 +199,15 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
         }
     }
 
+    /// カーソルより左の部分を返す
+    func remain() -> Self? {
+        if let cursor {
+            return ComposingState(isShift: isShift, text: text, romaji: romaji, cursor: nil)
+        } else {
+            return nil
+        }
+    }
+
     /// 辞書を引く際の読みを返す。
     /// カーソルがある場合はカーソルより左側の文字列だけを対象にする。
     /// 末尾がnの場合は「ん」と入力したとして解釈する
@@ -326,6 +335,8 @@ struct SelectingState: Equatable, MarkedTextProtocol {
     var candidateIndex: Int = 0
     /// カーソル位置。この位置を基に変換候補パネルを表示する
     let cursorPosition: NSRect
+    /// カーソル位置より後のテキスト部分
+    let remain: ComposingState?
 
     func addCandidateIndex(diff: Int) -> Self {
         return SelectingState(
@@ -333,7 +344,8 @@ struct SelectingState: Equatable, MarkedTextProtocol {
             yomi: yomi,
             candidates: candidates,
             candidateIndex: candidateIndex + diff,
-            cursorPosition: cursorPosition)
+            cursorPosition: cursorPosition,
+            remain: remain)
     }
 
     /// 現在選択されている変換候補を文字列を返す

--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -199,10 +199,10 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
         }
     }
 
-    /// カーソルより左の部分を返す
-    func remain() -> Self? {
+    /// カーソルより右の部分の文字の配列を返す
+    func remain() -> [String]? {
         if let cursor {
-            return ComposingState(isShift: isShift, text: text, romaji: romaji, cursor: nil)
+            return Array(text.dropFirst(cursor))
         } else {
             return nil
         }
@@ -335,8 +335,8 @@ struct SelectingState: Equatable, MarkedTextProtocol {
     var candidateIndex: Int = 0
     /// カーソル位置。この位置を基に変換候補パネルを表示する
     let cursorPosition: NSRect
-    /// カーソル位置より後のテキスト部分
-    let remain: ComposingState?
+    /// カーソル位置より後のテキスト部分。ひらがな(Abbrevモード以外) or 英数(Abbrevモード)の配列
+    let remain: [String]?
 
     func addCandidateIndex(diff: Int) -> Self {
         return SelectingState(

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -698,7 +698,8 @@ class StateMachine {
                                 yomi: yomiText,
                                 candidates: candidates,
                                 candidateIndex: 0,
-                                cursorPosition: action.cursorPosition)
+                                cursorPosition: action.cursorPosition,
+                                remain: composing.remain())
                             updateCandidates(selecting: selectingState)
                             state.inputMethod = .selecting(selectingState)
                         }
@@ -812,7 +813,8 @@ class StateMachine {
                 yomi: yomiText,
                 candidates: candidateWords,
                 candidateIndex: 0,
-                cursorPosition: action.cursorPosition)
+                cursorPosition: action.cursorPosition,
+                remain: composing.remain())
             updateCandidates(selecting: selectingState)
             state.inputMethod = .selecting(selectingState)
         }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -978,7 +978,7 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("あ"), .cursor, .plain("い")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("会う")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("会う"), .cursor, .plain("い")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
@@ -996,7 +996,7 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("え")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("えい")])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("え"), .cursor, .plain("い")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("絵")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("絵"), .cursor, .plain("い")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e", withShift: true)))
@@ -1260,7 +1260,7 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("あ"), .cursor, .plain("い")])))
             XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("あ*s"), .cursor, .plain("い")])))
-            XCTAssertEqual(events[4], .markedText(MarkedText([.markerSelect, .emphasized("褪し")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.markerSelect, .emphasized("褪し"), .cursor, .plain("い")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
@@ -1683,6 +1683,53 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleSelectingEnterRemain() {
+        dictionary.setEntries(["あい": [Word("愛")]])
+
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(7).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("あいう")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("あい"), .cursor, .plain("う")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.markerSelect, .emphasized("愛"), .cursor, .plain("う")])))
+            XCTAssertEqual(events[5], .fixedText("愛"))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.markerCompose, .plain("う")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testHandleSelectingPrintableRemain() {
+        dictionary.setEntries(["あい": [Word("愛")]])
+
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(8).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("あいう")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("あい"), .cursor, .plain("う")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.markerSelect, .emphasized("愛"), .cursor, .plain("う")])))
+            XCTAssertEqual(events[5], .fixedText("愛"))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.markerCompose, .plain("う")])))
+            XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("うえ")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleSelectingBackspace() {
         dictionary.setEntries(["と": [Word("戸"), Word("都")]])
 
@@ -1982,10 +2029,10 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("う")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .cursor, .plain("う")])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("え"), .cursor, .plain("う")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("絵")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("絵"), .cursor, .plain("う")])))
             XCTAssertEqual(events[4], .markedText(MarkedText([.markerCompose, .plain("え"), .cursor, .plain("う")])))
             XCTAssertEqual(events[5], .markedText(MarkedText([.markerCompose, .plain("え*r"), .cursor, .plain("う")])))
-            XCTAssertEqual(events[6], .markedText(MarkedText([.markerSelect, .emphasized("得る")])))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.markerSelect, .emphasized("得る"), .cursor, .plain("う")])))
             XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("え*る"), .cursor, .plain("う")])))
             expectation.fulfill()
         }.store(in: &cancellables)

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -204,15 +204,22 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(selectingState.fixedText, "有る")
     }
 
-    func testSelectingStateDisplayText() {
+    func testSelectingStateMarkedTextElements() {
         let composingState = ComposingState(isShift: true, text: ["お"], romaji: "")
-        let selectingState = SelectingState(prev: SelectingState.PrevState(mode: .hiragana, composing: composingState),
+        var selectingState = SelectingState(prev: SelectingState.PrevState(mode: .hiragana, composing: composingState),
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
                                             cursorPosition: .zero,
                                             remain: nil)
         XCTAssertEqual(selectingState.markedTextElements(inputMode: .hiragana), [.markerSelect, .emphasized("尾")])
+        selectingState = SelectingState(prev: SelectingState.PrevState(mode: .hiragana, composing: composingState),
+                                            yomi: "お",
+                                            candidates: [Candidate("尾")],
+                                            candidateIndex: 0,
+                                            cursorPosition: .zero,
+                                            remain: ["か", "き"])
+        XCTAssertEqual(selectingState.markedTextElements(inputMode: .hiragana), [.markerSelect, .emphasized("尾"), .cursor, .plain("かき")])
     }
 
     func testSelectingStateOkuri() {

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -169,7 +169,8 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("亜")],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         XCTAssertEqual(selectingState.fixedText, "亜")
     }
@@ -188,7 +189,8 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         XCTAssertEqual(selectingState.fixedText, "有る")
     }
@@ -199,7 +201,8 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero)
+                                            cursorPosition: .zero,
+                                            remain: nil)
         XCTAssertEqual(selectingState.markedTextElements(inputMode: .hiragana), [.markerSelect, .emphasized("尾")])
     }
 
@@ -216,7 +219,8 @@ final class StateTests: XCTestCase {
             yomi: "お",
             candidates: [Candidate("尾")],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         XCTAssertEqual(selectingState.okuri, nil)
 
@@ -233,7 +237,8 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         XCTAssertEqual(selectingState.okuri, "る")
     }
@@ -281,7 +286,8 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         var state = UnregisterState(
             prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "")
@@ -317,7 +323,8 @@ final class StateTests: XCTestCase {
                                             yomi: "い",
                                             candidates: [Candidate("井")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero)
+                                            cursorPosition: .zero,
+                                            remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
                              specialState: nil,
@@ -336,7 +343,8 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero)
+                                            cursorPosition: .zero,
+                                            remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
                              specialState: .register(registerState),
@@ -356,7 +364,8 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero)
+                                            cursorPosition: .zero,
+                                            remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
                              specialState: .register(registerState),
@@ -379,7 +388,8 @@ final class StateTests: XCTestCase {
             yomi: "あr",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         let unregisterState = UnregisterState(prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "yes")
         let state = IMEState(inputMode: .hiragana,
@@ -404,7 +414,8 @@ final class StateTests: XCTestCase {
             yomi: "だい2",
             candidates: [Candidate("第2", original: Candidate.Original(midashi: "だい#", word: "第#"))],
             candidateIndex: 0,
-            cursorPosition: .zero
+            cursorPosition: .zero,
+            remain: nil
         )
         let unregisterState = UnregisterState(prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "yes")
         let state = IMEState(inputMode: .hiragana,

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -161,6 +161,15 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(composingState.markedTextElements(inputMode: .hiragana), [.markerCompose, .plain("お*s"), .cursor, .plain("い")])
     }
 
+    func testComposingStateRemain() {
+        var composingState = ComposingState(isShift: true, text: ["あ", "い"], okuri: [], romaji: "", cursor: nil)
+        XCTAssertNil(composingState.remain()) // カーソルがnilのときはnil
+        composingState = ComposingState(isShift: true, text: ["あ", "い"], okuri: [], romaji: "", cursor: 0)
+        XCTAssertEqual(composingState.remain(), ["あ", "い"])
+        composingState = ComposingState(isShift: true, text: ["あ", "い"], okuri: [], romaji: "", cursor: 1)
+        XCTAssertEqual(composingState.remain(), ["い"])
+    }
+
     func testSelectingStateFixedText() throws {
         let selectingState = SelectingState(
             prev: SelectingState.PrevState(


### PR DESCRIPTION
未確定文字列の入力中にカーソル移動することができます。
ただし、これまではカーソルが未確定文字列の末尾にないときにスペースなどで変換開始したときにはカーソルより右にある文字列は入力しなかった扱いにしていました。

この修正では変換候補を選んだ時点でカーソルより右にあった文字列を未確定文字列として入力していたと扱うようにします。
例えば「かんどりょうこう」というエントリはSKK-JISYO.Lにないため変換を試みても単語登録画面へ移動してしまいます。そんなときはカーソル移動でまず「かんど」を変換することで再び「りょうこう」を打たなくとも即座に次の変換に移れるようになります。

https://github.com/mtgto/macSKK/assets/1213991/f9a8d1af-742d-4512-9cad-c1e322c0ab02

### 細かい仕様の補足

- 変換候補の選択中に文字を入力した場合は、カーソルより右にあった文字列に続けて入力した扱いとします
- 変換候補の選択中にqを押した場合は現在の変換候補を確定し、カーソルより右にあった文字列をカナかな変換して確定します
  - 同様にCtrl-qを押した場合はカーソルより右にあった文字列を半角カナ変換して確定します
