### PR TITLE
ノーマル時のかなキーの動作を`Ctrl-J`と同じにする

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -145,7 +145,7 @@ class StateMachine {
             return true
         case .printable(let input):
             return handleNormalPrintable(input: input, action: action, specialState: specialState)
-        case .ctrlJ:
+        case .ctrlJ, .kana:
             if case .unregister = specialState {
                 return true
             } else {
@@ -240,7 +240,7 @@ class StateMachine {
             } else {
                 return false
             }
-        case .eisu, .kana:
+        case .eisu:
             // 何もしない (OSがIMEの切り替えはしてくれる)
             return true
         }


### PR DESCRIPTION
- `Ctrl-j`（`C-j`）はノーマルモード時にはOSのIME切り替えとは別にIME状態を切り替えるようになっている
    - よって、たとえば`Ctrl-q`で半角英数入力となっている状態から`Ctrl-j`でかな入力へ戻ることができる
    - この振る舞いも（別のテストで利用されていたが）`Ctrl-j`のテストに追加した
- [`README.md`のワークアラウンド](https://github.com/mtgto/macSKK?tab=readme-ov-file#q-%E6%A8%99%E6%BA%96terminal--iterm2%E3%81%A7-c-j-%E3%82%92%E6%8A%BC%E3%81%99%E3%81%A8%E6%94%B9%E8%A1%8C%E3%81%95%E3%82%8C%E3%81%A6%E3%81%97%E3%81%BE%E3%81%84%E3%81%BE%E3%81%99)として、特定のアプリで`Ctrl-j`をかなキーへ変換するようなものが紹介されているが、この際にかなキーの動作が`Ctrl-j`と同じではないと混乱が生じると考えられる
- よって、ノーマルモード時のかなキー入力時は`Ctrl-j`と同じ分岐へ進入するようにし、テストを追加した