### PR TITLE
ユーザー辞書の読み込み状態が設定画面に反映されないバグを修正

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -11,6 +11,8 @@ import Combine
     static let shared = Global()
     /// 利用可能な辞書の集合
     static var dictionary: UserDict!
+    /// skkserv辞書
+    static var skkservDict: SKKServDict? = nil
     static let privateMode = CurrentValueSubject<Bool, Never>(false)
     // 直接入力するアプリケーションのBundleIdentifierの集合のコピー。
     // マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -231,10 +231,10 @@ final class SettingsViewModel: ObservableObject {
             if setting.enabled {
                 let destination = SKKServDestination(host: setting.address, port: setting.port, encoding: setting.encoding)
                 logger.log("skkserv辞書を設定します")
-                Global.dictionary.skkservDict = SKKServDict(destination: destination)
+                Global.skkservDict = SKKServDict(destination: destination)
             } else {
                 logger.log("skkserv辞書は無効化されています")
-                Global.dictionary.skkservDict = nil
+                Global.skkservDict = nil
             }
             UserDefaults.standard.set(setting.encode(), forKey: UserDefaultsKeys.skkservClient)
         }.store(in: &cancellables)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -21,8 +21,6 @@ class UserDict: NSObject, DictProtocol {
     var userDict: (any DictProtocol)?
     /// 有効になっている辞書。優先度が高い順。
     var dicts: [any DictProtocol]
-    /// skkserv辞書
-    var skkservDict: SKKServDict? = nil
     /**
      * プライベートモードのユーザー辞書。プライベートモードが有効な時に変換や単語登録するとユーザー辞書とは別に更新されます。
      *
@@ -114,14 +112,14 @@ class UserDict: NSObject, DictProtocol {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - option: 辞書を引くときに接頭辞や接尾辞から検索するかどうか。nilなら通常のエントリから検索する
      */
-    func referDicts(_ yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
+    @MainActor func referDicts(_ yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
         var result: [Candidate] = []
         var candidates = refer(yomi, option: option).map { word in
             let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
             return Candidate(word.word, annotations: annotations)
         }
         // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
-        if let skkservDict {
+        if let skkservDict = Global.skkservDict {
             let skkservCandidates: [Candidate] = skkservDict.refer(yomi, option: option).map { word in
                 let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
                 return Candidate(word.word, annotations: annotations)

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -47,7 +47,6 @@ struct macSKKApp: App {
         // 環境設定の初期値をSettingsViewModelより先に行う
         Self.setupUserDefaults()
         do {
-            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode)
             dictionariesDirectoryUrl = try FileManager.default.url(
                 for: .documentDirectory,
                 in: .userDomainMask,
@@ -56,6 +55,9 @@ struct macSKKApp: App {
             ).appendingPathComponent("Dictionaries")
             let settingsViewModel = try SettingsViewModel(dictionariesDirectoryUrl: dictionariesDirectoryUrl)
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
+            
+            // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
+            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode)
             settingsWindowController = NSWindowController(window: settingsWindow)
             self.settingsViewModel = settingsViewModel
             settingsWindowController.windowFrameAutosaveName = "Settings"


### PR DESCRIPTION
設定画面の辞書で、ユーザー辞書の読み込み状態が「読み込み中」のままになってしまうバグを修正します。
ユーザー辞書の読み込みをSettingsViewModelの初期化より行っていたため、SettingsViewModelの初期化時にやる「辞書読み込み状態変更イベントの購読」より先にユーザー辞書を読み込んでしまっていたため。