### PR TITLE
グローバル変数のうちMainActorでもてるものを分離

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA292AAC171B00E80E5E /* FileDictTests.swift */; };
 		CE06CA2D2AAC172F00E80E5E /* empty.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE06CA2C2AAC172F00E80E5E /* empty.txt */; };
 		CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */; };
+		CE11C7B52BDD461C00A35F3D /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7B42BDD461C00A35F3D /* Global.swift */; };
 		CE1B00552BA3DDEB00C830FD /* SKKServDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B00542BA3DDEB00C830FD /* SKKServDict.swift */; };
 		CE1B00622BA4286800C830FD /* Message+SKKServ.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B00612BA4286800C830FD /* Message+SKKServ.swift */; };
 		CE1B00642BA4287C00C830FD /* SKKServRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B00632BA4287C00C830FD /* SKKServRequest.swift */; };
@@ -154,6 +155,7 @@
 		CE06CA292AAC171B00E80E5E /* FileDictTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDictTests.swift; sourceTree = "<group>"; };
 		CE06CA2C2AAC172F00E80E5E /* empty.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
 		CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDict+Utilities.swift"; sourceTree = "<group>"; };
+		CE11C7B42BDD461C00A35F3D /* Global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Global.swift; sourceTree = "<group>"; };
 		CE1B00542BA3DDEB00C830FD /* SKKServDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServDict.swift; sourceTree = "<group>"; };
 		CE1B00612BA4286800C830FD /* Message+SKKServ.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+SKKServ.swift"; sourceTree = "<group>"; };
 		CE1B00632BA4287C00C830FD /* SKKServRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServRequest.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 			children = (
 				CE5ECF352957034B00E7BE7D /* macSKKApp.swift */,
 				CE7F9AD82AADEBF9001B1877 /* AppDelegate.swift */,
+				CE11C7B42BDD461C00A35F3D /* Global.swift */,
 				CE84A3B829570C37009394C4 /* InputController.swift */,
 				CE84A3DD29571797009394C4 /* Action.swift */,
 				CE39DB202A8DFD8F00BC619F /* MarkedText.swift */,
@@ -731,6 +734,7 @@
 				CEC061C82ABB0A0100A11614 /* CompletionPanel.swift in Sources */,
 				CE4CB5CC2AD557D90046FA34 /* NumberEntry.swift in Sources */,
 				CEF3D86C2B9C022900BD1D3A /* WorkaroundApplicationView.swift in Sources */,
+				CE11C7B52BDD461C00A35F3D /* Global.swift in Sources */,
 				CE84A3DE29571797009394C4 /* Action.swift in Sources */,
 				CED987412BB953E7001B40F9 /* Data+EucJis2004.swift in Sources */,
 				CE485A882A8FA195008271EF /* Release+UNNotification.swift in Sources */,

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import AppKit
 import Combine
-import Foundation
 
 /**
  * メインスレッドからのみ参照するグローバルな要素を保持する
  */
 @MainActor struct Global {
-    // static let shared = Global()
+    static let shared = Global()
     static let privateMode = CurrentValueSubject<Bool, Never>(false)
     // 直接入力するアプリケーションのBundleIdentifierの集合のコピー。
     // マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。
@@ -16,4 +16,25 @@ import Foundation
     static let directModeBundleIdentifiers = CurrentValueSubject<[String], Never>([])
     // モード変更時に空白文字を一瞬追加するワークアラウンドを適用するBundle Identifierの集合
     static let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
+    // 現在のモードを表示するパネル
+    private let inputModePanel: InputModePanel
+    private let candidatesPanel: CandidatesPanel
+    private let completionPanel: CompletionPanel
+
+    init() {
+        inputModePanel = InputModePanel()
+        candidatesPanel = CandidatesPanel(
+            showAnnotationPopover: UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation),
+            candidatesFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidatesFontSize),
+            annotationFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.annotationFontSize)
+        )
+        completionPanel = CompletionPanel()
+    }
+
+    static func showInputModePanel(at point: CGPoint, inputMode: InputMode, windowLevel: NSWindow.Level) {
+        shared.inputModePanel.show(at: point,
+                                   mode: inputMode,
+                                   privateMode: Global.privateMode.value,
+                                   windowLevel: windowLevel)
+    }
 }

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Combine
+import Foundation
+
+/**
+ * メインスレッドからのみ参照するグローバルな要素を保持する
+ */
+@MainActor struct Global {
+    // static let shared = Global()
+    static let privateMode = CurrentValueSubject<Bool, Never>(false)
+    // 直接入力するアプリケーションのBundleIdentifierの集合のコピー。
+    // マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。
+    // FIXME: NotificationCenter経由で設定画面で変更したことを各InputControllerに通知するようにしてこの変数は消すかも。
+    static let directModeBundleIdentifiers = CurrentValueSubject<[String], Never>([])
+    // モード変更時に空白文字を一瞬追加するワークアラウンドを適用するBundle Identifierの集合
+    static let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
+}

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -18,6 +18,7 @@ import Combine
     static let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
+    // 変換候補を表示するパネル
     private let candidatesPanel: CandidatesPanel
     // 補完候補を表示するパネル
     private let completionPanel: CompletionPanel
@@ -32,19 +33,15 @@ import Combine
         completionPanel = CompletionPanel()
     }
 
-    static func showInputModePanel(at point: CGPoint, inputMode: InputMode, windowLevel: NSWindow.Level) {
-        shared.inputModePanel.show(at: point,
-                                   mode: inputMode,
-                                   privateMode: Global.privateMode.value,
-                                   windowLevel: windowLevel)
+    static var inputModePanel: InputModePanel {
+        shared.inputModePanel
     }
 
-    static func showCompletionPanel(at point: CGPoint, completion: String) {
-        shared.completionPanel.viewModel.completion = completion
-        shared.completionPanel.show(at: point)
+    static var completionPanel: CompletionPanel {
+        shared.completionPanel
     }
 
-    static func hideCompletionPanel(_ sender: Any? = nil) {
-        shared.completionPanel.orderOut(sender)
+    static var candidatesPanel: CandidatesPanel {
+        shared.candidatesPanel
     }
 }

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -19,6 +19,7 @@ import Combine
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     private let candidatesPanel: CandidatesPanel
+    // 補完候補を表示するパネル
     private let completionPanel: CompletionPanel
 
     init() {
@@ -36,5 +37,14 @@ import Combine
                                    mode: inputMode,
                                    privateMode: Global.privateMode.value,
                                    windowLevel: windowLevel)
+    }
+
+    static func showCompletionPanel(at point: CGPoint, completion: String) {
+        shared.completionPanel.viewModel.completion = completion
+        shared.completionPanel.show(at: point)
+    }
+
+    static func hideCompletionPanel(_ sender: Any? = nil) {
+        shared.completionPanel.orderOut(sender)
     }
 }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -22,7 +22,6 @@ class InputController: IMKInputController {
     private var targetApp: TargetApplication! = nil
     private var cancellables: Set<AnyCancellable> = []
     private static let notFoundRange = NSRange(location: NSNotFound, length: NSNotFound)
-    private let inputModePanel: InputModePanel
     private let candidatesPanel: CandidatesPanel
     private let completionPanel: CompletionPanel
     /// 変換候補として選択されている単語を流すストリーム
@@ -37,7 +36,6 @@ class InputController: IMKInputController {
     private var windowLevel: NSWindow.Level = .floating
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
-        inputModePanel = InputModePanel()
         candidatesPanel = CandidatesPanel(
             showAnnotationPopover: UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation),
             candidatesFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidatesFontSize),
@@ -96,10 +94,7 @@ class InputController: IMKInputController {
                     }
                     if !self.directMode {
                         textInput.selectMode(inputMode.rawValue)
-                        self.inputModePanel.show(at: cursorPosition.origin,
-                                                  mode: inputMode,
-                                                  privateMode: Global.privateMode.value,
-                                                  windowLevel: windowLevel)
+                        Global.showInputModePanel(at: cursorPosition.origin, inputMode: inputMode, windowLevel: windowLevel)
                     }
                 }
             }
@@ -293,7 +288,7 @@ class InputController: IMKInputController {
         _ = textInput.attributes(forCharacterIndex: 0, lineHeightRectangle: &cursorPosition)
         windowLevel = NSWindow.Level(rawValue: Int(textInput.windowLevel() + 1))
         if !directMode {
-            inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: Global.privateMode.value, windowLevel: windowLevel)
+            Global.showInputModePanel(at: cursorPosition.origin, inputMode: inputMode, windowLevel: windowLevel)
         }
         // キー配列を設定する
         setCustomInputSource(textInput: textInput)
@@ -337,7 +332,7 @@ class InputController: IMKInputController {
     #if DEBUG
     @objc func showPanel() {
         let point = NSPoint(x: 100, y: 500)
-        inputModePanel.show(at: point, mode: .hiragana, privateMode: Global.privateMode.value, windowLevel: windowLevel)
+        Global.showInputModePanel(at: point, inputMode: .hiragana, windowLevel: windowLevel)
     }
     #endif
 

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -98,7 +98,7 @@ class InputController: IMKInputController {
                         textInput.selectMode(inputMode.rawValue)
                         self.inputModePanel.show(at: cursorPosition.origin,
                                                   mode: inputMode,
-                                                  privateMode: privateMode.value,
+                                                  privateMode: Global.privateMode.value,
                                                   windowLevel: windowLevel)
                     }
                 }
@@ -152,12 +152,12 @@ class InputController: IMKInputController {
                 }
             }
         }.store(in: &cancellables)
-        directModeBundleIdentifiers.sink { [weak self] bundleIdentifiers in
+        Global.directModeBundleIdentifiers.sink { [weak self] bundleIdentifiers in
             if let bundleIdentifier = self?.targetApp.bundleIdentifier {
                 self?.directMode = bundleIdentifiers.contains(bundleIdentifier)
             }
         }.store(in: &cancellables)
-        insertBlankStringBundleIdentifiers.sink { [weak self] bundleIdentifiers in
+        Global.insertBlankStringBundleIdentifiers.sink { [weak self] bundleIdentifiers in
             if let bundleIdentifier = self?.targetApp.bundleIdentifier {
                 self?.insertBlankString = bundleIdentifiers.contains(bundleIdentifier)
             }
@@ -236,7 +236,7 @@ class InputController: IMKInputController {
         let privateModeItem = NSMenuItem(title: NSLocalizedString("MenuItemPrivateMode", comment: "Private mode"),
                                          action: #selector(togglePrivateMode),
                                          keyEquivalent: "")
-        privateModeItem.state = privateMode.value ? .on : .off
+        privateModeItem.state = Global.privateMode.value ? .on : .off
         preferenceMenu.addItem(privateModeItem)
         if targetApp.bundleIdentifier != nil {
             let directModeItem = NSMenuItem(title: String(format: NSLocalizedString("MenuItemDirectInput", comment: "\"%@\"では直接入力"), targetApp.localizedName ?? "?"),
@@ -293,7 +293,7 @@ class InputController: IMKInputController {
         _ = textInput.attributes(forCharacterIndex: 0, lineHeightRectangle: &cursorPosition)
         windowLevel = NSWindow.Level(rawValue: Int(textInput.windowLevel() + 1))
         if !directMode {
-            inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: privateMode.value, windowLevel: windowLevel)
+            inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: Global.privateMode.value, windowLevel: windowLevel)
         }
         // キー配列を設定する
         setCustomInputSource(textInput: textInput)
@@ -317,7 +317,7 @@ class InputController: IMKInputController {
     }
 
     @objc func togglePrivateMode() {
-        privateMode.send(!privateMode.value)
+        Global.privateMode.send(!Global.privateMode.value)
     }
 
     /// 現在最前面にあるアプリからの入力をハンドルしないかどうかを切り替える
@@ -337,7 +337,7 @@ class InputController: IMKInputController {
     #if DEBUG
     @objc func showPanel() {
         let point = NSPoint(x: 100, y: 500)
-        inputModePanel.show(at: point, mode: .hiragana, privateMode: privateMode.value, windowLevel: windowLevel)
+        inputModePanel.show(at: point, mode: .hiragana, privateMode: Global.privateMode.value, windowLevel: windowLevel)
     }
     #endif
 

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -22,7 +22,6 @@ class InputController: IMKInputController {
     private var targetApp: TargetApplication! = nil
     private var cancellables: Set<AnyCancellable> = []
     private static let notFoundRange = NSRange(location: NSNotFound, length: NSNotFound)
-    private let candidatesPanel: CandidatesPanel
     /// 変換候補として選択されている単語を流すストリーム
     private let selectedWord = PassthroughSubject<Word.Word?, Never>()
     /// 入力を処理しないで直接入力させるかどうか
@@ -35,11 +34,6 @@ class InputController: IMKInputController {
     private var windowLevel: NSWindow.Level = .floating
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
-        candidatesPanel = CandidatesPanel(
-            showAnnotationPopover: UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation),
-            candidatesFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidatesFontSize),
-            annotationFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.annotationFontSize)
-        )
         super.init(server: server, delegate: delegate, client: inputClient)
 
         guard let textInput = inputClient as? any IMKTextInput else {
@@ -92,7 +86,10 @@ class InputController: IMKInputController {
                     }
                     if !self.directMode {
                         textInput.selectMode(inputMode.rawValue)
-                        Global.showInputModePanel(at: cursorPosition.origin, inputMode: inputMode, windowLevel: windowLevel)
+                        Global.inputModePanel.show(at: cursorPosition.origin,
+                                                   mode: inputMode,
+                                                   privateMode: Global.privateMode.value,
+                                                   windowLevel: windowLevel)
                     }
                 }
             }
@@ -100,48 +97,48 @@ class InputController: IMKInputController {
         stateMachine.candidateEvent.sink { [weak self] candidates in
             if let self {
                 let showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
-                self.candidatesPanel.setShowAnnotationPopover(showAnnotation)
+                Global.candidatesPanel.setShowAnnotationPopover(showAnnotation)
                 if let candidates {
                     // 下線のスタイルがthickのときに被らないように1ピクセル下に余白を設ける
                     var cursorPosition = candidates.cursorPosition.offsetBy(dx: 0, dy: -1)
                     cursorPosition.size.height += 1
-                    self.candidatesPanel.setCursorPosition(cursorPosition)
+                    Global.candidatesPanel.setCursorPosition(cursorPosition)
 
                     if let page = candidates.page {
                         let currentCandidates: CurrentCandidates = .panel(words: page.words,
                                                                           currentPage: page.current,
                                                                           totalPageCount: page.total)
-                        self.candidatesPanel.setCandidates(currentCandidates, selected: candidates.selected)
-                        self.candidatesPanel.show(windowLevel: self.windowLevel)
+                        Global.candidatesPanel.setCandidates(currentCandidates, selected: candidates.selected)
+                        Global.candidatesPanel.show(windowLevel: self.windowLevel)
                     } else {
                         if candidates.selected.annotations.isEmpty || !showAnnotation {
-                            self.candidatesPanel.orderOut(nil)
+                            Global.candidatesPanel.orderOut(nil)
                         } else {
-                            self.candidatesPanel.show(windowLevel: windowLevel)
+                            Global.candidatesPanel.show(windowLevel: self.windowLevel)
                         }
-                        self.candidatesPanel.setCandidates(.inline, selected: candidates.selected)
+                        Global.candidatesPanel.setCandidates(.inline, selected: candidates.selected)
                     }
                 } else {
                     // 変換→キャンセル→再変換しても注釈が表示されなくならないように状態を変えておく
                     self.selectedWord.send(nil)
-                    self.candidatesPanel.orderOut(nil)
+                    Global.candidatesPanel.orderOut(nil)
                 }
             }
         }.store(in: &cancellables)
-        candidatesPanel.viewModel.$selected.compactMap { $0 }.sink { [weak self] selected in
+        Global.candidatesPanel.viewModel.$selected.compactMap { $0 }.sink { [weak self] selected in
             self?.stateMachine.didSelectCandidate(selected)
             // TODO: バックグラウンドで引いて表示のときだけフォアグラウンドで処理をさせたい
             // TODO: 一度引いた単語を二度引かないようにしたい
             self?.selectedWord.send(selected.word)
         }.store(in: &cancellables)
-        candidatesPanel.viewModel.$doubleSelected.compactMap { $0 }.sink { [weak self] doubleSelected in
+        Global.candidatesPanel.viewModel.$doubleSelected.compactMap { $0 }.sink { [weak self] doubleSelected in
             self?.stateMachine.didDoubleSelectCandidate(doubleSelected)
         }.store(in: &cancellables)
         selectedWord.removeDuplicates().compactMap({ $0 }).sink { [weak self] word in
             if UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation) {
                 if let self, let systemAnnotation = SystemDict.lookup(word), !systemAnnotation.isEmpty {
-                    self.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
-                    self.candidatesPanel.show(windowLevel: self.windowLevel)
+                    Global.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
+                    Global.candidatesPanel.show(windowLevel: self.windowLevel)
                 }
             }
         }.store(in: &cancellables)
@@ -159,12 +156,13 @@ class InputController: IMKInputController {
             if let self {
                 if let completion = dictionary.findCompletion(prefix: yomi) {
                     self.stateMachine.completion = (yomi, completion)
+                    Global.completionPanel.viewModel.completion = completion
                     // 下線分1ピクセル下に余白を設ける
                     let cursorPosition = self.cursorPosition.offsetBy(dx: 0, dy: -1)
-                    Global.showCompletionPanel(at: cursorPosition.origin, completion: completion)
+                    Global.completionPanel.show(at: cursorPosition.origin)
                 } else {
                     self.stateMachine.completion = nil
-                    Global.hideCompletionPanel()
+                    Global.completionPanel.orderOut(nil)
                 }
             }
         }.store(in: &cancellables)
@@ -178,15 +176,15 @@ class InputController: IMKInputController {
             }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameCandidatesFontSize)
-            .sink { [weak self] notification in
+            .sink { notification in
                 if let candidatesFontSize = notification.object as? Int {
-                    self?.candidatesPanel.setCandidatesFontSize(candidatesFontSize)
+                    Global.candidatesPanel.setCandidatesFontSize(candidatesFontSize)
                 }
             }.store(in: &cancellables)
         NotificationCenter.default.publisher(for: notificationNameAnnotationFontSize)
-            .sink { [weak self] notification in
+            .sink { notification in
                 if let annotationFontSize = notification.object as? Int {
-                    self?.candidatesPanel.setAnnotationFontSize(annotationFontSize)
+                    Global.candidatesPanel.setAnnotationFontSize(annotationFontSize)
                 }
             }.store(in: &cancellables)
     }
@@ -261,8 +259,8 @@ class InputController: IMKInputController {
 
     override func deactivateServer(_ sender: Any!) {
         // 他の入力に切り替わるときには入力候補や補完候補は消す + 現在表示中の候補を確定させる
-        candidatesPanel.orderOut(sender)
-        Global.hideCompletionPanel(sender)
+        Global.candidatesPanel.orderOut(sender)
+        Global.completionPanel.orderOut(sender)
         super.deactivateServer(sender)
     }
 
@@ -285,7 +283,7 @@ class InputController: IMKInputController {
         _ = textInput.attributes(forCharacterIndex: 0, lineHeightRectangle: &cursorPosition)
         windowLevel = NSWindow.Level(rawValue: Int(textInput.windowLevel() + 1))
         if !directMode {
-            Global.showInputModePanel(at: cursorPosition.origin, inputMode: inputMode, windowLevel: windowLevel)
+            Global.inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: Global.privateMode.value, windowLevel: windowLevel)
         }
         // キー配列を設定する
         setCustomInputSource(textInput: textInput)
@@ -329,7 +327,7 @@ class InputController: IMKInputController {
     #if DEBUG
     @objc func showPanel() {
         let point = NSPoint(x: 100, y: 500)
-        Global.showInputModePanel(at: point, inputMode: .hiragana, windowLevel: windowLevel)
+        Global.inputModePanel.show(at: point, mode: .hiragana, privateMode: Global.privateMode.value, windowLevel: windowLevel)
     }
     #endif
 

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -242,7 +242,7 @@ final class SettingsViewModel: ObservableObject {
         $directModeApplications.dropFirst().sink { applications in
             let bundleIdentifiers = applications.map { $0.bundleIdentifier }
             UserDefaults.standard.set(bundleIdentifiers, forKey: UserDefaultsKeys.directModeBundleIdentifiers)
-            directModeBundleIdentifiers.send(bundleIdentifiers)
+            Global.directModeBundleIdentifiers.send(bundleIdentifiers)
         }
         .store(in: &cancellables)
 
@@ -252,7 +252,7 @@ final class SettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $workaroundApplications.sink { applications in
-            insertBlankStringBundleIdentifiers.send(applications.filter { $0.insertBlankString }.map { $0.bundleIdentifier })
+            Global.insertBlankStringBundleIdentifiers.send(applications.filter { $0.insertBlankString }.map { $0.bundleIdentifier })
         }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameToggleDirectMode)

--- a/macSKK/View/CompletionPanel.swift
+++ b/macSKK/View/CompletionPanel.swift
@@ -16,9 +16,8 @@ class CompletionPanel: NSPanel {
         level = .floating
     }
 
-    func show(at cursorPosition: NSRect) {
-        var origin = cursorPosition.origin
-        setFrameTopLeftPoint(origin)
+    func show(at point: NSPoint) {
+        setFrameTopLeftPoint(point)
         orderFrontRegardless()
     }
 }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -7,19 +7,12 @@ import SwiftUI
 import UserNotifications
 import os
 
-let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "main")
+nonisolated(unsafe) let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "main")
 var dictionary: UserDict!
 /// 現在のローマ字かな変換ルール
 var kanaRule: Romaji!
 /// デフォルトでもってるローマ字かな変換ルール
 var defaultKanaRule: Romaji!
-let privateMode = CurrentValueSubject<Bool, Never>(false)
-// 直接入力するアプリケーションのBundleIdentifierの集合のコピー。
-// マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。
-// FIXME: NotificationCenter経由で設定画面で変更したことを各InputControllerに通知するようにしてこの変数は消すかも。
-let directModeBundleIdentifiers = CurrentValueSubject<[String], Never>([])
-// モード変更時に空白文字を一瞬追加するワークアラウンドを適用するBundle Identifierの集合
-let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
 // 直接入力モードを切り替えたいときに通知される通知の名前。
 let notificationNameToggleDirectMode = Notification.Name("toggleDirectMode")
 // 空文字挿入のワークアラウンドの有効無効を切り替えたいときに通知される通知の名前。
@@ -59,7 +52,7 @@ struct macSKKApp: App {
         // 環境設定の初期値をSettingsViewModelより先に行う
         Self.setupUserDefaults()
         do {
-            dictionary = try UserDict(dicts: [], privateMode: privateMode)
+            dictionary = try UserDict(dicts: [], privateMode: Global.privateMode)
             dictionariesDirectoryUrl = try FileManager.default.url(
                 for: .documentDirectory,
                 in: .userDomainMask,
@@ -243,7 +236,7 @@ struct macSKKApp: App {
 
     private func setupDirectMode() {
         if let bundleIdentifiers = UserDefaults.standard.array(forKey: "directModeBundleIdentifiers") as? [String] {
-            directModeBundleIdentifiers.send(bundleIdentifiers)
+            Global.directModeBundleIdentifiers.send(bundleIdentifiers)
         }
     }
 


### PR DESCRIPTION
Global.swiftを追加して、メインスレッドからのみ参照できるグローバル変数の一部を配置するようにします。
目的は次の2つです。

1. Xcode 15.3でビルドするとSwift 6でエラーになるSwift Concurrency系の警告の一部の修正
2. IMKInputControllerごとに変換候補パネルや補完候補パネルなどのGUIリソースを作らずにグローバルに1つだけ持つようにする

ほんとうはローマ字かな変換ルールやユーザー辞書などもおそらくメインスレッドからのみ参照可能にできると思うんですが、ユニットテストがうまく通らなかったのでまずは簡単なところからやることにしました。

- プライベートモードかどうかのCombineのSubject
  - GlobalをObservableObjectにして `@Published` にしてもいいかも…? (以下も)
- 直接入力になっているBundle Identifiersの集合であるCombineのSubject
- ワークアラウンドを行うBundle Identifiersの集合であるCombineのSubject
- IMKInputControllerごとにもっていた入力モード、変換候補表示、補完候補表示のパネル