### PR TITLE
ForkからのPull Requestでもxcresulttoolが実行できるようにpull_request_targetで発火するように修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 jobs:
@@ -15,6 +15,7 @@ jobs:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
     - name: Select Xcode version
       run: sudo xcode-select -s '/Applications/Xcode_15.2.app/Contents/Developer'
+    # NOTE: pull_request_targetで実行したときはPull RequestがマージされたリビジョンではなくBaseのリビジョンで実行されます。
     - uses: actions/checkout@v4
     - name: test
       run: |


### PR DESCRIPTION
#121 の続き。#121 では解決しなかったのでpull_request_targetイベントでCIを実行するようにします。

pull_request_targetの制約として、マージ後のリビジョンではなくBaseのリビジョンが git checkoutされます。GitHub APIを使ってマージ後のリビジョンをポーリングすることでも解決可能ですが、mainブランチではその処理をスキップしないといけなく、それを考えるのが面倒になってきたのでいったんこれでお茶を濁すことにします。
Pull Requestがmainとはなれた古いリビジョンでのCIが実行されてしまったとしても、マージ後にmainブランチでCIは実行されるのでとりあえずこれでよしとしようと思います。