### PR TITLE
KittyやLINEでq/lやC-jによるモード切り替えで文字が挿入される問題のワークアラウンド

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -81,10 +81,10 @@ class InputController: IMKInputController {
                     }
                     textInput.setMarkedText(NSAttributedString(attributedText), selectionRange: cursorRange, replacementRange: Self.notFoundRange)
                 case .modeChanged(let inputMode, let cursorPosition):
-                    // Kittyでq/lによるモード切り替えでq/lが入力されたり、C-jで改行が入力されるのを回避するワークアラウンド
+                    // KittyやLINEでq/lによるモード切り替えでq/lが入力されたり、C-jで改行が入力されるのを回避するワークアラウンド
                     // AquaSKKの空文字列挿入を参考にしています。
                     // https://github.com/codefirst/aquaskk/blob/4.7.5/platform/mac/src/server/SKKInputController.mm#L405-L412
-                    if textInput.bundleIdentifier() == "net.kovidgoyal.kitty" {
+                    if ["net.kovidgoyal.kitty", "jp.naver.line.mac"].contains(textInput.bundleIdentifier()) {
                         textInput.setMarkedText(String(format: "%c", 0x0c), selectionRange: Self.notFoundRange, replacementRange: Self.notFoundRange)
                         textInput.setMarkedText("", selectionRange: Self.notFoundRange, replacementRange: Self.notFoundRange)
                     }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -81,6 +81,13 @@ class InputController: IMKInputController {
                     }
                     textInput.setMarkedText(NSAttributedString(attributedText), selectionRange: cursorRange, replacementRange: Self.notFoundRange)
                 case .modeChanged(let inputMode, let cursorPosition):
+                    // Kittyでq/lによるモード切り替えでq/lが入力されたり、C-jで改行が入力されるのを回避するワークアラウンド
+                    // AquaSKKの空文字列挿入を参考にしています。
+                    // https://github.com/codefirst/aquaskk/blob/4.7.5/platform/mac/src/server/SKKInputController.mm#L405-L412
+                    if textInput.bundleIdentifier() == "net.kovidgoyal.kitty" {
+                        textInput.setMarkedText(String(format: "%c", 0x0c), selectionRange: Self.notFoundRange, replacementRange: Self.notFoundRange)
+                        textInput.setMarkedText("", selectionRange: Self.notFoundRange, replacementRange: Self.notFoundRange)
+                    }
                     if !self.directMode {
                         textInput.selectMode(inputMode.rawValue)
                         self.inputModePanel.show(at: cursorPosition.origin,


### PR DESCRIPTION
#119 Kitty 0.32.2で確認。

- qキーやlキーによるモード切り替えを行うとqやlが挿入されてしまう
- C-jによるモード切り替えを行うと改行されてしまう

これらの問題はモード変換キーが押されたときに "\f" を未確定文字列として一瞬入力することで回避できるということを知りました。
将来はAquaSKKのようにユーザーがカスタマイズできるようにするかもしれませんが、ひとまずKittyのBundle Identifierのときにこのワークアラウンドを発動させます。