### PR TITLE
Abbrevモードから抜けたときに入る前のモードに戻す

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -82,16 +82,16 @@ protocol SpecialStateProtocol: CursorProtocol {
 /// 入力中の未確定文字列の定義
 struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
     /// (Sticky)Shiftによる未確定入力中かどうか。先頭に▽ついてる状態。
-    var isShift: Bool
+    let isShift: Bool
     /// かな/カナならかなになっているひらがなの文字列、abbrevなら入力した文字列.
-    var text: [String]
+    let text: [String]
     /// (Sticky)Shiftが押されたあとに入力されてかなになっている文字列。送り仮名モードになってなければnil
     /// StickyShiftが押されたり送り仮名をバックスペースで削除して送り仮名モードだけど送り仮名が空のときは空配列
-    var okuri: [Romaji.Moji]?
+    let okuri: [Romaji.Moji]?
     /// ローマ字モードで未確定部分。"k" や "ky" など最低あと1文字でかなに変換できる文字列。
-    var romaji: String
+    let romaji: String
     /// カーソル位置。末尾のときはnil。先頭の▽分は含まないので非nilのときは[0, text.count)の範囲を取る。
-    var cursor: Int?
+    let cursor: Int?
     /// 未確定文字列の入力開始前のモード。
     /// スラッシュでAbbrevモードに入るときにその前のモードを設定しておき、Abbrevモードから抜けるときにそのモードに戻す
     let prevMode: InputMode?

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -80,7 +80,7 @@ final class StateTests: XCTestCase {
         var state = ComposingState(
             isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: 1)
         XCTAssertEqual(state.subText(), ["あ"])
-        state.cursor = nil
+        state = state.with(cursor: nil)
         XCTAssertEqual(state.subText(), ["あ", "い"])
     }
 
@@ -109,10 +109,9 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(state.yomi(for: .katakana), "あい")
         XCTAssertEqual(state.yomi(for: .hankaku), "あい")
         XCTAssertEqual(state.yomi(for: .direct), "あい")
-        state.cursor = 1
+        state = state.with(cursor: 1)
         XCTAssertEqual(state.yomi(for: .hiragana), "あ")
-        state.okuri = [Romaji.Moji(firstRomaji: "u", kana: "う")]
-        state.cursor = nil
+        state = state.with(okuri: [Romaji.Moji(firstRomaji: "u", kana: "う")]).with(cursor: nil)
         XCTAssertEqual(state.yomi(for: .katakana), "あいu")
     }
 
@@ -124,7 +123,7 @@ final class StateTests: XCTestCase {
             romaji: "",
             cursor: nil)
         XCTAssertEqual(state.yomi(for: .direct), "ab")
-        state.cursor = 1
+        state = state.with(cursor: 1)
         XCTAssertEqual(state.yomi(for: .direct), "a")
     }
 
@@ -466,5 +465,15 @@ final class StateTests: XCTestCase {
                              candidates: [])
         let displayText = state.displayText()
         XCTAssertEqual(displayText.elements, [.plain("だい# /第#/ を削除します(yes/no)"), .plain("yes")])
+    }
+}
+
+extension ComposingState {
+    func with(cursor : Int?) -> Self {
+        ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: romaji, cursor: cursor, prevMode: prevMode)
+    }
+
+    func with(okuri: [Romaji.Moji]) -> Self {
+        ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: romaji, cursor: cursor, prevMode: prevMode)
     }
 }


### PR DESCRIPTION
#127 スラッシュを入力するとAbbrevモードに入ります。そのあと変換が確定させたりキャンセルしたりしてAbbrevモードを抜けるときに、Abbrevモードに入る前がひらがな入力だったらひらがな入力に戻るようにします。