### PR TITLE
送り仮名つきの辞書登録完了時に確定する文字列に送り仮名がついてなかったバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -90,7 +90,11 @@ class StateMachine {
                         addWordToUserDict(yomi: registerState.yomi, okuri: registerState.okuri, candidate: Candidate(registerState.text))
                         state.specialState = nil
                         state.inputMode = registerState.prev.mode
-                        addFixedText(registerState.text)
+                        if let okuri = registerState.okuri {
+                            addFixedText(registerState.text + okuri)
+                        } else {
+                            addFixedText(registerState.text)
+                        }
                     }
                     return true
                 } else if case .unregister(let unregisterState) = specialState {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1788,7 +1788,7 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[2], .modeChanged(.hiragana, .zero))
             XCTAssertEqual(events[3], .markedText(MarkedText([.plain("[登録：あ*け]")])))
             XCTAssertEqual(events[4], .markedText(MarkedText([.plain("[登録：あ*け]"), .plain("い")])))
-            XCTAssertEqual(events[5], .fixedText("い"))
+            XCTAssertEqual(events[5], .fixedText("いけ"), "辞書登録後は単語登録時に使用した送り仮名つきで確定する")
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))


### PR DESCRIPTION
#136 

送り仮名つきの辞書登録完了時に確定する文字列が、送り仮名付きでなかったバグを修正します。