### PR TITLE
GitHub ActionsのCIのパーミッションでForkからのPull Requestでchecks: writeを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: macos-14
+    permissions:
+      checks: write
     steps:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
     - name: Select Xcode version


### PR DESCRIPTION
#120 でFork先からのPull Requestだと `kishikawakatsumi/xcresulttool@v1` からのchecks: writeがなくて死んでそうだったので試しに追加してみます。