### PR TITLE
tqのようなローマ字変換ルールがあるときにシフト押してないときにも未確定文字入力モードになるバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -602,10 +602,13 @@ class StateMachine {
             // "tq"のような"q"を使ったルールがある場合はそれを優先させる
             if let converted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: composing.romaji, input: "q") {
                 if let kakutei = converted.kakutei {
-                    state.inputMethod = .composing(
-                        ComposingState(isShift: isShift, text: text + [kakutei.string(for: state.inputMode)], okuri: okuri, romaji: converted.input))
-                    updateMarkedText()
-                    return true
+                    return handleComposingPrintable(
+                        input: " ",
+                        converted: converted,
+                        action: action,
+                        composing: composing,
+                        specialState: specialState
+                    )
                 }
             }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -56,6 +56,19 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testHandleNormalRomajiKanaRuleQ() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana), kanaRule: try! Romaji(source: "tq,たん"))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("t")])))
+            XCTAssertEqual(events[1], .fixedText("たん"))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testHandleNormalSpace() throws {
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(2).sink { events in


### PR DESCRIPTION
#120 で "tq" のように末尾にqをもつローマ字かな変換ルールをもつとき、シフトを押さないで入力しても下線が表示されてしまう (未確定文字入力モード) のを修正します。

この問題とは別に、tqのようなルールをもつとき一文字目はシフトキーなしで二文字目にシフトキーを押しながらqを入力しても未確定文字入力モードにならないのはおかしい気がする? ので問題があるようなら別途直します。