### PR TITLE
入力元のウィンドウレベルより1大きいレベルでパネルを表示する

### DIFF
--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -55,7 +55,7 @@ final class CandidatesPanel: NSPanel {
      * - 下にはみ出る場合: テキストの上側に表示する
      * - 右にはみ出す場合: スクリーン右端に接するように表示する
      */
-    func show() {
+    func show(windowLevel: NSWindow.Level) {
         guard let viewController = contentViewController as? NSHostingController<CandidatesView> else {
             fatalError("ビューコントローラの状態が壊れている")
         }
@@ -93,7 +93,7 @@ final class CandidatesPanel: NSPanel {
             // スクリーン下にはみ出す場合はテキスト入力位置の上に表示する
             setFrameOrigin(CGPoint(x: origin.x, y: origin.y + cursorPosition.size.height))
         }
-        level = .floating
+        level = windowLevel
         orderFrontRegardless()
     }
 }

--- a/macSKK/View/InputModePanel.swift
+++ b/macSKK/View/InputModePanel.swift
@@ -12,7 +12,7 @@ class InputModePanel: NSPanel {
     init() {
         imageSize = CGSize(width: 32, height: 32)
         imageView = NSImageView(frame: .zero)
-        super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
+        super.init(contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: true)
         imageView.imageScaling = .scaleProportionallyUpOrDown
         backgroundColor = .clear
         isOpaque = false
@@ -22,12 +22,12 @@ class InputModePanel: NSPanel {
         setContentSize(imageSize)
     }
 
-    func show(at point: NSPoint, mode: InputMode, privateMode: Bool) {
+    func show(at point: NSPoint, mode: InputMode, privateMode: Bool, windowLevel: NSWindow.Level) {
         // 画像の高さ分だけ下にずらす
         let origin = NSPoint(x: point.x, y: point.y - imageSize.height)
         let rect = NSRect(origin: origin, size: imageSize)
         setFrame(rect, display: true)
-        level = .floating
+        level = windowLevel
         switch mode {
         case .hiragana:
             imageView.image = NSImage(named: privateMode ? "icon-hiragana-locked" : "icon-hiragana")

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -134,7 +134,7 @@ struct macSKKApp: App {
                     let word = Candidate("インライン", annotations: [Annotation(dictId: "", text: String(repeating: "これはインラインのテスト用注釈です", count: 5))])
                     candidatesPanel.setCandidates(.inline, selected: word)
                     candidatesPanel.setCursorPosition(NSRect(origin: NSPoint(x: 100, y: 640), size: CGSize(width: 0, height: 30)))
-                    candidatesPanel.show()
+                    candidatesPanel.show(windowLevel: .floating)
                 }
                 Button("Hide AnnotataionsPanel") {
                     candidatesPanel.orderOut(nil)
@@ -148,7 +148,7 @@ struct macSKKApp: App {
                                  Candidate("おはようございます")]
                     candidatesPanel.setCandidates(.panel(words: words, currentPage: 0, totalPageCount: 1), selected: words.first)
                     candidatesPanel.setCursorPosition(NSRect(origin: NSPoint(x: 100, y: 20), size: CGSize(width: 0, height: 30)))
-                    candidatesPanel.show()
+                    candidatesPanel.show(windowLevel: .floating)
                 }
                 Button("Add Word") {
                     let words = [Candidate("こんにちは", annotations: [Annotation(dictId: "", text: "辞書の注釈")]),
@@ -159,7 +159,7 @@ struct macSKKApp: App {
                     candidatesPanel.viewModel.systemAnnotations = [words.last!.word: String(repeating: "これはシステム辞書の注釈です。", count: 5)]
                 }
                 Button("InputMode Panel") {
-                    inputModePanel.show(at: NSPoint(x: 200, y: 200), mode: .hiragana, privateMode: true)
+                    inputModePanel.show(at: NSPoint(x: 200, y: 200), mode: .hiragana, privateMode: true, windowLevel: .floating)
                 }
                 Button("User Notification") {
                     let release = Release(version: ReleaseVersion(major: 0, minor: 4, patch: 0),


### PR DESCRIPTION
Issue #117
Alfredの入力バーのウィンドウレベル (CGWindowLevelで27) では、 NSWindow.Level = .floatingで表示すると裏側に表示されてしまうことがわかりました。
入力元のウィンドウレベルに1足した値で表示することにします。