### PR TITLE
フルキーボードアクセスが有効時に変換候補パネルが一瞬で消える問題に対処

### DIFF
--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -25,6 +25,8 @@ final class CandidatesPanel: NSPanel {
         super.init(contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: true)
         backgroundColor = .clear
         contentViewController = viewController
+        // フルキーボードアクセスが有効なときに変換パネルが表示されなくなるのを回避
+        setAccessibilityElement(false)
     }
 
     func setCandidates(_ candidates: CurrentCandidates, selected: Candidate?) {


### PR DESCRIPTION
#115 macOSの設定でフルキーボードアクセスが有効なときに変換候補パネルが一瞬表示されて消えてしまうことがわかりました。
テキストフィールドをもつアプリケーションと別で稼動しているmacSKKプロセスのビューが表示されてしまうことが原因なのかなあと思っていますが、ちゃんとはわかっていません。

暫定対処としてアクセシビリティでの操作対象ではないとすることでフルキーボードアクセスが有効時にも変換パネルが出たままにできるようなので対応します。