### PR TITLE
変換候補パネルで状態がおかしいときにクラッシュさせないように修正

### DIFF
--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -56,8 +56,10 @@ final class CandidatesPanel: NSPanel {
      * - 右にはみ出す場合: スクリーン右端に接するように表示する
      */
     func show(windowLevel: NSWindow.Level) {
+        // 原因は特定できてないが特殊な場合 (終了が要求されているときなど?) で下記の分岐がfalseになるケースがあったので対処
         guard let viewController = contentViewController as? NSHostingController<CandidatesView> else {
-            fatalError("ビューコントローラの状態が壊れている")
+            logger.error("ビューコントローラの状態が想定と異なるため変換候補パネルを表示できません")
+            return
         }
         #if DEBUG
         print("content size = \(viewController.sizeThatFits(in: CGSize(width: Int.max, height: Int.max)))")


### PR DESCRIPTION
PCの再起動時にクラッシュが発生しました。
クラッシュログから、変換候補パネルの表示で想定と違ってSwiftUI用のNSHostingControllerでない場合がありました。
SwiftUIのバグなのかOSのバグなのかは不明ですが、ひとまずクラッシュはさせないことにします。

通常時には発生しないですが、この対処により変換候補パネルが表示できないというケースが発生する可能性はなくはないです。