### PR TITLE
グローバル変数でもっていたユーザー辞書をMainActorからのみ触れるようにする

### DIFF
--- a/macSKK/AppDelegate.swift
+++ b/macSKK/AppDelegate.swift
@@ -6,7 +6,7 @@ import Cocoa
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")
-        try? dictionary.save()
+        try? Global.dictionary.save()
         return .terminateNow
     }
 }

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -9,6 +9,8 @@ import Combine
  */
 @MainActor struct Global {
     static let shared = Global()
+    /// 利用可能な辞書の集合
+    static var dictionary: UserDict!
     static let privateMode = CurrentValueSubject<Bool, Never>(false)
     // 直接入力するアプリケーションのBundleIdentifierの集合のコピー。
     // マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -154,7 +154,7 @@ class InputController: IMKInputController {
         }.store(in: &cancellables)
         stateMachine.yomiEvent.sink { [weak self] yomi in
             if let self {
-                if let completion = dictionary.findCompletion(prefix: yomi) {
+                if let completion = Global.dictionary.findCompletion(prefix: yomi) {
                     self.stateMachine.completion = (yomi, completion)
                     Global.completionPanel.viewModel.completion = completion
                     // 下線分1ピクセル下に余白を設ける
@@ -299,7 +299,7 @@ class InputController: IMKInputController {
 
     @objc func saveDict() {
         do {
-            try dictionary.save()
+            try Global.dictionary.save()
         } catch {
             // TODO: NotificationCenterでユーザーに通知する
             logger.error("ユーザー辞書保存中にエラーが発生しました")

--- a/macSKK/Release.swift
+++ b/macSKK/Release.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-struct Release {
+struct Release: Sendable {
     let version: ReleaseVersion
     let updated: Date
     let url: URL

--- a/macSKK/ReleaseVersion.swift
+++ b/macSKK/ReleaseVersion.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// リリースされたバージョン番号。PackageDescription.Versionと同じようにセマンティックバージョニングを採用しています。
-struct ReleaseVersion: Comparable, CustomStringConvertible {
+struct ReleaseVersion: Comparable, CustomStringConvertible, Sendable {
     // 将来その下にベータとかアルファの情報を追加するかも
     let major: Int
     let minor: Int

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -197,7 +197,7 @@ final class SettingsViewModel: ObservableObject {
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
             let enabledDicts = dictSettings.compactMap { dictSetting -> FileDict? in
-                let dict = dictionary.fileDict(id: dictSetting.id)
+                let dict = Global.dictionary.fileDict(id: dictSetting.id)
                 if dictSetting.enabled {
                     // 無効だった辞書が有効化された、もしくは辞書のエンコーディング設定が変わったら読み込む
                     if dictSetting.encoding != dict?.encoding {
@@ -222,7 +222,7 @@ final class SettingsViewModel: ObservableObject {
                     return nil
                 }
             }
-            dictionary.dicts = enabledDicts
+            Global.dictionary.dicts = enabledDicts
             UserDefaults.standard.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
         }
         .store(in: &cancellables)
@@ -231,10 +231,10 @@ final class SettingsViewModel: ObservableObject {
             if setting.enabled {
                 let destination = SKKServDestination(host: setting.address, port: setting.port, encoding: setting.encoding)
                 logger.log("skkserv辞書を設定します")
-                dictionary.skkservDict = SKKServDict(destination: destination)
+                Global.dictionary.skkservDict = SKKServDict(destination: destination)
             } else {
                 logger.log("skkserv辞書は無効化されています")
-                dictionary.skkservDict = nil
+                Global.dictionary.skkservDict = nil
             }
             UserDefaults.standard.set(setting.encode(), forKey: UserDefaultsKeys.skkservClient)
         }.store(in: &cancellables)
@@ -325,7 +325,7 @@ final class SettingsViewModel: ObservableObject {
 
         NotificationCenter.default.publisher(for: notificationNameDictLoad).receive(on: RunLoop.main).sink { [weak self] notification in
             if let loadEvent = notification.object as? DictLoadEvent, let self {
-                if let userDict = dictionary.userDict as? FileDict, userDict.id == loadEvent.id {
+                if let userDict = Global.dictionary.userDict as? FileDict, userDict.id == loadEvent.id {
                     self.userDictLoadingStatus = loadEvent.status
                     if case .fail(let error) = loadEvent.status {
                         UNNotifier.sendNotificationForUserDict(readError: error)

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -101,7 +101,7 @@ final class StateMachine {
                     if unregisterState.text == "yes" {
                         let word = unregisterState.prev.selecting.candidates[
                             unregisterState.prev.selecting.candidateIndex]
-                        _ = dictionary.delete(yomi: unregisterState.prev.selecting.yomi, word: word.word)
+                        _ = Global.dictionary.delete(yomi: unregisterState.prev.selecting.yomi, word: word.word)
                         state.inputMode = unregisterState.prev.mode
                         state.inputMethod = .normal
                         state.specialState = nil
@@ -1113,8 +1113,8 @@ final class StateMachine {
     }
 
     /// 見出し語で辞書を引く。同じ文字列である変換候補が複数の辞書にある場合は最初の1つにまとめる。
-    func candidates(for yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
-        return dictionary.referDicts(yomi, option: option)
+    @MainActor func candidates(for yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
+        return Global.dictionary.referDicts(yomi, option: option)
     }
 
     /**
@@ -1127,8 +1127,8 @@ final class StateMachine {
      *   - okuri: 送り仮名として確定したひらがな。"A Ru" のように入力した場合 "る" の部分。
      *   - candidate: 追加したい変換候補
      */
-    func addWordToUserDict(yomi: String, okuri: String?, candidate: Candidate, annotation: Annotation? = nil) {
-        dictionary.add(yomi: candidate.toMidashiString(yomi: yomi),
+    @MainActor func addWordToUserDict(yomi: String, okuri: String?, candidate: Candidate, annotation: Annotation? = nil) {
+        Global.dictionary.add(yomi: candidate.toMidashiString(yomi: yomi),
                        word: Word(candidate.candidateString, okuri: okuri, annotation: annotation))
     }
 
@@ -1144,7 +1144,7 @@ final class StateMachine {
     }
 
     /// StateMachine外で選択されている変換候補が二回選択されたときに通知される
-    func didDoubleSelectCandidate(_ candidate: Candidate) {
+    @MainActor func didDoubleSelectCandidate(_ candidate: Candidate) {
         if case .selecting(let selecting) = state.inputMethod {
             addWordToUserDict(yomi: selecting.yomi, okuri: selecting.okuri, candidate: candidate)
             updateCandidates(selecting: nil)

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -716,7 +716,6 @@ final class StateMachine {
                         // 送り仮名が1文字以上確定した時点で変換を開始する
                         // 変換候補がないときは辞書登録へ
                         // カーソル位置がnilじゃないときはその前までで変換を試みる
-                        let subText: [String] = composing.subText()
                         let newComposing = ComposingState(isShift: true,
                                                           text: composing.text,
                                                           okuri: (okuri ?? []) + [moji],

--- a/macSKK/SystemDict.swift
+++ b/macSKK/SystemDict.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// Dictionary Serviceを使ってシステム辞書から検索する
-class SystemDict {
+@MainActor class SystemDict {
     private static let dictionary: DCSDictionary? = findSystemJapaneseDict()
 
     class func lookup(_ word: String) -> String? {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -5,6 +5,7 @@ import Combine
 import Foundation
 
 /// ユーザー辞書。マイ辞書 (単語登録対象。ファイル名固定) とファイル辞書 をまとめて参照することができる。
+/// v0.22.0以降はskkservサーバーを辞書としても利用することが可能。
 ///
 /// TODO: ファイル辞書にしかない単語を削除しようとしたときにどうやってそれを記録するか。NG登録?
 class UserDict: NSObject, DictProtocol {

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -8,7 +8,6 @@ import UserNotifications
 import os
 
 nonisolated(unsafe) let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "main")
-var dictionary: UserDict!
 // 直接入力モードを切り替えたいときに通知される通知の名前。
 let notificationNameToggleDirectMode = Notification.Name("toggleDirectMode")
 // 空文字挿入のワークアラウンドの有効無効を切り替えたいときに通知される通知の名前。
@@ -48,7 +47,7 @@ struct macSKKApp: App {
         // 環境設定の初期値をSettingsViewModelより先に行う
         Self.setupUserDefaults()
         do {
-            dictionary = try UserDict(dicts: [], privateMode: Global.privateMode)
+            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode)
             dictionariesDirectoryUrl = try FileManager.default.url(
                 for: .documentDirectory,
                 in: .userDomainMask,
@@ -119,7 +118,7 @@ struct macSKKApp: App {
                 }
                 Button("Save User Directory") {
                     do {
-                        try dictionary.save()
+                        try Global.dictionary.save()
                     } catch {
                         print(error)
                     }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -15,8 +15,8 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor override func setUpWithError() throws {
-        dictionary.setEntries([:])
-        dictionary.skkservDict = nil
+        Global.dictionary.setEntries([:])
+        Global.dictionary.skkservDict = nil
         cancellables = []
         // テストごとにローマ字かな変換ルールをデフォルトに戻す
         // こうしないとテストの中でGlobal.kanaRuleを書き換えるテストと一緒に走らせると違うかな変換ルールのままに実行されてしまう
@@ -724,7 +724,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingSpaceOkurinashi() {
-        dictionary.setEntries(["と": [Word("戸"), Word("都")]])
+        Global.dictionary.setEntries(["と": [Word("戸"), Word("都")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -748,7 +748,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingPrefix() {
-        dictionary.setEntries(["あ>": [Word("亜")], "あ": [Word("阿")]])
+        Global.dictionary.setEntries(["あ>": [Word("亜")], "あ": [Word("阿")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -768,7 +768,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingPrefixAbbrev() {
-        dictionary.setEntries(["A": [Word("Å")]])
+        Global.dictionary.setEntries(["A": [Word("Å")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -788,7 +788,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingSuffix() {
-        dictionary.setEntries([">あ": [Word("亜")], "あ": [Word("阿")]])
+        Global.dictionary.setEntries([">あ": [Word("亜")], "あ": [Word("阿")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -816,7 +816,7 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testHandleComposingNumber() {
         let entries = ["だい#": [Word("第#1"), Word("第#0"), Word("第#2"), Word("第#3")], "だい2": [Word("第2")]]
-        dictionary.dicts.append(MemoryDict(entries: entries, readonly: true))
+        Global.dictionary.dicts.append(MemoryDict(entries: entries, readonly: true))
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -853,19 +853,19 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "d", withShift: true)))
-        XCTAssertEqual(dictionary.userDict?.refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
+        XCTAssertEqual(Global.dictionary.userDict?.refer("だい#", option: nil), [Word("第#3")], "ユーザー辞書には#形式で保存する")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "2")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.userDict?.refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
+        XCTAssertEqual(Global.dictionary.userDict?.refer("だい2", option: nil), [Word("第2")], "数値変換より通常のエントリを優先する")
         wait(for: [expectation], timeout: 1.0)
     }
 
     // 送り仮名入力でShiftキーを押すのを子音側でするパターン
     @MainActor func testHandleComposingOkuriari() {
-        dictionary.setEntries(["とr": [Word("取"), Word("撮")]])
+        Global.dictionary.setEntries(["とr": [Word("取"), Word("撮")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -892,7 +892,7 @@ final class StateMachineTests: XCTestCase {
 
     // 送り仮名入力でShiftキーを押すのを母音側にしたパターン
     @MainActor func testHandleComposingOkuriari2() {
-        dictionary.setEntries(["とらw": [Word("捕"), Word("捉")]])
+        Global.dictionary.setEntries(["とらw": [Word("捕"), Word("捉")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -923,7 +923,7 @@ final class StateMachineTests: XCTestCase {
 
     // 送り仮名入力でShiftキーを押すのを途中の子音でするパターン
     @MainActor func testHandleComposingOkuriari3() {
-        dictionary.setEntries(["とr": [Word("取"), Word("撮")]])
+        Global.dictionary.setEntries(["とr": [Word("取"), Word("撮")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -952,7 +952,7 @@ final class StateMachineTests: XCTestCase {
 
     // 送り仮名が空の状態で変換したとき
     @MainActor func testHandleComposingEmptyOkuri() {
-        dictionary.setEntries(["え": [Word("絵")]])
+        Global.dictionary.setEntries(["え": [Word("絵")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -968,11 +968,11 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(dictionary.refer("え"), [Word("絵", okuri: nil)], "送り仮名が空文字列で登録されない (エンバグ防止)")
+        XCTAssertEqual(Global.dictionary.refer("え"), [Word("絵", okuri: nil)], "送り仮名が空文字列で登録されない (エンバグ防止)")
     }
 
     @MainActor func testHandleComposingOkuriariIncludeN() {
-        dictionary.setEntries(["かんj": [Word("感")]])
+        Global.dictionary.setEntries(["かんj": [Word("感")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -996,7 +996,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingOkuriSokuon() {
-        dictionary.setEntries(["あt": [Word("会")]])
+        Global.dictionary.setEntries(["あt": [Word("会")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1015,7 +1015,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingOkuriSokuon2() {
-        dictionary.setEntries(["あt": [Word("会")]])
+        Global.dictionary.setEntries(["あt": [Word("会")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1036,7 +1036,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingOkuriSokuon3() {
-        dictionary.setEntries(["やっt": [Word("八")]])
+        Global.dictionary.setEntries(["やっt": [Word("八")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1057,7 +1057,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingOkuriN() {
-        dictionary.setEntries(["あn": [Word("編")]])
+        Global.dictionary.setEntries(["あn": [Word("編")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1076,7 +1076,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingStickyShiftN() {
-        dictionary.setEntries(["あn": [Word("編")]])
+        Global.dictionary.setEntries(["あn": [Word("編")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1097,7 +1097,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingOkuriQ() {
-        dictionary.setEntries(["おu": [Word("追")]])
+        Global.dictionary.setEntries(["おu": [Word("追")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1116,7 +1116,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingOkuriCursor() {
-        dictionary.setEntries(["あu": [Word("会")]])
+        Global.dictionary.setEntries(["あu": [Word("会")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1135,7 +1135,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingCursorSpace() {
-        dictionary.setEntries(["え": [Word("絵")]])
+        Global.dictionary.setEntries(["え": [Word("絵")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1412,7 +1412,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingLeft() {
-        dictionary.setEntries(["あs": [Word("褪")]])
+        Global.dictionary.setEntries(["あs": [Word("褪")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1474,7 +1474,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingLeftOkuri() {
-        dictionary.setEntries(["あs": [Word("褪")]])
+        Global.dictionary.setEntries(["あs": [Word("褪")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1624,7 +1624,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleComposingAbbrevSpace() {
-        dictionary.setEntries(["n": [Word("美")]])
+        Global.dictionary.setEntries(["n": [Word("美")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1657,7 +1657,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleRegisteringEnter() {
-        dictionary.setEntries(["お": [Word("尾")]])
+        Global.dictionary.setEntries(["お": [Word("尾")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1681,7 +1681,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.refer("あ"), [Word("そ尾")])
+        XCTAssertEqual(Global.dictionary.refer("あ"), [Word("そ尾")])
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1698,7 +1698,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.refer("あ"), [])
+        XCTAssertEqual(Global.dictionary.refer("あ"), [])
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1844,7 +1844,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleRegisterN() {
-        dictionary.setEntries(["もん": [Word("門")]])
+        Global.dictionary.setEntries(["もん": [Word("門")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1921,12 +1921,12 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.refer("あk"), [Word("い", okuri: "け")], "単語登録時に使用した送り仮名が辞書にセットされる")
+        XCTAssertEqual(Global.dictionary.refer("あk"), [Word("い", okuri: "け")], "単語登録時に使用した送り仮名が辞書にセットされる")
         wait(for: [expectation], timeout: 1.0)
     }
 
     @MainActor func testHandleSelectingEnter() {
-        dictionary.setEntries(["と": [Word("戸")]])
+        Global.dictionary.setEntries(["と": [Word("戸")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1945,7 +1945,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingEnterOkuriari() {
-        dictionary.setEntries(["とr": [Word("取")]])
+        Global.dictionary.setEntries(["とr": [Word("取")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1966,7 +1966,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingOkuriBlock() {
-        dictionary.setEntries(["おおk": [Word("多"), Word("大", okuri: "き")]])
+        Global.dictionary.setEntries(["おおk": [Word("多"), Word("大", okuri: "き")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1988,7 +1988,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingEnterRemain() {
-        dictionary.setEntries(["あい": [Word("愛")]])
+        Global.dictionary.setEntries(["あい": [Word("愛")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2012,7 +2012,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingPrintableRemain() {
-        dictionary.setEntries(["あい": [Word("愛")]])
+        Global.dictionary.setEntries(["あい": [Word("愛")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2037,7 +2037,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingBackspace() {
-        dictionary.setEntries(["と": [Word("戸"), Word("都")]])
+        Global.dictionary.setEntries(["と": [Word("戸"), Word("都")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2061,7 +2061,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingTab() {
-        dictionary.setEntries(["お": [Word("尾")]])
+        Global.dictionary.setEntries(["お": [Word("尾")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2077,7 +2077,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingStickyShift() {
-        dictionary.setEntries(["と": [Word("戸")]])
+        Global.dictionary.setEntries(["と": [Word("戸")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2097,7 +2097,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingCancel() {
-        dictionary.setEntries(["と": [Word("戸"), Word("都")]])
+        Global.dictionary.setEntries(["と": [Word("戸"), Word("都")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2118,7 +2118,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingSpaceBackspace() {
-        dictionary.setEntries(["あ": "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { Word(String($0)) }])
+        Global.dictionary.setEntries(["あ": "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { Word(String($0)) }])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2174,7 +2174,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingCtrlACtrlE() {
-        dictionary.setEntries(["と": [Word("戸"), Word("都"), Word("徒"), Word("途"), Word("斗")]])
+        Global.dictionary.setEntries(["と": [Word("戸"), Word("都"), Word("徒"), Word("途"), Word("斗")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2209,7 +2209,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingPrev() {
-        dictionary.setEntries(["と": [Word("戸"), Word("都"), Word("徒"), Word("途"), Word("斗")]])
+        Global.dictionary.setEntries(["と": [Word("戸"), Word("都"), Word("徒"), Word("途"), Word("斗")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2235,7 +2235,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingCtrlY() {
-        dictionary.setEntries(["と": [Word("戸")]])
+        Global.dictionary.setEntries(["と": [Word("戸")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2253,7 +2253,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingNum() {
-        dictionary.setEntries(["あ": "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { Word(String($0)) }])
+        Global.dictionary.setEntries(["あ": "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { Word(String($0)) }])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2290,7 +2290,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testHandleSelectingUnregister() {
-        dictionary.setEntries(["え": [Word("絵")]])
+        Global.dictionary.setEntries(["え": [Word("絵")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2314,12 +2314,12 @@ final class StateMachineTests: XCTestCase {
             XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: character)))
         }
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.refer("え"), [])
+        XCTAssertEqual(Global.dictionary.refer("え"), [])
         wait(for: [expectation], timeout: 1.0)
     }
 
     @MainActor func testHandleSelectingUnregisterCancel() {
-        dictionary.setEntries(["え": [Word("絵")]])
+        Global.dictionary.setEntries(["え": [Word("絵")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2334,12 +2334,12 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "x", withShift: true)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertEqual(dictionary.refer("え"), [Word("絵")])
+        XCTAssertEqual(Global.dictionary.refer("え"), [Word("絵")])
         wait(for: [expectation], timeout: 1.0)
     }
 
     @MainActor func testHandleSelectingRememberCursor() {
-        dictionary.setEntries(["え": [Word("絵")], "えr": [Word("得")]])
+        Global.dictionary.setEntries(["え": [Word("絵")], "えr": [Word("得")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2368,14 +2368,14 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testHandleSelectingMergeAnnotations() {
         let annotation0 = Annotation(dictId: Annotation.userDictId, text: "user")
-        dictionary.setEntries(["う": [Word("雨", annotation: annotation0)]])
+        Global.dictionary.setEntries(["う": [Word("雨", annotation: annotation0)]])
         let annotation1 = Annotation(dictId: "dict1", text: "dict1")
         let annotation2 = Annotation(dictId: "dict2", text: "dict2")
         let annotation3 = Annotation(dictId: "dict3", text: "dict2")
         let dict1 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation1)]], readonly: true)
         let dict2 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation2)]], readonly: true)
         let dict3 = MemoryDict(entries: ["う": [Word("雨", annotation: annotation3)]], readonly: true)
-        dictionary.dicts = [dict1, dict2, dict3]
+        Global.dictionary.dicts = [dict1, dict2, dict3]
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2399,7 +2399,7 @@ final class StateMachineTests: XCTestCase {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
         let dict = MemoryDict(entries: ["と": [Word("都")]], readonly: true)
-        dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode)
+        Global.dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode)
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2411,14 +2411,14 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[3], .fixedText("都"))
             expectation.fulfill()
         }.store(in: &cancellables)
-        XCTAssertNil(dictionary.entries())
-        XCTAssertTrue(dictionary.privateUserDict.entries.isEmpty)
+        XCTAssertNil(Global.dictionary.entries())
+        XCTAssertTrue(Global.dictionary.privateUserDict.entries.isEmpty)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .space, originalEvent: nil, cursorPosition: .zero)))
         XCTAssertTrue(stateMachine.handle(Action(keyEvent: .enter, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertNil(dictionary.entries())
-        XCTAssertFalse(dictionary.privateUserDict.entries.isEmpty)
+        XCTAssertNil(Global.dictionary.entries())
+        XCTAssertFalse(Global.dictionary.privateUserDict.entries.isEmpty)
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -2447,7 +2447,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testCommitCompositionSelecting() {
-        dictionary.setEntries(["え": [Word("絵")]])
+        Global.dictionary.setEntries(["え": [Word("絵")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2484,7 +2484,7 @@ final class StateMachineTests: XCTestCase {
     }
 
     @MainActor func testCommitCompositionUnregister() {
-        dictionary.setEntries(["お": [Word("尾")]])
+        Global.dictionary.setEntries(["お": [Word("尾")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -2505,17 +2505,17 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testAddWordToUserDict() {
+    @MainActor func testAddWordToUserDict() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         stateMachine.addWordToUserDict(yomi: "あ", okuri: nil, candidate: Candidate("あああ"))
-        XCTAssertEqual(dictionary.refer("あ"), [Word("あああ", annotation: nil)])
+        XCTAssertEqual(Global.dictionary.refer("あ"), [Word("あああ", annotation: nil)])
         let annotation = Annotation(dictId: "test", text: "test辞書の注釈")
         stateMachine.addWordToUserDict(yomi: "い", okuri: nil, candidate: Candidate("いいい"), annotation: annotation)
-        XCTAssertEqual(dictionary.refer("い"), [Word("いいい", annotation: annotation)])
+        XCTAssertEqual(Global.dictionary.refer("い"), [Word("いいい", annotation: annotation)])
         stateMachine.addWordToUserDict(yomi: "だい1", okuri: nil, candidate: Candidate("第一", original: Candidate.Original(midashi: "だい#", word: "第#3")))
-        XCTAssertEqual(dictionary.refer("だい#"), [Word("第#3", annotation: nil)])
+        XCTAssertEqual(Global.dictionary.refer("だい#"), [Word("第#3", annotation: nil)])
         stateMachine.addWordToUserDict(yomi: "いt", okuri: "った", candidate: Candidate("言"))
-        XCTAssertEqual(dictionary.refer("いt"), [Word("言", okuri: "った", annotation: nil)])
+        XCTAssertEqual(Global.dictionary.refer("いt"), [Word("言", okuri: "った", annotation: nil)])
     }
 
     private func printableKeyEventAction(character: Character, characterIgnoringModifier: Character? = nil, withShift: Bool = false) -> Action {


### PR DESCRIPTION
#147 #150 と同様。
Xcode 15.3でビルドすると、Swift 6でエラーになるSwift Concurrency系の警告が出ているため、その修正の一部としてdictionary (ユーザー辞書やファイル辞書、skkserv辞書) もGlobal構造体でもつようにします。
また小さなコンパイル時警告も解消します。まだ警告0にはできてないです。