### PR TITLE
kana-rule.confで`k;`や`kq`のようなセミコロン/`q`を含むルールを許可

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -804,12 +804,12 @@ class StateMachine {
         if inputMode != .direct && !romaji.isEmpty {
             let converted = kanaRule.convert(romaji + input)
             if converted.kakutei != nil && converted.input == "" {
-                return .some(converted)
+                return converted
             } else {
-                return .none
+                return nil
             }
         } else {
-            return .none
+            return nil
         }
     }
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -16,6 +16,9 @@ enum InputMethodEvent: Equatable {
     case modeChanged(InputMode, NSRect)
 }
 
+// `kanaRule`という名称を`StateMachine`でメンバー変数で使うためエイリアスをあたえる
+private let currentKanaRule = kanaRule
+
 class StateMachine {
     private(set) var state: IMEState
     let inputMethodEvent: AnyPublisher<InputMethodEvent, Never>
@@ -40,12 +43,15 @@ class StateMachine {
     /// 変換候補パネルに一度に表示する変換候補の数
     let displayCandidateCount = 9
 
-    init(initialState: IMEState = IMEState(), inlineCandidateCount: Int = 3) {
+    private let kanaRule: Romaji!
+
+    init(initialState: IMEState = IMEState(), inlineCandidateCount: Int = 3, kanaRule: Romaji! = currentKanaRule) {
         state = initialState
         inputMethodEvent = inputMethodEventSubject.eraseToAnyPublisher()
         candidateEvent = candidateEventSubject.removeDuplicates().eraseToAnyPublisher()
         yomiEvent = yomiEventSubject.removeDuplicates().eraseToAnyPublisher()
         self.inlineCandidateCount = inlineCandidateCount
+        self.kanaRule = kanaRule
     }
 
     func handle(_ action: Action) -> Bool {
@@ -371,18 +377,15 @@ class StateMachine {
             updateMarkedText()
             return true
         case .space:
-            if state.inputMode != .direct && !romaji.isEmpty {
-                // "z " のようなスペースを使ったローマ字変換ルールがある場合は漢字変換よりも優先する
-                let converted = kanaRule.convert(romaji + " ")
-                if converted.kakutei != nil && converted.input == "" {
-                    return handleComposingPrintable(
-                        input: " ",
-                        converted: converted,
-                        action: action,
-                        composing: composing,
-                        specialState: specialState
-                    )
-                }
+            // "z " のようなスペースを使ったローマ字変換ルールがある場合は漢字変換よりも優先する
+            if let converted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: romaji, input: " ") {
+                return handleComposingPrintable(
+                    input: " ",
+                    converted: converted,
+                    action: action,
+                    composing: composing,
+                    specialState: specialState
+                )
             }
             if text.isEmpty {
                 addFixedText(" ")
@@ -420,7 +423,20 @@ class StateMachine {
                     action: action,
                     composing: composing,
                     specialState: specialState)
-            } else if okuri != nil {
+            }
+
+            // "q;"のようなセミコロンを使ったルールがある場合はそれを優先させる
+            if let converted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: romaji, input: ";") {
+                return handleComposingPrintable(
+                    input: ";",
+                    converted: converted,
+                    action: action,
+                    composing: composing,
+                    specialState: specialState
+                )
+            }
+
+            if okuri != nil {
                 // 送り仮名入力中は無視する
                 // AquaSKKは送り仮名の末尾に"；"をつけて変換処理もしくは単語登録に遷移
                 return true
@@ -556,6 +572,19 @@ class StateMachine {
             return true
         case .up, .down, .ctrlY, .eisu, .kana:
             return true
+        }
+    }
+    
+    private func useKanaRuleIfPresent(inputMode: InputMode, romaji: String, input: String) -> Romaji.ConvertedMoji? {
+        if inputMode != .direct && !romaji.isEmpty {
+            let converted = kanaRule.convert(romaji + input)
+            if converted.kakutei != nil && converted.input == "" {
+                return .some(converted)
+            } else {
+                return .none
+            }
+        } else {
+            return .none
         }
     }
 

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -31,6 +31,7 @@ class RomajiTests: XCTestCase {
         XCTAssertEqual(kanaRule.convert("z,"), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "z", kana: "‥")))
         XCTAssertEqual(kanaRule.convert("x,,"), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "x", kana: "だぶるかんま")))
         XCTAssertEqual(kanaRule.convert("@"), Romaji.ConvertedMoji(input: "@", kakutei: nil), "ルールにない文字は変換されない")
+        XCTAssertEqual(kanaRule.convert("a;"), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "a", kana:"あせみころん")), "システム用の文字を含むことができる")
     }
 
     func testVu() throws {

--- a/macSKKTests/fixture/kana-rule-for-test.conf
+++ b/macSKKTests/fixture/kana-rule-for-test.conf
@@ -10,3 +10,4 @@ nn,ん
 &comma;,、
 z&comma;,‥
 x&comma;&comma;,だぶるかんま
+a;,あせみころん


### PR DESCRIPTION
- スペースを含むルールについては #96 で対応が行なわれていたが`;`にはこのような特殊処理がはいっていなかった
- [ACT](http://www1.vecceed.ne.jp/~bemu/act/act_index.html)のような拡張では、日本語入力で利用頻度の低い`;`や`q`のようなキーに特殊な役割を与えることがあり、このために必要となった
- これのテストを行うにあたって`StateMachine`クラスでグローバルに定義された`kanaRule`を参照しているとデフォルトの`kana-rule.conf`が利用されてしまうため、テスト目的で`StateMachine`のコンストラクターで`kanaRule: Romaji!`を受けとるようにした
    - 省略すれば従来どおりグローバルに定義された`kanaRule`を用いる