### PR TITLE
送り仮名が未入力で変換すると空文字列を送り仮名として使用してしまうバグを修正

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -387,9 +387,9 @@ struct SelectingState: Equatable, MarkedTextProtocol {
         }
     }
 
-    /// 送り仮名
+    /// 送り仮名。ComposingStateのokuriは空配列の場合があるが、その場合はnilを返す
     var okuri: String? {
-        if let okuri = prev.composing.okuri {
+        if let okuri = prev.composing.okuri, !okuri.isEmpty {
             return okuri.map { $0.kana }.joined()
         } else {
             return nil
@@ -463,9 +463,9 @@ struct RegisterState: SpecialStateProtocol {
         }
     }
 
-    /// 送り仮名
+    /// 送り仮名。ComposingStateのokuriは空配列の場合があるが、その場合はnilを返す
     var okuri: String? {
-        if let okuri = prev.composing.okuri {
+        if let okuri = prev.composing.okuri, !okuri.isEmpty {
             return okuri.map { $0.kana }.joined()
         } else {
             return nil
@@ -659,7 +659,7 @@ struct IMEState {
                 let mode = registerState.prev.mode
                 let composing = registerState.prev.composing
                 var yomi = composing.subText().joined()
-                if let okuri = composing.okuri {
+                if let okuri = composing.okuri, !okuri.isEmpty {
                     yomi += "*" + okuri.map { $0.string(for: mode) }.joined()
                 }
                 elements.append(.plain("[登録：\(yomi)]"))

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -821,7 +821,7 @@ final class StateMachine {
         } else if yomiText.hasPrefix(">") {
             yomiText = String(yomiText.dropFirst())
             candidateWords = candidates(for: yomiText, option: .suffix) + candidates(for: yomiText, option: nil)
-        } else if let okuri = composing.okuri {
+        } else if let okuri = composing.okuri, !okuri.isEmpty {
             candidateWords = candidates(for: yomiText, option: .okuri(okuri.map { $0.kana }.joined()))
         } else {
             candidateWords = candidates(for: yomiText, option: nil)

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -267,6 +267,25 @@ final class StateTests: XCTestCase {
             remain: nil
         )
         XCTAssertEqual(selectingState.okuri, "る")
+
+        selectingState = SelectingState(
+            prev: SelectingState.PrevState(
+                mode: .hiragana,
+                composing: ComposingState(
+                    isShift: true,
+                    text: ["あ"],
+                    okuri: [], // 送り仮名入力モードだけど送り仮名が入力されてない状態
+                    romaji: ""
+                )
+            ),
+            yomi: "あ",
+            candidates: [Candidate("有")],
+            candidateIndex: 0,
+            cursorPosition: .zero,
+            remain: nil
+        )
+        XCTAssertNil(selectingState.okuri)
+
     }
 
     func testRegisterStateAppendText() throws {
@@ -311,6 +330,15 @@ final class StateTests: XCTestCase {
         state = state.moveCursorFirst().dropForward()
         XCTAssertEqual(state.text, "い")
         XCTAssertEqual(state.cursor, 0)
+    }
+
+    func testRegisterStateEmptyOkuri() {
+        // StickyShiftなどで送り仮名の入力モードになっているけど送り仮名自体はまだ入力されてない状態
+        let prevComposingState = ComposingState(isShift: true, text: ["あ"], okuri: [], romaji: "")
+        let state = RegisterState(
+            prev: RegisterState.PrevState(mode: .hiragana, composing: prevComposingState),
+            yomi: "あ", text: "あいう", cursor: nil)
+        XCTAssertNil(state.okuri)
     }
 
     func testUnregisterState() throws {


### PR DESCRIPTION
使っていて気付いたバグを修正。

`Shift-A, StickyShift, Space` のように入力すると送り仮名が空 ( `あ*` ) の状態で変換を行います。
変換候補自体は上記の例だと読みが「あ」であるものを見つけてはくれるのですが、その後ユーザー辞書に保存するときに `あ /[亜]/` のように(空文字列の)送り仮名があるかのように取り扱ってしまうバグがあることがわかりました。このバグを修正します。

同様に辞書にない読みが入力されたときは `[登録：あ*]` のように表示されていたのですが、これも `[登録：あ]` と空の送り仮名は入力してないように扱うようにします。