### PR TITLE
`kanaRule`を`StateMachine`のコンストラクターに渡すのをやめる

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -16,9 +16,6 @@ enum InputMethodEvent: Equatable {
     case modeChanged(InputMode, NSRect)
 }
 
-// `kanaRule`という名称を`StateMachine`でメンバー変数で使うためエイリアスをあたえる
-private let currentKanaRule = kanaRule
-
 class StateMachine {
     private(set) var state: IMEState
     let inputMethodEvent: AnyPublisher<InputMethodEvent, Never>
@@ -43,15 +40,12 @@ class StateMachine {
     /// 変換候補パネルに一度に表示する変換候補の数
     let displayCandidateCount = 9
 
-    private let kanaRule: Romaji!
-
-    init(initialState: IMEState = IMEState(), inlineCandidateCount: Int = 3, kanaRule: Romaji! = currentKanaRule) {
+    init(initialState: IMEState = IMEState(), inlineCandidateCount: Int = 3) {
         state = initialState
         inputMethodEvent = inputMethodEventSubject.eraseToAnyPublisher()
         candidateEvent = candidateEventSubject.removeDuplicates().eraseToAnyPublisher()
         yomiEvent = yomiEventSubject.removeDuplicates().eraseToAnyPublisher()
         self.inlineCandidateCount = inlineCandidateCount
-        self.kanaRule = kanaRule
     }
 
     /// `Action`をハンドルした場合には`true`、しなかった場合は`false`を返す

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -9,8 +9,10 @@ import XCTest
 final class StateMachineTests: XCTestCase {
     var stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
     var cancellables: Set<AnyCancellable> = []
+    let globalKanaRule = kanaRule
 
     override func setUpWithError() throws {
+        kanaRule = globalKanaRule
         dictionary.setEntries([:])
         cancellables = []
     }
@@ -57,7 +59,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     func testHandleNormalRomajiKanaRuleQ() {
-        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana), kanaRule: try! Romaji(source: "tq,たん"))
+        kanaRule = try! Romaji(source: "tq,たん")
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(2).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.plain("t")])))
@@ -1078,7 +1080,7 @@ final class StateMachineTests: XCTestCase {
     }
     
     func testHandleComposingSpaceAfterPrintable() {
-        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana), kanaRule: try! Romaji(source: "z ,スペース"))
+        kanaRule = try! Romaji(source: "z ,スペース")
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(2).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.plain("z")])))
@@ -1091,7 +1093,7 @@ final class StateMachineTests: XCTestCase {
     }
     
     func testHandleComposingStickyShiftAfterPrintable() {
-        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana), kanaRule: try! Romaji(source: "a;,あせみころん"))
+        kanaRule = try! Romaji(source: "a;,あせみころん")
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(2).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.plain("a")])))
@@ -1104,7 +1106,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     func testHandleComposingQAfterPrintable() {
-        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana), kanaRule: try! Romaji(source: "tq,たん"))
+        kanaRule = try! Romaji(source: "tq,たん")
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(3).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("t")])))


### PR DESCRIPTION
- #120 でテストのために導入したが、これがあることでおそらく`kana-rule.conf`が変更されても`StateMachine`クラスでそれが反映されず、macSKKの再起動まで古い設定が利用されてしまう
- よってコンストラクターでの注入をやめて、テストではグローバルな`kanaRule`を変更することにした