### PR TITLE
キーバインドをソースコードで固定していたのを修正

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		CE06CA2D2AAC172F00E80E5E /* empty.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE06CA2C2AAC172F00E80E5E /* empty.txt */; };
 		CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */; };
 		CE11C7B52BDD461C00A35F3D /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7B42BDD461C00A35F3D /* Global.swift */; };
+		CE11C7BD2BE47D5D00A35F3D /* KeyBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7BC2BE47D5D00A35F3D /* KeyBindingView.swift */; };
+		CE11C7BF2BE47D9800A35F3D /* KeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */; };
 		CE1B00552BA3DDEB00C830FD /* SKKServDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B00542BA3DDEB00C830FD /* SKKServDict.swift */; };
 		CE1B00622BA4286800C830FD /* Message+SKKServ.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B00612BA4286800C830FD /* Message+SKKServ.swift */; };
 		CE1B00642BA4287C00C830FD /* SKKServRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B00632BA4287C00C830FD /* SKKServRequest.swift */; };
@@ -156,6 +158,8 @@
 		CE06CA2C2AAC172F00E80E5E /* empty.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
 		CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDict+Utilities.swift"; sourceTree = "<group>"; };
 		CE11C7B42BDD461C00A35F3D /* Global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Global.swift; sourceTree = "<group>"; };
+		CE11C7BC2BE47D5D00A35F3D /* KeyBindingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingView.swift; sourceTree = "<group>"; };
+		CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBinding.swift; sourceTree = "<group>"; };
 		CE1B00542BA3DDEB00C830FD /* SKKServDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServDict.swift; sourceTree = "<group>"; };
 		CE1B00612BA4286800C830FD /* Message+SKKServ.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+SKKServ.swift"; sourceTree = "<group>"; };
 		CE1B00632BA4287C00C830FD /* SKKServRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServRequest.swift; sourceTree = "<group>"; };
@@ -364,6 +368,7 @@
 				CEA78FAF2964209B00B67E25 /* UserDict.swift */,
 				CEADA44A2B025A0F0026E2BD /* Entry.swift */,
 				CE84A3E6295DA4DA009394C4 /* Romaji.swift */,
+				CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */,
 				CE3E44AC2B5391DB00105798 /* SettingsWatcher.swift */,
 				CE40D9A22A6D0C3900D44799 /* SystemDict.swift */,
 				CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */,
@@ -461,6 +466,7 @@
 				CEC376EA2965211200D9C432 /* KeyEventView.swift */,
 				CE40D9A02A6D0C2F00D44799 /* SystemDictView.swift */,
 				CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */,
+				CE11C7BC2BE47D5D00A35F3D /* KeyBindingView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -753,6 +759,7 @@
 				CE496C8C2B43968A001C623C /* LogView.swift in Sources */,
 				CEE3717529653112000DB2C3 /* SoftwareUpdateView.swift in Sources */,
 				CE496C912B440892001C623C /* URL+Additions.swift in Sources */,
+				CE11C7BD2BE47D5D00A35F3D /* KeyBindingView.swift in Sources */,
 				CE39DB212A8DFD8F00BC619F /* MarkedText.swift in Sources */,
 				CE40D9A32A6D0C3900D44799 /* SystemDict.swift in Sources */,
 				CE5EB6AD2AAC0DE000389B98 /* FileDict.swift in Sources */,
@@ -760,6 +767,7 @@
 				CEC376E82965199500D9C432 /* SettingsView.swift in Sources */,
 				CEC376EB2965211200D9C432 /* KeyEventView.swift in Sources */,
 				CE6DBAB02A85AA1200F5A227 /* LatestReleaseFetcher.swift in Sources */,
+				CE11C7BF2BE47D9800A35F3D /* KeyBinding.swift in Sources */,
 				CE6DBACD2A864A3B00F5A227 /* DictionariesView.swift in Sources */,
 				CEF0823A296BCDB000646366 /* InputModePanel.swift in Sources */,
 			);

--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CE2157662B2EA985006E4C41 /* UserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */; };
 		CE313A1F2AF5213700A49142 /* Candidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE313A1E2AF5213700A49142 /* Candidate.swift */; };
 		CE39DB212A8DFD8F00BC619F /* MarkedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39DB202A8DFD8F00BC619F /* MarkedText.swift */; };
+		CE39FA952BEB942B00E293F0 /* Character+KeyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */; };
 		CE3E44A52B4ED2D700105798 /* utf8-bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE3E44A42B4ED2D700105798 /* utf8-bom.txt */; };
 		CE3E44A72B52AFB400105798 /* kana-rule.conf in Resources */ = {isa = PBXBuildFile; fileRef = CE3E44A62B52AFB400105798 /* kana-rule.conf */; };
 		CE3E44A92B52C89800105798 /* kana-rule-for-test.conf in Resources */ = {isa = PBXBuildFile; fileRef = CE3E44A82B52C89800105798 /* kana-rule-for-test.conf */; };
@@ -170,6 +171,7 @@
 		CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKeys.swift; sourceTree = "<group>"; };
 		CE313A1E2AF5213700A49142 /* Candidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Candidate.swift; sourceTree = "<group>"; };
 		CE39DB202A8DFD8F00BC619F /* MarkedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkedText.swift; sourceTree = "<group>"; };
+		CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+KeyCode.swift"; sourceTree = "<group>"; };
 		CE3E44A42B4ED2D700105798 /* utf8-bom.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "utf8-bom.txt"; sourceTree = "<group>"; };
 		CE3E44A62B52AFB400105798 /* kana-rule.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kana-rule.conf"; sourceTree = "<group>"; };
 		CE3E44A82B52C89800105798 /* kana-rule-for-test.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kana-rule-for-test.conf"; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 				CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */,
 				CE496C942B440BBD001C623C /* Data+EucJis2004Tests.swift */,
 				CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */,
+				CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */,
 				CED7CA572A83BFE9004EF988 /* fixture */,
 			);
 			path = macSKKTests;
@@ -791,6 +794,7 @@
 				CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */,
 				CED1CA1E2BAFBE0600C32AE3 /* SKKServDictTests.swift in Sources */,
 				CE6DBA912A846C1700F5A227 /* ReleaseVersionTests.swift in Sources */,
+				CE39FA952BEB942B00E293F0 /* Character+KeyCode.swift in Sources */,
 				CEA78FAE2961BA1D00B67E25 /* String+TransformTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CE313A1F2AF5213700A49142 /* Candidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE313A1E2AF5213700A49142 /* Candidate.swift */; };
 		CE39DB212A8DFD8F00BC619F /* MarkedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39DB202A8DFD8F00BC619F /* MarkedText.swift */; };
 		CE39FA952BEB942B00E293F0 /* Character+KeyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */; };
+		CE39FA972BF0813E00E293F0 /* KeyBindingSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39FA962BF0813E00E293F0 /* KeyBindingSet.swift */; };
 		CE3E44A52B4ED2D700105798 /* utf8-bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE3E44A42B4ED2D700105798 /* utf8-bom.txt */; };
 		CE3E44A72B52AFB400105798 /* kana-rule.conf in Resources */ = {isa = PBXBuildFile; fileRef = CE3E44A62B52AFB400105798 /* kana-rule.conf */; };
 		CE3E44A92B52C89800105798 /* kana-rule-for-test.conf in Resources */ = {isa = PBXBuildFile; fileRef = CE3E44A82B52C89800105798 /* kana-rule-for-test.conf */; };
@@ -172,6 +173,7 @@
 		CE313A1E2AF5213700A49142 /* Candidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Candidate.swift; sourceTree = "<group>"; };
 		CE39DB202A8DFD8F00BC619F /* MarkedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkedText.swift; sourceTree = "<group>"; };
 		CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+KeyCode.swift"; sourceTree = "<group>"; };
+		CE39FA962BF0813E00E293F0 /* KeyBindingSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingSet.swift; sourceTree = "<group>"; };
 		CE3E44A42B4ED2D700105798 /* utf8-bom.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "utf8-bom.txt"; sourceTree = "<group>"; };
 		CE3E44A62B52AFB400105798 /* kana-rule.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kana-rule.conf"; sourceTree = "<group>"; };
 		CE3E44A82B52C89800105798 /* kana-rule-for-test.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kana-rule-for-test.conf"; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 				CEADA44A2B025A0F0026E2BD /* Entry.swift */,
 				CE84A3E6295DA4DA009394C4 /* Romaji.swift */,
 				CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */,
+				CE39FA962BF0813E00E293F0 /* KeyBindingSet.swift */,
 				CE3E44AC2B5391DB00105798 /* SettingsWatcher.swift */,
 				CE40D9A22A6D0C3900D44799 /* SystemDict.swift */,
 				CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */,
@@ -468,8 +471,8 @@
 				CE496C8B2B43968A001C623C /* LogView.swift */,
 				CEC376EA2965211200D9C432 /* KeyEventView.swift */,
 				CE40D9A02A6D0C2F00D44799 /* SystemDictView.swift */,
-				CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */,
 				CE11C7BC2BE47D5D00A35F3D /* KeyBindingView.swift */,
+				CE2157652B2EA985006E4C41 /* UserDefaultsKeys.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -726,6 +729,7 @@
 				CE84A3B929570C37009394C4 /* InputController.swift in Sources */,
 				CE6599DC2ADBF2630052F8C0 /* SettingsWindow.swift in Sources */,
 				CE3E44AD2B5391DB00105798 /* SettingsWatcher.swift in Sources */,
+				CE39FA972BF0813E00E293F0 /* KeyBindingSet.swift in Sources */,
 				CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */,
 				CE84A3EB295DA715009394C4 /* Dict.swift in Sources */,
 				CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */,

--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -5,20 +5,21 @@ import Cocoa
 
 struct Action {
     let keyBind: KeyBinding.Action?
-    let originalEvent: NSEvent
+    /// キーイベント
+    let event: NSEvent
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect
 
     func shiftIsPressed() -> Bool {
-        return originalEvent.modifierFlags.contains(.shift)
+        return event.modifierFlags.contains(.shift)
     }
 
     func optionIsPressed() -> Bool {
-        return originalEvent.modifierFlags.contains(.option)
+        return event.modifierFlags.contains(.option)
     }
 
     /// Option-Shift-E (´) のように入力したキーコードを元に整形された文字列を返す
     func characters() -> String? {
-        return originalEvent.characters
+        return event.characters
     }
 }

--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -5,26 +5,20 @@ import Cocoa
 
 struct Action {
     let keyBind: KeyBinding.Action?
-    let originalEvent: NSEvent?
+    let originalEvent: NSEvent
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect
 
     func shiftIsPressed() -> Bool {
-        guard let event = originalEvent else {
-            return false
-        }
-        return event.modifierFlags.contains(.shift)
+        return originalEvent.modifierFlags.contains(.shift)
     }
 
     func optionIsPressed() -> Bool {
-        guard let event = originalEvent else {
-            return false
-        }
-        return event.modifierFlags.contains(.option)
+        return originalEvent.modifierFlags.contains(.option)
     }
 
     /// Option-Shift-E (´) のように入力したキーコードを元に整形された文字列を返す
     func characters() -> String? {
-        return originalEvent?.characters
+        return originalEvent.characters
     }
 }

--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -4,56 +4,10 @@
 import Cocoa
 
 struct Action {
-    let keyEvent: KeyEvent
     let keyBind: KeyBinding.Action?
     let originalEvent: NSEvent?
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect
-
-    enum KeyEvent: Equatable {
-        case enter
-        case backspace
-        case delete
-        case space
-        case tab
-        case stickyShift
-        /**
-         * 印字可能な文字の入力 (space以外).
-         * 値はNSEvent.charactersIgnoringModifiersベースで、シフトが押されているときは小文字になる。Shift-1なら "1" になる
-         * - TODO: NSEvent.keyCodeからキーボードフォーマットを使って生の文字列を取る
-         */
-        case printable(String)
-        /**
-         * Ctrl-J
-         */
-        case ctrlJ
-        /**
-         * Ctrl-G
-         */
-        case cancel
-        /**
-         * 半角カナ
-         */
-        case ctrlQ
-        /// 左矢印キー or Ctrl-B
-        case left
-        /// 右矢印キー or Ctrl-F
-        case right
-        /// 上矢印キー or Ctrl-P
-        case up
-        /// 下矢印キー or Ctrl-N
-        case down
-        /// Ctrl-A
-        case ctrlA
-        /// Ctrl-E
-        case ctrlE
-        /// Ctrl-Y. 登録モードでのみクリップボードからのペースト用
-        case ctrlY
-        /// 英数キー
-        case eisu
-        /// かなキー
-        case kana
-    }
 
     func shiftIsPressed() -> Bool {
         guard let event = originalEvent else {

--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -5,7 +5,7 @@ import Cocoa
 
 struct Action {
     let keyEvent: KeyEvent
-    let keyBind: KeyBinding.Key?
+    let keyBind: KeyBinding.Action?
     let originalEvent: NSEvent?
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect

--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -5,6 +5,7 @@ import Cocoa
 
 struct Action {
     let keyEvent: KeyEvent
+    let keyBind: KeyBinding.Key?
     let originalEvent: NSEvent?
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -24,6 +24,8 @@ import Combine
     static var kanaRule: Romaji!
     /// デフォルトでもってるローマ字かな変換ルール
     static var defaultKanaRule: Romaji!
+    /// 現在のキーバインディング
+    static var keyBinding: KeyBinding!
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     // 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -25,7 +25,7 @@ import Combine
     /// デフォルトでもってるローマ字かな変換ルール
     static var defaultKanaRule: Romaji!
     /// 現在のキーバインディング
-    static var keyBinding: KeyBinding = KeyBinding.defaultKeyBinding
+    static var keyBinding: KeyBindingSet = KeyBindingSet.defaultKeyBindingSet
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     // 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -25,7 +25,7 @@ import Combine
     /// デフォルトでもってるローマ字かな変換ルール
     static var defaultKanaRule: Romaji!
     /// 現在のキーバインディング
-    static var keyBinding: KeyBinding!
+    static var keyBinding: KeyBinding = KeyBinding.defaultKeyBinding
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     // 変換候補を表示するパネル

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -212,7 +212,7 @@ class InputController: IMKInputController {
             return stateMachine.handleUnhandledEvent(event)
         }
 
-        return stateMachine.handle(Action(keyBind: keyBind, originalEvent: event, cursorPosition: cursorPosition))
+        return stateMachine.handle(Action(keyBind: keyBind, event: event, cursorPosition: cursorPosition))
     }
 
     override func menu() -> NSMenu! {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -212,7 +212,7 @@ class InputController: IMKInputController {
             return stateMachine.handleUnhandledEvent(event)
         }
 
-        return stateMachine.handle(Action(keyEvent: keyEvent, originalEvent: event, cursorPosition: cursorPosition))
+        return stateMachine.handle(Action(keyEvent: keyEvent, keyBind: Global.keyBinding.key(event: event), originalEvent: event, cursorPosition: cursorPosition))
     }
 
     override func menu() -> NSMenu! {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -190,8 +190,9 @@ class InputController: IMKInputController {
     }
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+        let keyBind = Global.keyBinding.action(event: event)
         if directMode {
-            if let keyEvent = convert(event: event), keyEvent == .kana || keyEvent == .eisu {
+            if let keyBind, keyBind == .kana || keyBind == .eisu {
                 // 英数・かなキーは握り潰さないとエディタによって空白が入ってしまう
                 return true
             }
@@ -207,12 +208,11 @@ class InputController: IMKInputController {
         } else {
             logger.log("IMKTextInputが取得できません")
         }
-        guard let keyEvent = convert(event: event) else {
-            logger.debug("Can not convert event to KeyEvent")
+        if keyBind == nil && event.charactersIgnoringModifiers == nil {
             return stateMachine.handleUnhandledEvent(event)
         }
 
-        return stateMachine.handle(Action(keyEvent: keyEvent, keyBind: Global.keyBinding.action(event: event), originalEvent: event, cursorPosition: cursorPosition))
+        return stateMachine.handle(Action(keyBind: Global.keyBinding.action(event: event), originalEvent: event, cursorPosition: cursorPosition))
     }
 
     override func menu() -> NSMenu! {
@@ -336,93 +336,6 @@ class InputController: IMKInputController {
         let printable = [CharacterSet.alphanumerics, CharacterSet.symbols, CharacterSet.punctuationCharacters]
             .reduce(CharacterSet()) { $0.union($1) }
         return !text.unicodeScalars.contains { !printable.contains($0) }
-    }
-
-    private func convert(event: NSEvent) -> Action.KeyEvent? {
-        // Ctrl-J, Ctrl-Gなどは受け取るが、基本的にはCtrl, Command, Fnが押されていたら無視する
-        // Optionは修飾キーを打つかもしれないので許容する
-        let modifiers = event.modifierFlags
-        let keyCode = event.keyCode
-        let charactersIgnoringModifiers = event.charactersIgnoringModifiers
-        if modifiers.contains(.control) || modifiers.contains(.command) || modifiers.contains(.function) {
-            if modifiers == [.control] {
-                switch charactersIgnoringModifiers {
-                case "j":
-                    return .ctrlJ
-                case "g":
-                    return .cancel
-                case "q":
-                    return .ctrlQ
-                case "h":
-                    return .backspace
-                case "b":
-                    return .left
-                case "f":
-                    return .right
-                case "p":
-                    return .up
-                case "n":
-                    return .down
-                case "a":
-                    return .ctrlA
-                case "e":
-                    return .ctrlE
-                case "d":
-                    return .delete
-                case "y":
-                    return .ctrlY
-                default:
-                    break
-                }
-            }
-            // カーソルキーやDelキーはFn + NumPadがmodifierFlagsに設定されている
-            if !modifiers.contains(.control) && !modifiers.contains(.command) && modifiers.contains(.function) {
-                if keyCode == 123 {
-                    return .left
-                } else if keyCode == 124 {
-                    return .right
-                } else if keyCode == 125 {
-                    return .down
-                } else if keyCode == 126 {
-                    return .up
-                } else if keyCode == 117 {
-                    return .delete
-                }
-            }
-
-            return nil
-        }
-
-        if keyCode == 36 {  // エンター
-            return .enter
-        } else if keyCode == 48 {
-            return .tab
-        } else if keyCode == 123 {
-            return .left
-        } else if keyCode == 124 {
-            return .right
-        } else if keyCode == 126 {
-            return .up
-        } else if keyCode == 125 {
-            return .down
-        } else if keyCode == 51 {
-            return .backspace
-        } else if keyCode == 53 {  // ESC
-            return .cancel
-        } else if keyCode == 102 { // 英数キー
-            return .eisu
-        } else if keyCode == 104 { // かなキー
-            return .kana
-        } else if event.characters == " " {
-            return .space
-        } else if event.characters == ";" {
-            return .stickyShift
-        } else if let text = charactersIgnoringModifiers {
-            if isPrintable(text) {
-                return .printable(text)
-            }
-        }
-        return nil
     }
 
     // キー配列を設定する

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -212,7 +212,7 @@ class InputController: IMKInputController {
             return stateMachine.handleUnhandledEvent(event)
         }
 
-        return stateMachine.handle(Action(keyEvent: keyEvent, keyBind: Global.keyBinding.key(event: event), originalEvent: event, cursorPosition: cursorPosition))
+        return stateMachine.handle(Action(keyEvent: keyEvent, keyBind: Global.keyBinding.action(event: event), originalEvent: event, cursorPosition: cursorPosition))
     }
 
     override func menu() -> NSMenu! {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -212,7 +212,7 @@ class InputController: IMKInputController {
             return stateMachine.handleUnhandledEvent(event)
         }
 
-        return stateMachine.handle(Action(keyBind: Global.keyBinding.action(event: event), originalEvent: event, cursorPosition: cursorPosition))
+        return stateMachine.handle(Action(keyBind: keyBind, originalEvent: event, cursorPosition: cursorPosition))
     }
 
     override func menu() -> NSMenu! {

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -8,54 +8,54 @@ import AppKit
  */
 struct KeyBinding {
     enum Action: CaseIterable, CodingKey {
-        // ひらがな入力に切り替える。デフォルトはCtrl-jキー
+        /// ひらがな入力に切り替える。デフォルトはCtrl-jキー
         case hiragana
-        // ひらがな・カタカナ入力に切り替える。デフォルトはqキー
+        /// ひらがな・カタカナ入力に切り替える。デフォルトはqキー
         case toggleKana
-        // 半角カナ入力に切り替える。デフォルトはCtrl-qキー
+        /// 半角カナ入力に切り替える。デフォルトはCtrl-qキー
         case hankakuKana
-        // 半角英数入力に切り替える。デフォルトはlキー
+        /// 半角英数入力に切り替える。デフォルトはlキー
         case direct
-        // 全角英数入力に切り替える。デフォルトはShift-lキー
+        /// 全角英数入力に切り替える。デフォルトはShift-lキー
         case zenkaku
-        // Abbrevに入るためのキー。デフォルトは/キー
+        /// Abbrevに入るためのキー。デフォルトは/キー
         case abbrev
-        // 未確定入力を始めるキー。Sticky Shiftとは違って未確定文字列があるときは確定させてから未確定入力を始める。
-        // デフォルトはShift-qキー
+        /// 未確定入力を始めるキー。Sticky Shiftとは違って未確定文字列があるときは確定させてから未確定入力を始める。
+        /// デフォルトはShift-qキー
         case japanese
-        // デフォルトは;キー
+        /// デフォルトは;キー
         case stickyShift
-        // デフォルトはEnterキー
+        /// デフォルトはEnterキー
         case enter
-        // デフォルトはSpaceキー
+        /// デフォルトはSpaceキー
         case space
-        // 補完候補の確定用。デフォルトはTabキー
+        /// 補完候補の確定用。デフォルトはTabキー
         case tab
-        // デフォルトはBackspaceキーとCtrl-hキー
+        /// デフォルトはBackspaceキーとCtrl-hキー
         case backspace
-        // デフォルトはDeleteキーとCtrl-dキー
+        /// デフォルトはDeleteキーとCtrl-dキー
         case delete
-        // 未確定入力や単語登録状態のキャンセル。デフォルトはESCとCtrl-gキー
+        /// 未確定入力や単語登録状態のキャンセル。デフォルトはESCとCtrl-gキー
         case cancel
-        // カーソルの左移動。デフォルトは左矢印キーとCtrl-bキー
+        /// カーソルの左移動。デフォルトは左矢印キーとCtrl-bキー
         case left
-        // カーソルの右移動。デフォルトは右矢印キーとCtrl-fキー
+        /// カーソルの右移動。デフォルトは右矢印キーとCtrl-fキー
         case right
-        // カーソルの下移動。デフォルトは下矢印キーとCtrl-nキー
+        /// カーソルの下移動。デフォルトは下矢印キーとCtrl-nキー
         case down
-        // カーソルの上移動。デフォルトは上矢印キーとCtrl-pキー
+        /// カーソルの上移動。デフォルトは上矢印キーとCtrl-pキー
         case up
-        // カーソルを行先頭に移動する。デフォルトはCtrl-aキー
+        /// カーソルを行先頭に移動する。デフォルトはCtrl-aキー
         case startOfLine
-        // カーソルを行終端に移動する。デフォルトはCtrl-eキー
+        /// カーソルを行終端に移動する。デフォルトはCtrl-eキー
         case endOfLine
-        // 単語登録時のみクリップボードからテキストをペーストする。デフォルトはCtrl-yキー
+        /// 単語登録時のみクリップボードからテキストをペーストする。デフォルトはCtrl-yキー
         case registerPaste
-        // 英数キー
-        // TODO: カスタマイズできなくする?
+        /// 英数キー
+        /// TODO: カスタマイズできなくする?
         case eisu
-        // かなキー
-        // TODO: カスタマイズできなくする?
+        /// かなキー
+        /// TODO: カスタマイズできなくする?
         case kana
     }
 

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -72,7 +72,7 @@ struct KeyBinding: Identifiable {
         init(event: NSEvent) {
             keyCode = event.keyCode
             // 使用する可能性があるものだけを抽出する。じゃないとrawValueで256が入ってしまうっぽい?
-            modifierFlags = event.modifierFlags.intersection([.shift, .control, .function, .option])
+            modifierFlags = event.modifierFlags.intersection([.shift, .control, .function, .option, .command])
             displayString = (event.charactersIgnoringModifiers ?? event.characters) ?? ""
         }
 
@@ -151,10 +151,10 @@ struct KeyBinding: Identifiable {
                 return KeyBinding(action, [Input(keyCode: 0x30, displayString: "Tab", modifierFlags: [])])
             case .backspace:
                 return KeyBinding(action, [Input(keyCode: 0x33, displayString: "Backspace", modifierFlags: []),
-                                           Input(keyCode: 0x02, displayString: "H", modifierFlags: .control)])
+                                           Input(keyCode: 0x04, displayString: "H", modifierFlags: .control)])
             case .delete:
                 return KeyBinding(action, [Input(keyCode: 0x75, displayString: "Delete", modifierFlags: []),
-                                           Input(keyCode: 0x04, displayString: "D", modifierFlags: .control)])
+                                           Input(keyCode: 0x02, displayString: "D", modifierFlags: .control)])
             case .cancel:
                 return KeyBinding(action, [Input(keyCode: 0x35, displayString: "ESC", modifierFlags: []),
                                            Input(keyCode: 0x05, displayString: "G", modifierFlags: .control)])
@@ -169,11 +169,11 @@ struct KeyBinding: Identifiable {
                                            Input(keyCode: 0x2d, displayString: "N", modifierFlags: .control)])
             case .up:
                 return KeyBinding(action, [Input(keyCode: 0x7e, displayString: "↑", modifierFlags: .function),
-                                           Input(keyCode: 0x33, displayString: "P", modifierFlags: .control)])
+                                           Input(keyCode: 0x23, displayString: "P", modifierFlags: .control)])
             case .startOfLine:
                 return KeyBinding(action, [Input(keyCode: 0x00, displayString: "A", modifierFlags: .control)])
             case .endOfLine:
-                return KeyBinding(action, [Input(keyCode: 0x0d, displayString: "E", modifierFlags: .control)])
+                return KeyBinding(action, [Input(keyCode: 0x0e, displayString: "E", modifierFlags: .control)])
             case .registerPaste:
                 return KeyBinding(action, [Input(keyCode: 0x10, displayString: "Y", modifierFlags: .control)])
             case .eisu:

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -7,7 +7,7 @@ import AppKit
  * macSKKで使用できるキーバインディング
  */
 struct KeyBinding {
-    enum Key: Hashable, CaseIterable, CodingKey {
+    enum Key: CaseIterable, CodingKey {
         // デフォルトはCtrl-jキー
         case toggleHiragana
         // デフォルトはqキー
@@ -24,10 +24,43 @@ struct KeyBinding {
         case stickyShift
     }
 
-    struct Value {
-        let keyCode: UInt16
-        let modifiers: NSEvent.ModifierFlags
+    struct ModifierFlags: OptionSet {
+        let rawValue: Int
+
+        static let control = Self(rawValue: 1 << 0)
+        static let shift = Self(rawValue: 1 << 1)
     }
 
-    var values: [Key: Value] = [:]
+    struct Value {
+        let keyCode: UInt16
+        let modifiers: ModifierFlags
+    }
+
+    let values: [Key: [Value]] = [:]
+
+    /// デフォルトのキーバインディング
+    static var defaultKeyBinding: [Key: [Value]] {
+        return Dictionary(uniqueKeysWithValues: Key.allCases.map { key in
+            switch key {
+            case .toggleHiragana:
+                return (key, [Value(keyCode: 0x26, modifiers: .control)])
+            case .toggleKana:
+                return (key, [Value(keyCode: 0x0c, modifiers: [])])
+            case .toggleHankakuKana:
+                return (key, [Value(keyCode: 0x0c, modifiers: .control)])
+            case .direct:
+                return (key, [Value(keyCode: 0x25, modifiers: [])])
+            case .zenkaku:
+                return (key, [Value(keyCode: 0x25, modifiers: .shift)])
+            case .abbrev:
+                return (key, [Value(keyCode: 0x2c, modifiers: [])])
+            case .stickyShift:
+                return (key, [Value(keyCode: 0x29, modifiers: [])])
+            }
+        })
+    }
+
+    func key(event: NSEvent) -> Key? {
+        return nil
+    }
 }

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -8,20 +8,55 @@ import AppKit
  */
 struct KeyBinding {
     enum Key: CaseIterable, CodingKey {
-        // デフォルトはCtrl-jキー
-        case toggleHiragana
-        // デフォルトはqキー
+        // ひらがな入力に切り替える。デフォルトはCtrl-jキー
+        case hiragana
+        // ひらがな・カタカナ入力に切り替える。デフォルトはqキー
         case toggleKana
-        // デフォルトはCtrl-qキー
-        case toggleHankakuKana
-        // デフォルトはlキー
+        // 半角カナ入力に切り替える。デフォルトはCtrl-qキー
+        case hankakuKana
+        // 半角英数入力に切り替える。デフォルトはlキー
         case direct
-        // デフォルトはShift-lキー
+        // 全角英数入力に切り替える。デフォルトはShift-lキー
         case zenkaku
-        // デフォルトは/キー
+        // Abbrevに入るためのキー。デフォルトは/キー
         case abbrev
+        // 未確定入力を始めるキー。Sticky Shiftとは違って未確定文字列があるときは確定させてから未確定入力を始める。
+        // デフォルトはShift-qキー
+        case japanese
         // デフォルトは;キー
         case stickyShift
+        // デフォルトはEnterキー
+        case enter
+        // デフォルトはSpaceキー
+        case space
+        // 補完候補の確定用。デフォルトはTabキー
+        case tab
+        // デフォルトはBackspaceキーとCtrl-hキー
+        case backspace
+        // デフォルトはDeleteキーとCtrl-dキー
+        case delete
+        // 未確定入力や単語登録状態のキャンセル。デフォルトはESCとCtrl-gキー
+        case cancel
+        // カーソルの左移動。デフォルトは左矢印キーとCtrl-bキー
+        case left
+        // カーソルの右移動。デフォルトは右矢印キーとCtrl-fキー
+        case right
+        // カーソルの下移動。デフォルトは下矢印キーとCtrl-nキー
+        case down
+        // カーソルの上移動。デフォルトは上矢印キーとCtrl-pキー
+        case up
+        // カーソルを行先頭に移動する。デフォルトはCtrl-aキー
+        case startOfLine
+        // カーソルを行終端に移動する。デフォルトはCtrl-eキー
+        case endOfLine
+        // 単語登録時のみクリップボードからテキストをペーストする。デフォルトはCtrl-yキー
+        case registerPaste
+        // 英数キー
+        // TODO: カスタマイズできなくする?
+        case eisu
+        // かなキー
+        // TODO: カスタマイズできなくする?
+        case kana
     }
 
     struct Value: Hashable {
@@ -51,11 +86,11 @@ struct KeyBinding {
     static var defaultKeyBindingSettings: [Key: [Value]] {
         return Dictionary(uniqueKeysWithValues: Key.allCases.map { key in
             switch key {
-            case .toggleHiragana:
+            case .hiragana:
                 return (key, [Value(keyCode: 0x26, modifierFlags: .control)])
             case .toggleKana:
                 return (key, [Value(keyCode: 0x0c, modifierFlags: [])])
-            case .toggleHankakuKana:
+            case .hankakuKana:
                 return (key, [Value(keyCode: 0x0c, modifierFlags: .control)])
             case .direct:
                 return (key, [Value(keyCode: 0x25, modifierFlags: [])])
@@ -63,8 +98,47 @@ struct KeyBinding {
                 return (key, [Value(keyCode: 0x25, modifierFlags: .shift)])
             case .abbrev:
                 return (key, [Value(keyCode: 0x2c, modifierFlags: [])])
+            case .japanese:
+                return (key, [Value(keyCode: 0x0c, modifierFlags: .shift)])
             case .stickyShift:
                 return (key, [Value(keyCode: 0x29, modifierFlags: [])])
+            case .enter:
+                return (key, [Value(keyCode: 0x24, modifierFlags: [])])
+            case .space:
+                return (key, [Value(keyCode: 0x31, modifierFlags: [])])
+            case .tab:
+                return (key, [Value(keyCode: 0x30, modifierFlags: [])])
+            case .backspace:
+                return (key, [Value(keyCode: 0x33, modifierFlags: [.function]),
+                              Value(keyCode: 0x02, modifierFlags: .control)])
+            case .delete:
+                return (key, [Value(keyCode: 0x75, modifierFlags: []),
+                              Value(keyCode: 0x04, modifierFlags: .control)])
+            case .cancel:
+                return (key, [Value(keyCode: 0x35, modifierFlags: []),
+                              Value(keyCode: 0x05, modifierFlags: .control)])
+            case .left:
+                return (key, [Value(keyCode: 0x7b, modifierFlags: [.function]),
+                              Value(keyCode: 0x0b, modifierFlags: .control)])
+            case .right:
+                return (key, [Value(keyCode: 0x7c, modifierFlags: [.function]),
+                              Value(keyCode: 0x03, modifierFlags: .control)])
+            case .down:
+                return (key, [Value(keyCode: 0x7d, modifierFlags: [.function]),
+                              Value(keyCode: 0x2d, modifierFlags: .control)])
+            case .up:
+                return (key, [Value(keyCode: 0x7e, modifierFlags: [.function]),
+                              Value(keyCode: 0x33, modifierFlags: .control)])
+            case .startOfLine:
+                return (key, [Value(keyCode: 0x00, modifierFlags: .control)])
+            case .endOfLine:
+                return (key, [Value(keyCode: 0x0d, modifierFlags: .control)])
+            case .registerPaste:
+                return (key, [Value(keyCode: 0x10, modifierFlags: .control)])
+            case .eisu:
+                return (key, [Value(keyCode: 0x66, modifierFlags: [])])
+            case .kana:
+                return (key, [Value(keyCode: 0x68, modifierFlags: [])])
             }
         })
     }

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -138,7 +138,7 @@ struct KeyBinding: Identifiable {
             case .zenkaku:
                 return KeyBinding(action, [Input(keyCode: 0x25, displayString: "L", modifierFlags: .shift)])
             case .abbrev:
-                return KeyBinding(action, [Input(keyCode: 0x2c, displayString: "Q", modifierFlags: [])])
+                return KeyBinding(action, [Input(keyCode: 0x2c, displayString: "/", modifierFlags: [])])
             case .japanese:
                 return KeyBinding(action, [Input(keyCode: 0x0c, displayString: "Q", modifierFlags: .shift)])
             case .stickyShift:
@@ -177,9 +177,9 @@ struct KeyBinding: Identifiable {
             case .registerPaste:
                 return KeyBinding(action, [Input(keyCode: 0x10, displayString: "Y", modifierFlags: .control)])
             case .eisu:
-                return KeyBinding(action, [Input(keyCode: 0x66, displayString: "Eisu", modifierFlags: [])])
+                return KeyBinding(action, [Input(keyCode: 0x66, displayString: String(localized: "KeyEisu"), modifierFlags: [])])
             case .kana:
-                return KeyBinding(action, [Input(keyCode: 0x68, displayString: "Kana", modifierFlags: [])])
+                return KeyBinding(action, [Input(keyCode: 0x68, displayString: String(localized: "KeyKana"), modifierFlags: [])])
             }
         }
     }

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -61,7 +61,7 @@ struct KeyBinding: Identifiable {
         case kana
     }
 
-    struct Input: Hashable {
+    struct Input: Hashable, Equatable {
         let keyCode: UInt16
         let modifierFlags: NSEvent.ModifierFlags
         /**
@@ -71,7 +71,8 @@ struct KeyBinding: Identifiable {
 
         init(event: NSEvent) {
             keyCode = event.keyCode
-            modifierFlags = event.modifierFlags
+            // 使用する可能性があるものだけを抽出する。じゃないとrawValueで256が入ってしまうっぽい?
+            modifierFlags = event.modifierFlags.intersection([.shift, .control, .function, .option])
             displayString = (event.charactersIgnoringModifiers ?? event.characters) ?? ""
         }
 
@@ -84,6 +85,10 @@ struct KeyBinding: Identifiable {
         func hash(into hasher: inout Hasher) {
             hasher.combine(keyCode)
             hasher.combine(modifierFlags.rawValue)
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            return lhs.keyCode == rhs.keyCode && lhs.modifierFlags == rhs.modifierFlags
         }
 
         var localized: String {
@@ -145,7 +150,7 @@ struct KeyBinding: Identifiable {
             case .tab:
                 return KeyBinding(action, [Input(keyCode: 0x30, displayString: "Tab", modifierFlags: [])])
             case .backspace:
-                return KeyBinding(action, [Input(keyCode: 0x33, displayString: "Backspace", modifierFlags: [.function]),
+                return KeyBinding(action, [Input(keyCode: 0x33, displayString: "Backspace", modifierFlags: []),
                                            Input(keyCode: 0x02, displayString: "H", modifierFlags: .control)])
             case .delete:
                 return KeyBinding(action, [Input(keyCode: 0x75, displayString: "Delete", modifierFlags: []),
@@ -154,16 +159,16 @@ struct KeyBinding: Identifiable {
                 return KeyBinding(action, [Input(keyCode: 0x35, displayString: "ESC", modifierFlags: []),
                                            Input(keyCode: 0x05, displayString: "G", modifierFlags: .control)])
             case .left:
-                return KeyBinding(action, [Input(keyCode: 0x7b, displayString: "←", modifierFlags: [.function]),
+                return KeyBinding(action, [Input(keyCode: 0x7b, displayString: "←", modifierFlags: .function),
                                            Input(keyCode: 0x0b, displayString: "B", modifierFlags: .control)])
             case .right:
-                return KeyBinding(action, [Input(keyCode: 0x7c, displayString: "→", modifierFlags: [.function]),
+                return KeyBinding(action, [Input(keyCode: 0x7c, displayString: "→", modifierFlags: .function),
                                            Input(keyCode: 0x03, displayString: "F", modifierFlags: .control)])
             case .down:
-                return KeyBinding(action, [Input(keyCode: 0x7d, displayString: "↓", modifierFlags: [.function]),
+                return KeyBinding(action, [Input(keyCode: 0x7d, displayString: "↓", modifierFlags: .function),
                                            Input(keyCode: 0x2d, displayString: "N", modifierFlags: .control)])
             case .up:
-                return KeyBinding(action, [Input(keyCode: 0x7e, displayString: "↑", modifierFlags: [.function]),
+                return KeyBinding(action, [Input(keyCode: 0x7e, displayString: "↑", modifierFlags: .function),
                                            Input(keyCode: 0x33, displayString: "P", modifierFlags: .control)])
             case .startOfLine:
                 return KeyBinding(action, [Input(keyCode: 0x00, displayString: "A", modifierFlags: .control)])

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -7,7 +7,7 @@ import AppKit
  * macSKKで使用できるキーバインディング
  */
 struct KeyBinding {
-    enum Key: CaseIterable, CodingKey {
+    enum Action: CaseIterable, CodingKey {
         // ひらがな入力に切り替える。デフォルトはCtrl-jキー
         case hiragana
         // ひらがな・カタカナ入力に切り替える。デフォルトはqキー
@@ -59,7 +59,7 @@ struct KeyBinding {
         case kana
     }
 
-    struct Value: Hashable {
+    struct Input: Hashable {
         let keyCode: UInt16
         let modifierFlags: NSEvent.ModifierFlags
 
@@ -79,79 +79,79 @@ struct KeyBinding {
         }
     }
 
-    let values: [Key: [Value]]
-    let dict: [Value: Key]
+    let values: [Action: [Input]]
+    let dict: [Input: Action]
 
     /// デフォルトのキーバインディング
-    static var defaultKeyBindingSettings: [Key: [Value]] {
-        return Dictionary(uniqueKeysWithValues: Key.allCases.map { key in
-            switch key {
+    static var defaultKeyBindingSettings: [Action: [Input]] {
+        return Dictionary(uniqueKeysWithValues: Action.allCases.map { action in
+            switch action {
             case .hiragana:
-                return (key, [Value(keyCode: 0x26, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x26, modifierFlags: .control)])
             case .toggleKana:
-                return (key, [Value(keyCode: 0x0c, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x0c, modifierFlags: [])])
             case .hankakuKana:
-                return (key, [Value(keyCode: 0x0c, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x0c, modifierFlags: .control)])
             case .direct:
-                return (key, [Value(keyCode: 0x25, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x25, modifierFlags: [])])
             case .zenkaku:
-                return (key, [Value(keyCode: 0x25, modifierFlags: .shift)])
+                return (action, [Input(keyCode: 0x25, modifierFlags: .shift)])
             case .abbrev:
-                return (key, [Value(keyCode: 0x2c, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x2c, modifierFlags: [])])
             case .japanese:
-                return (key, [Value(keyCode: 0x0c, modifierFlags: .shift)])
+                return (action, [Input(keyCode: 0x0c, modifierFlags: .shift)])
             case .stickyShift:
-                return (key, [Value(keyCode: 0x29, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x29, modifierFlags: [])])
             case .enter:
-                return (key, [Value(keyCode: 0x24, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x24, modifierFlags: [])])
             case .space:
-                return (key, [Value(keyCode: 0x31, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x31, modifierFlags: [])])
             case .tab:
-                return (key, [Value(keyCode: 0x30, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x30, modifierFlags: [])])
             case .backspace:
-                return (key, [Value(keyCode: 0x33, modifierFlags: [.function]),
-                              Value(keyCode: 0x02, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x33, modifierFlags: [.function]),
+                                 Input(keyCode: 0x02, modifierFlags: .control)])
             case .delete:
-                return (key, [Value(keyCode: 0x75, modifierFlags: []),
-                              Value(keyCode: 0x04, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x75, modifierFlags: []),
+                                 Input(keyCode: 0x04, modifierFlags: .control)])
             case .cancel:
-                return (key, [Value(keyCode: 0x35, modifierFlags: []),
-                              Value(keyCode: 0x05, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x35, modifierFlags: []),
+                                 Input(keyCode: 0x05, modifierFlags: .control)])
             case .left:
-                return (key, [Value(keyCode: 0x7b, modifierFlags: [.function]),
-                              Value(keyCode: 0x0b, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x7b, modifierFlags: [.function]),
+                                 Input(keyCode: 0x0b, modifierFlags: .control)])
             case .right:
-                return (key, [Value(keyCode: 0x7c, modifierFlags: [.function]),
-                              Value(keyCode: 0x03, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x7c, modifierFlags: [.function]),
+                                 Input(keyCode: 0x03, modifierFlags: .control)])
             case .down:
-                return (key, [Value(keyCode: 0x7d, modifierFlags: [.function]),
-                              Value(keyCode: 0x2d, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x7d, modifierFlags: [.function]),
+                                 Input(keyCode: 0x2d, modifierFlags: .control)])
             case .up:
-                return (key, [Value(keyCode: 0x7e, modifierFlags: [.function]),
-                              Value(keyCode: 0x33, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x7e, modifierFlags: [.function]),
+                                 Input(keyCode: 0x33, modifierFlags: .control)])
             case .startOfLine:
-                return (key, [Value(keyCode: 0x00, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x00, modifierFlags: .control)])
             case .endOfLine:
-                return (key, [Value(keyCode: 0x0d, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x0d, modifierFlags: .control)])
             case .registerPaste:
-                return (key, [Value(keyCode: 0x10, modifierFlags: .control)])
+                return (action, [Input(keyCode: 0x10, modifierFlags: .control)])
             case .eisu:
-                return (key, [Value(keyCode: 0x66, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x66, modifierFlags: [])])
             case .kana:
-                return (key, [Value(keyCode: 0x68, modifierFlags: [])])
+                return (action, [Input(keyCode: 0x68, modifierFlags: [])])
             }
         })
     }
     static let defaultKeyBinding = KeyBinding(KeyBinding.defaultKeyBindingSettings)
 
-    init(_ values: [Key: [Value]]) {
+    init(_ values: [Action: [Input]]) {
         self.values = values
         self.dict = Dictionary(uniqueKeysWithValues: values.flatMap { keyValue in
             keyValue.value.map { ($0, keyValue.key) }
         })
     }
 
-    func key(event: NSEvent) -> Key? {
-        return dict[Value(event: event)]
+    func action(event: NSEvent) -> Action? {
+        return dict[Input(event: event)]
     }
 }

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+
+/**
+ * macSKKで使用できるキーバインディング
+ */
+struct KeyBinding {
+    enum Key: Hashable, CaseIterable, CodingKey {
+        // デフォルトはCtrl-jキー
+        case toggleHiragana
+        // デフォルトはqキー
+        case toggleKana
+        // デフォルトはCtrl-qキー
+        case toggleHankakuKana
+        // デフォルトはlキー
+        case direct
+        // デフォルトはShift-lキー
+        case zenkaku
+        // デフォルトは/キー
+        case abbrev
+        // デフォルトは;キー
+        case stickyShift
+    }
+
+    struct Value {
+        let keyCode: UInt16
+        let modifiers: NSEvent.ModifierFlags
+    }
+
+    var values: [Key: Value] = [:]
+}

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -24,43 +24,60 @@ struct KeyBinding {
         case stickyShift
     }
 
-    struct ModifierFlags: OptionSet {
-        let rawValue: Int
-
-        static let control = Self(rawValue: 1 << 0)
-        static let shift = Self(rawValue: 1 << 1)
-    }
-
-    struct Value {
+    struct Value: Hashable {
         let keyCode: UInt16
-        let modifiers: ModifierFlags
+        let modifierFlags: NSEvent.ModifierFlags
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(keyCode)
+            hasher.combine(modifierFlags.rawValue)
+        }
+
+        init(event: NSEvent) {
+            keyCode = event.keyCode
+            modifierFlags = event.modifierFlags
+        }
+
+        init(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) {
+            self.keyCode = keyCode
+            self.modifierFlags = modifierFlags
+        }
     }
 
-    let values: [Key: [Value]] = [:]
+    let values: [Key: [Value]]
+    let dict: [Value: Key]
 
     /// デフォルトのキーバインディング
-    static var defaultKeyBinding: [Key: [Value]] {
+    static var defaultKeyBindingSettings: [Key: [Value]] {
         return Dictionary(uniqueKeysWithValues: Key.allCases.map { key in
             switch key {
             case .toggleHiragana:
-                return (key, [Value(keyCode: 0x26, modifiers: .control)])
+                return (key, [Value(keyCode: 0x26, modifierFlags: .control)])
             case .toggleKana:
-                return (key, [Value(keyCode: 0x0c, modifiers: [])])
+                return (key, [Value(keyCode: 0x0c, modifierFlags: [])])
             case .toggleHankakuKana:
-                return (key, [Value(keyCode: 0x0c, modifiers: .control)])
+                return (key, [Value(keyCode: 0x0c, modifierFlags: .control)])
             case .direct:
-                return (key, [Value(keyCode: 0x25, modifiers: [])])
+                return (key, [Value(keyCode: 0x25, modifierFlags: [])])
             case .zenkaku:
-                return (key, [Value(keyCode: 0x25, modifiers: .shift)])
+                return (key, [Value(keyCode: 0x25, modifierFlags: .shift)])
             case .abbrev:
-                return (key, [Value(keyCode: 0x2c, modifiers: [])])
+                return (key, [Value(keyCode: 0x2c, modifierFlags: [])])
             case .stickyShift:
-                return (key, [Value(keyCode: 0x29, modifiers: [])])
+                return (key, [Value(keyCode: 0x29, modifierFlags: [])])
             }
+        })
+    }
+    static let defaultKeyBinding = KeyBinding(KeyBinding.defaultKeyBindingSettings)
+
+    init(_ values: [Key: [Value]]) {
+        self.values = values
+        self.dict = Dictionary(uniqueKeysWithValues: values.flatMap { keyValue in
+            keyValue.value.map { ($0, keyValue.key) }
         })
     }
 
     func key(event: NSEvent) -> Key? {
-        return nil
+        return dict[Value(event: event)]
     }
 }

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -11,8 +11,8 @@ struct KeyBindingSet {
 
     init(_ values: [KeyBinding]) {
         self.values = Dictionary(uniqueKeysWithValues: values.map { ($0.action, $0.inputs) })
-        self.dict = Dictionary(uniqueKeysWithValues: self.values.flatMap { keyValue in
-            keyValue.value.map { ($0, keyValue.key) }
+        self.dict = Dictionary(uniqueKeysWithValues: values.flatMap { keyValue in
+            keyValue.inputs.map { ($0, keyValue.action) }
         })
     }
 

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+
+struct KeyBindingSet {
+    let values: [KeyBinding.Action: [KeyBinding.Input]]
+    let dict: [KeyBinding.Input: KeyBinding.Action]
+
+    static let defaultKeyBindingSet = KeyBindingSet(KeyBinding.defaultKeyBindingSettings)
+
+    init(_ values: [KeyBinding]) {
+        self.values = Dictionary(uniqueKeysWithValues: values.map { ($0.action, $0.inputs) })
+        self.dict = Dictionary(uniqueKeysWithValues: self.values.flatMap { keyValue in
+            keyValue.value.map { ($0, keyValue.key) }
+        })
+    }
+
+    func action(event: NSEvent) -> KeyBinding.Action? {
+        return dict[KeyBinding.Input(event: event)]
+    }
+}

--- a/macSKK/Settings/KeyBindingView.swift
+++ b/macSKK/Settings/KeyBindingView.swift
@@ -4,11 +4,16 @@
 import SwiftUI
 
 struct KeyBindingView: View {
+    @StateObject var settingsViewModel: SettingsViewModel
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Table(settingsViewModel.keyBingings) {
+            TableColumn("Action", value: \.localizedAction)
+            TableColumn("Key", value: \.localizedInputs)
+        }
     }
 }
 
 #Preview {
-    KeyBindingView()
+    KeyBindingView(settingsViewModel: try! SettingsViewModel(keyBindings: KeyBinding.defaultKeyBindingSettings))
 }

--- a/macSKK/Settings/KeyBindingView.swift
+++ b/macSKK/Settings/KeyBindingView.swift
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import SwiftUI
+
+struct KeyBindingView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    KeyBindingView()
+}

--- a/macSKK/Settings/KeyEventView.swift
+++ b/macSKK/Settings/KeyEventView.swift
@@ -12,6 +12,7 @@ struct KeyEventView: View {
     @State private var charactersIgnoringModifiers: String = ""
     @State private var keyCode: String = ""
     @State private var modifiers: String = ""
+    @State private var keyBinding: KeyBinding.Action? = nil
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -47,6 +48,7 @@ struct KeyEventView: View {
                             modifiers.append("Fn")
                         }
                         self.modifiers = modifiers.joined(separator: ", ")
+                        self.keyBinding = Global.keyBinding.action(event: event)
 
                         return event
                     }
@@ -55,6 +57,9 @@ struct KeyEventView: View {
                     NSEvent.removeMonitor(eventMonitor!)
                 }
             Form {
+                Section {
+                    TextField("KeyBinding", text: .constant(keyBinding?.stringValue ?? ""))
+                }
                 Section {
                     TextField("KeyCode", text: .constant(keyCode))
                 }

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     // rawValueはLocalizable.stringsのキー名
     enum Section: String, CaseIterable {
         case general = "SettingsNameGeneral"
+        case keyBinding = "SettingsNameKeyBinding"
         case dictionaries = "SettingsNameDictionaries"
         case softwareUpdate = "SettingsNameSoftwareUpdate"
         case directMode = "SettingsNameDirectMode"
@@ -31,6 +32,8 @@ struct SettingsView: View {
                     switch section {
                     case .general:
                         Label(section.localizedStringKey, systemImage: "gear")
+                    case .keyBinding:
+                        Label(section.localizedStringKey, systemImage: "keyboard")
                     case .dictionaries:
                         Label(section.localizedStringKey, systemImage: "books.vertical")
                     case .softwareUpdate:
@@ -43,7 +46,7 @@ struct SettingsView: View {
                         Label(section.localizedStringKey, systemImage: "doc.plaintext")
                     #if DEBUG
                     case .keyEvent:
-                        Label(section.localizedStringKey, systemImage: "keyboard")
+                        Label(section.localizedStringKey, systemImage: "keyboard.badge.eye")
                     case .systemDict:
                         Label(section.localizedStringKey, systemImage: "book.closed.fill")
                     #endif
@@ -58,6 +61,9 @@ struct SettingsView: View {
             switch selectedSection {
             case .general:
                 GeneralView(settingsViewModel: settingsViewModel)
+                    .navigationTitle(selectedSection.localizedStringKey)
+            case .keyBinding:
+                KeyBindingView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
             case .dictionaries:
                 DictionariesView(settingsViewModel: settingsViewModel)

--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -7,8 +7,8 @@ struct SettingsView: View {
     // rawValueはLocalizable.stringsのキー名
     enum Section: String, CaseIterable {
         case general = "SettingsNameGeneral"
-        case keyBinding = "SettingsNameKeyBinding"
         case dictionaries = "SettingsNameDictionaries"
+        case keyBinding = "SettingsNameKeyBinding"
         case softwareUpdate = "SettingsNameSoftwareUpdate"
         case directMode = "SettingsNameDirectMode"
         case workaround = "SettingsNameWorkaround"
@@ -32,10 +32,10 @@ struct SettingsView: View {
                     switch section {
                     case .general:
                         Label(section.localizedStringKey, systemImage: "gear")
-                    case .keyBinding:
-                        Label(section.localizedStringKey, systemImage: "keyboard")
                     case .dictionaries:
                         Label(section.localizedStringKey, systemImage: "books.vertical")
+                    case .keyBinding:
+                        Label(section.localizedStringKey, systemImage: "keyboard")
                     case .softwareUpdate:
                         Label(section.localizedStringKey, systemImage: "gear.badge")
                     case .directMode:
@@ -62,11 +62,11 @@ struct SettingsView: View {
             case .general:
                 GeneralView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
-            case .keyBinding:
-                KeyBindingView(settingsViewModel: settingsViewModel)
-                    .navigationTitle(selectedSection.localizedStringKey)
             case .dictionaries:
                 DictionariesView(settingsViewModel: settingsViewModel)
+                    .navigationTitle(selectedSection.localizedStringKey)
+            case .keyBinding:
+                KeyBindingView(settingsViewModel: settingsViewModel)
                     .navigationTitle(selectedSection.localizedStringKey)
             case .softwareUpdate:
                 SoftwareUpdateView(settingsViewModel: settingsViewModel)

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -163,7 +163,7 @@ final class SettingsViewModel: ObservableObject {
     /// skkserv辞書設定
     @Published var skkservDictSetting: SKKServDictSetting
     /// キーバインディング
-    @Published var keyBinging: [KeyBinding.Key: [KeyBinding.Value]]
+    @Published var keyBinging: [KeyBinding.Action: [KeyBinding.Input]]
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
     private var cancellables = Set<AnyCancellable>()

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -163,7 +163,7 @@ final class SettingsViewModel: ObservableObject {
     /// skkserv辞書設定
     @Published var skkservDictSetting: SKKServDictSetting
     /// キーバインディング
-    @Published var keyBinging: [KeyBinding.Action: [KeyBinding.Input]]
+    @Published var keyBingings: [KeyBinding]
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
     private var cancellables = Set<AnyCancellable>()
@@ -195,7 +195,8 @@ final class SettingsViewModel: ObservableObject {
         }
         self.skkservDictSetting = skkservDictSetting
 
-        self.keyBinging = [:]
+        // TODO: 設定化。いまはとりあえず固定でデフォルト設定を表示
+        self.keyBingings = KeyBinding.defaultKeyBindingSettings
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -358,7 +359,7 @@ final class SettingsViewModel: ObservableObject {
         candidatesFontSize = 13
         annotationFontSize = 13
         skkservDictSetting = SKKServDictSetting(enabled: true, address: "127.0.0.1", port: 1178, encoding: .japaneseEUC)
-        keyBinging = [:]
+        keyBingings = []
     }
 
     // DictionaryViewのPreviewProvider用
@@ -389,6 +390,12 @@ final class SettingsViewModel: ObservableObject {
     internal convenience init(skkservDictSetting: SKKServDictSetting) throws {
         try self.init()
         self.skkservDictSetting = skkservDictSetting
+    }
+
+    // KeyBindingViewのPreviewProvider用
+    internal convenience init(keyBindings: [KeyBinding]) throws {
+        try self.init()
+        self.keyBingings = keyBindings
     }
 
     /**

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -162,6 +162,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var workaroundApplications: [WorkaroundApplication]
     /// skkserv辞書設定
     @Published var skkservDictSetting: SKKServDictSetting
+    /// キーバインディング
+    @Published var keyBinging: [KeyBinding.Key: [KeyBinding.Value]]
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
     private var cancellables = Set<AnyCancellable>()
@@ -187,12 +189,13 @@ final class SettingsViewModel: ObservableObject {
                 nil
             }
         } ?? []
-        // TODO: UserDefaultsから読み込む
         guard let skkservDictSettingDict = UserDefaults.standard.dictionary(forKey: UserDefaultsKeys.skkservClient),
         let skkservDictSetting = SKKServDictSetting(skkservDictSettingDict) else {
             fatalError("skkservClientの設定がありません")
         }
         self.skkservDictSetting = skkservDictSetting
+
+        self.keyBinging = [:]
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -355,6 +358,7 @@ final class SettingsViewModel: ObservableObject {
         candidatesFontSize = 13
         annotationFontSize = 13
         skkservDictSetting = SKKServDictSetting(enabled: true, address: "127.0.0.1", port: 1178, encoding: .japaneseEUC)
+        keyBinging = [:]
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -301,7 +301,7 @@ final class StateMachine {
             break
         }
 
-        if let originalEvent = action.originalEvent, let input = originalEvent.charactersIgnoringModifiers {
+        if let event = action.originalEvent, let input = event.charactersIgnoringModifiers, !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.command) {
             return handleNormalPrintable(input: input, action: action, specialState: specialState)
         } else {
             return false
@@ -369,14 +369,14 @@ final class StateMachine {
         let text = composing.text
         let okuri = composing.okuri
         let romaji = composing.romaji
-        let originalEvent = action.originalEvent
-        let input = action.originalEvent?.charactersIgnoringModifiers
+        let event = action.originalEvent
+        let input = event?.charactersIgnoringModifiers
         let converted: Romaji.ConvertedMoji?
 
         // ローマ字かな変換ルールで変換できる場合、そちらを優先する ("z " で全角スペース、"zl" で右矢印など)
         // Controlが押されているときは変換しない (s + Ctrl-a だと "さ" にはせずCtrl-aを優先する)
         // Optionが押されていても無視するようにしている (そちらのほうがうれしい人が多いかな程度の消極的理由)
-        if let input, let originalEvent, !originalEvent.modifierFlags.contains(.control) {
+        if let input, let event, !event.modifierFlags.contains(.control) {
             if !input.isAlphabet, let characters = action.characters() {
                 converted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: romaji, input: characters)
             } else {
@@ -692,7 +692,7 @@ final class StateMachine {
             break
         }
 
-        if let input {
+        if let input, let event, !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.command) {
             let converted: Romaji.ConvertedMoji
             if !input.isAlphabet, let characters = action.characters() {
                 converted = Global.kanaRule.convert(romaji + characters)

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -378,7 +378,7 @@ final class StateMachine {
         // Controlが押されているときは変換しない (s + Ctrl-a だと "さ" にはせずCtrl-aを優先する)
         // Optionが押されていても無視するようにしている (そちらのほうがうれしい人が多いかな程度の消極的理由)
         if action.keyBind == nil && (event.modifierFlags.contains(.control) || event.modifierFlags.contains(.command)) {
-            return false
+            return true
         } else if let input, !event.modifierFlags.contains(.control) {
             if !input.isAlphabet, let characters = action.characters() {
                 converted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: romaji, input: characters)

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -301,7 +301,7 @@ final class StateMachine {
             break
         }
 
-        let event = action.originalEvent
+        let event = action.event
         if let input = event.charactersIgnoringModifiers, !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.command) {
             return handleNormalPrintable(input: input, action: action, specialState: specialState)
         } else {
@@ -371,7 +371,7 @@ final class StateMachine {
         let text = composing.text
         let okuri = composing.okuri
         let romaji = composing.romaji
-        let event = action.originalEvent
+        let event = action.event
         let input = event.charactersIgnoringModifiers
         let converted: Romaji.ConvertedMoji?
 
@@ -1010,7 +1010,7 @@ final class StateMachine {
             break
         }
 
-        if let input = action.originalEvent.charactersIgnoringModifiers {
+        if let input = action.event.charactersIgnoringModifiers {
             if input == "x" {
                 if action.shiftIsPressed() {
                     state.specialState = .unregister(

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -305,7 +305,8 @@ final class StateMachine {
         if let input = event.charactersIgnoringModifiers, !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.command) {
             return handleNormalPrintable(input: input, action: action, specialState: specialState)
         } else {
-            return false
+            // 単語登録中や登録解除中はtrueを返してなにもしない
+            return state.specialState != nil
         }
     }
 

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -94,3 +94,6 @@
 "KeyBindingActionRegisterpaste" = "Paste on register";
 "KeyBindingActionEisu" = "Eisu Key";
 "KeyBindingActionKana" = "Kana Key";
+
+"KeyEisu" = "英数";
+"KeyKana" = "かな";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "MenuItemDirectInput" = "Direct input from \"%@\"";
 "MenuItemInsertBlankString" = "Insert Blank String for Workaround";
 "SettingsNameGeneral" = "General";
+"SettingsNameKeyBinding" = "Key Bindings";
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameSoftwareUpdate" = "Software Update";
 "SettingsNameDirectMode" = "Direct Mode";
@@ -69,3 +70,27 @@
 "Address" = "Address";
 "TCP Port" = "TCP Port No.";
 "Response Encoding" = "Response Encoding";
+
+"KeyBindingActionHiragana" = "Hiragana Mode";
+"KeyBindingActionTogglekana" = "Toggle Kana";
+"KeyBindingActionHankakukana" = "Hankaku Kana";
+"KeyBindingActionDirect" = "Direct Input";
+"KeyBindingActionZenkaku" = "Zenkaku Eisu Mode";
+"KeyBindingActionAbbrev" = "Abbrev Mode";
+"KeyBindingActionJapanese" = "Start Input Mode";
+"KeyBindingActionStickyshift" = "Sticky Shift";
+"KeyBindingActionEnter" = "Enter";
+"KeyBindingActionSpace" = "Space";
+"KeyBindingActionTab" = "Tab";
+"KeyBindingActionBackspace" = "Backspace";
+"KeyBindingActionDelete" = "Delete";
+"KeyBindingActionCancel" = "Cancel";
+"KeyBindingActionLeft" = "Left";
+"KeyBindingActionRight" = "Right";
+"KeyBindingActionDown" = "Down";
+"KeyBindingActionUp" = "Up";
+"KeyBindingActionStartofline" = "Go start of line";
+"KeyBindingActionEndofline" = "Go end of line";
+"KeyBindingActionRegisterpaste" = "Paste on register";
+"KeyBindingActionEisu" = "Eisu Key";
+"KeyBindingActionKana" = "Kana Key";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -4,8 +4,8 @@
 "MenuItemDirectInput" = "Direct input from \"%@\"";
 "MenuItemInsertBlankString" = "Insert Blank String for Workaround";
 "SettingsNameGeneral" = "General";
-"SettingsNameKeyBinding" = "Key Bindings";
 "SettingsNameDictionaries" = "Dictionaries";
+"SettingsNameKeyBinding" = "Key Bindings";
 "SettingsNameSoftwareUpdate" = "Software Update";
 "SettingsNameDirectMode" = "Direct Mode";
 "SettingsNameWorkaround" = "Workaround";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -4,8 +4,8 @@
 "MenuItemDirectInput" = "\"%@\"では直接入力";
 "MenuItemInsertBlankString" = "空文字挿入 (互換性)";
 "SettingsNameGeneral" = "一般";
-"SettingsNameKeyBinding" = "キーバインド";
 "SettingsNameDictionaries" = "辞書";
+"SettingsNameKeyBinding" = "キーバインド";
 "SettingsNameSoftwareUpdate" = "ソフトウェアアップデート";
 "SettingsNameDirectMode" = "直接入力";
 "SettingsNameWorkaround" = "互換性の設定";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "MenuItemDirectInput" = "\"%@\"では直接入力";
 "MenuItemInsertBlankString" = "空文字挿入 (互換性)";
 "SettingsNameGeneral" = "一般";
+"SettingsNameKeyBinding" = "キーバインド";
 "SettingsNameDictionaries" = "辞書";
 "SettingsNameSoftwareUpdate" = "ソフトウェアアップデート";
 "SettingsNameDirectMode" = "直接入力";
@@ -69,3 +70,27 @@
 "Address" = "アドレス";
 "TCP Port" = "TCPポート番号";
 "Response Encoding" = "応答エンコーディング";
+
+"KeyBindingActionHiragana" = "ひらがなモード";
+"KeyBindingActionTogglekana" = "かなカナ切り替え";
+"KeyBindingActionHankakukana" = "半角カナモード";
+"KeyBindingActionDirect" = "直接入力";
+"KeyBindingActionZenkaku" = "全角英数モード";
+"KeyBindingActionAbbrev" = "Abbrevモード";
+"KeyBindingActionJapanese" = "未確定入力開始";
+"KeyBindingActionStickyshift" = "Sticky Shift";
+"KeyBindingActionEnter" = "Enter";
+"KeyBindingActionSpace" = "Space";
+"KeyBindingActionTab" = "Tab";
+"KeyBindingActionBackspace" = "Backspace";
+"KeyBindingActionDelete" = "Delete";
+"KeyBindingActionCancel" = "キャンセル";
+"KeyBindingActionLeft" = "左";
+"KeyBindingActionRight" = "右";
+"KeyBindingActionDown" = "下";
+"KeyBindingActionUp" = "上";
+"KeyBindingActionStartofline" = "行頭へ移動";
+"KeyBindingActionEndofline" = "行末へ移動";
+"KeyBindingActionRegisterpaste" = "登録モードでペースト";
+"KeyBindingActionEisu" = "英数キー";
+"KeyBindingActionKana" = "かなキー";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -94,3 +94,6 @@
 "KeyBindingActionRegisterpaste" = "登録モードでペースト";
 "KeyBindingActionEisu" = "英数キー";
 "KeyBindingActionKana" = "かなキー";
+
+"KeyEisu" = "英数";
+"KeyKana" = "かな";

--- a/macSKKTests/Character+KeyCode.swift
+++ b/macSKKTests/Character+KeyCode.swift
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Carbon.HIToolbox.Events
+
+extension Character {
+    var keyCode: UInt16? {
+        switch self {
+        case "a":
+            return UInt16(kVK_ANSI_A)
+        case "b":
+            return UInt16(kVK_ANSI_B)
+        case "c":
+            return UInt16(kVK_ANSI_C)
+        case "d":
+            return UInt16(kVK_ANSI_D)
+        case "e":
+            return UInt16(kVK_ANSI_E)
+        case "f":
+            return UInt16(kVK_ANSI_F)
+        case "g":
+            return UInt16(kVK_ANSI_G)
+        case "h":
+            return UInt16(kVK_ANSI_H)
+        case "i":
+            return UInt16(kVK_ANSI_I)
+        case "j":
+            return UInt16(kVK_ANSI_J)
+        case "k":
+            return UInt16(kVK_ANSI_K)
+        case "l":
+            return UInt16(kVK_ANSI_L)
+        case "m":
+            return UInt16(kVK_ANSI_M)
+        case "n":
+            return UInt16(kVK_ANSI_N)
+        case "o":
+            return UInt16(kVK_ANSI_O)
+        case "p":
+            return UInt16(kVK_ANSI_P)
+        case "q":
+            return UInt16(kVK_ANSI_Q)
+        case "r":
+            return UInt16(kVK_ANSI_R)
+        case "s":
+            return UInt16(kVK_ANSI_S)
+        case "t":
+            return UInt16(kVK_ANSI_T)
+        case "u":
+            return UInt16(kVK_ANSI_U)
+        case "v":
+            return UInt16(kVK_ANSI_V)
+        case "w":
+            return UInt16(kVK_ANSI_W)
+        case "x":
+            return UInt16(kVK_ANSI_X)
+        case "y":
+            return UInt16(kVK_ANSI_Y)
+        case "z":
+            return UInt16(kVK_ANSI_Z)
+        case ";":
+            return UInt16(kVK_ANSI_Semicolon)
+        case "/":
+            return UInt16(kVK_ANSI_Slash)
+        case " ":
+            return UInt16(kVK_Space)
+        default:
+            return nil
+        }
+    }
+}

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1667,10 +1667,10 @@ final class StateMachineTests: XCTestCase {
     @MainActor func testHandleComposingUnregisteredKeyEventWithModifiers() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
-        // キーバインドとして登録されてないC-kはhandleはfalseを返す
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
-        // Cmd-cもhandleせずfalseを返す
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
+        // キーバインドとして登録されてないC-kはhandleはtrueを返して無視する
+        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
+        // Cmd-cもhandleせずtrueを返して無視する
+        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
     }
 
     @MainActor func testHandleRegisteringEnter() {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -209,6 +209,14 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleNormalUnregisteredKeyEventWithModifiers() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        // キーバインドとして登録されてないC-kはhandleはfalseを返す
+        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
+        // Cmd-cもhandleせずfalseを返す
+        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
+    }
+
     @MainActor func testHandleNormalNoAlphabetEisu() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .eisu))
         let expectation = XCTestExpectation()
@@ -1689,6 +1697,15 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(registerPasteAction))
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor func testHandleComposingUnregisteredKeyEventWithModifiers() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        // キーバインドとして登録されてないC-kはhandleはfalseを返す
+        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
+        // Cmd-cもhandleせずfalseを返す
+        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
     }
 
     @MainActor func testHandleRegisteringEnter() {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -13,42 +13,6 @@ final class StateMachineTests: XCTestCase {
         let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule", withExtension: "conf")!
         return try! Romaji(contentsOf: kanaRuleFileURL)
     }
-    // Ctrl-jを押した
-    var hiraganaAction: Action {
-        Action(keyBind: .hiragana, originalEvent: generateNSEvent(character: "j", characterIgnoringModifiers: "j", modifierFlags: .control), cursorPosition: .zero)
-    }
-    // Ctrl-qを押した
-    var hankakuKanaAction: Action {
-        Action(keyBind: .hankakuKana, originalEvent: generateNSEvent(character: "q", characterIgnoringModifiers: "q", modifierFlags: .control), cursorPosition: .zero)
-    }
-    // エンターキーを押した
-    var enterAction: Action {
-        Action(keyBind: .enter, originalEvent: generateNSEvent(character: "\r", characterIgnoringModifiers: "\r"), cursorPosition: .zero)
-    }
-    // Ctrl-gキーを押した
-    var cancelAction: Action {
-        Action(keyBind: .cancel, originalEvent: generateNSEvent(character: "g", characterIgnoringModifiers: "g", modifierFlags: .control), cursorPosition: .zero)
-    }
-    // Ctrl-aキーを押した
-    var startOfLineAction: Action {
-        Action(keyBind: .startOfLine, originalEvent: generateNSEvent(character: "a", characterIgnoringModifiers: "a", modifierFlags: .control), cursorPosition: .zero)
-    }
-    // Ctrl-eキーを押した
-    var endOfLineAction: Action {
-        Action(keyBind: .endOfLine, originalEvent: generateNSEvent(character: "e", characterIgnoringModifiers: "e", modifierFlags: .control), cursorPosition: .zero)
-    }
-    // Ctrl-yキーを押した
-    var registerPasteAction: Action {
-        Action(keyBind: .registerPaste, originalEvent: generateNSEvent(character: "y", characterIgnoringModifiers: "y", modifierFlags: .control), cursorPosition: .zero)
-    }
-    // 英数キーを押した
-    var eisuKeyAction: Action {
-        Action(keyBind: .eisu, originalEvent: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
-    }
-    // かなキーを押した
-    var kanaKeyAction: Action {
-        Action(keyBind: .kana, originalEvent: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
-    }
 
     @MainActor override func setUpWithError() throws {
         Global.dictionary.setEntries([:])
@@ -236,8 +200,8 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testHandleNormalUpDown() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .up, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(upKeyAction))
+        XCTAssertFalse(stateMachine.handle(downKeyAction))
     }
 
     @MainActor func testHandleNormalPrintable() {
@@ -295,7 +259,7 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .space, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
         wait(for: [expectation], timeout: 1.0)
@@ -465,14 +429,14 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
         XCTAssertTrue(stateMachine.handle(cancelAction))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal)
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(leftKeyAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
     @MainActor func testHandleNormalLeftRight() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(leftKeyAction))
+        XCTAssertFalse(stateMachine.handle(rightKeyAction))
     }
 
     @MainActor func testHandleNormalCtrlAEY() {
@@ -758,12 +722,12 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "h", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1173,7 +1137,7 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -1192,7 +1156,7 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -1212,7 +1176,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "/")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "b")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "c")))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -1444,13 +1408,13 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ";")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(rightKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(rightKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k", withShift: true)))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -1471,7 +1435,7 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "r")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "y")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
@@ -1495,13 +1459,13 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで左矢印キーが押されたら未入力に戻す")
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(rightKeyAction))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみで右矢印キーが押されたら未入力に戻す")
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(rightKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
         XCTAssertTrue(stateMachine.handle(startOfLineAction))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Aが押されたら未入力に戻す")
@@ -1511,9 +1475,9 @@ final class StateMachineTests: XCTestCase {
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでCtrl-Eが押されたら未入力に戻す")
         XCTAssertFalse(stateMachine.handle(endOfLineAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "b")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         XCTAssertEqual(stateMachine.state.inputMethod, .normal, "ローマ字のみでBackspaceが押されたら未入力に戻す")
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1532,7 +1496,7 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         wait(for: [expectation], timeout: 1.0)
@@ -1551,9 +1515,9 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .up, originalEvent: nil, cursorPosition: .zero)), "受理するけど無視する")
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)), "受理するけど無視する")
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(upKeyAction), "受理するけど無視する")
+        XCTAssertTrue(stateMachine.handle(downKeyAction), "受理するけど無視する")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -1568,7 +1532,7 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -1612,8 +1576,8 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1629,9 +1593,9 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .delete, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .delete, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(deleteAction))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(deleteAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1661,7 +1625,7 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         stateMachine.completion = ("い", "いろは")
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "\t")))
         wait(for: [expectation], timeout: 1.0)
@@ -1815,14 +1779,14 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(rightKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .right, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(rightKeyAction))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
@@ -1847,8 +1811,8 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1869,8 +1833,8 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .delete, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(deleteAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -1933,8 +1897,8 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .up, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(upKeyAction))
+        XCTAssertTrue(stateMachine.handle(downKeyAction))
         Pasteboard.stringForTest = nil
         wait(for: [expectation], timeout: 1.0)
     }
@@ -2058,7 +2022,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(enterAction))
         wait(for: [expectation], timeout: 1.0)
@@ -2083,7 +2047,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
         wait(for: [expectation], timeout: 1.0)
@@ -2107,9 +2071,9 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -2219,11 +2183,11 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(downKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(downKeyAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -2281,7 +2245,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .up, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(upKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "x")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
@@ -2337,8 +2301,8 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(downKeyAction))
+        XCTAssertTrue(stateMachine.handle(downKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "2")))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -2361,8 +2325,8 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "x", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .up, originalEvent: nil, cursorPosition: .zero)), "上キーやC-pは無視")
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .down, originalEvent: nil, cursorPosition: .zero)), "下キーやC-nは無視")
+        XCTAssertTrue(stateMachine.handle(upKeyAction), "上キーやC-pは無視")
+        XCTAssertTrue(stateMachine.handle(downKeyAction), "下キーやC-nは無視")
         XCTAssertTrue(stateMachine.handle(hiraganaAction))
         "yes".forEach { character in
             XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: character)))
@@ -2409,14 +2373,14 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "r", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .backspace, originalEvent: nil, cursorPosition: .zero)))
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: .left, originalEvent: nil, cursorPosition: .zero))) // 何もinputMethodEventには流れない
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction)) // 何もinputMethodEventには流れない
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -2572,6 +2536,67 @@ final class StateMachineTests: XCTestCase {
         XCTAssertEqual(Global.dictionary.refer("いt"), [Word("言", okuri: "った", annotation: nil)])
     }
 
+    // Ctrl-jを押した
+    var hiraganaAction: Action {
+        Action(keyBind: .hiragana, originalEvent: generateNSEvent(character: "j", characterIgnoringModifiers: "j", modifierFlags: .control), cursorPosition: .zero)
+    }
+    // Ctrl-qを押した
+    var hankakuKanaAction: Action {
+        Action(keyBind: .hankakuKana, originalEvent: generateNSEvent(character: "q", characterIgnoringModifiers: "q", modifierFlags: .control), cursorPosition: .zero)
+    }
+    // エンターキーを押した
+    var enterAction: Action {
+        Action(keyBind: .enter, originalEvent: generateNSEvent(character: "\r", characterIgnoringModifiers: "\r"), cursorPosition: .zero)
+    }
+    // Ctrl-gキーを押した
+    var cancelAction: Action {
+        Action(keyBind: .cancel, originalEvent: generateNSEvent(character: "g", characterIgnoringModifiers: "g", modifierFlags: .control), cursorPosition: .zero)
+    }
+    // Ctrl-aキーを押した
+    var startOfLineAction: Action {
+        Action(keyBind: .startOfLine, originalEvent: generateNSEvent(character: "a", characterIgnoringModifiers: "a", modifierFlags: .control), cursorPosition: .zero)
+    }
+    // Ctrl-eキーを押した
+    var endOfLineAction: Action {
+        Action(keyBind: .endOfLine, originalEvent: generateNSEvent(character: "e", characterIgnoringModifiers: "e", modifierFlags: .control), cursorPosition: .zero)
+    }
+    // Ctrl-yキーを押した
+    var registerPasteAction: Action {
+        Action(keyBind: .registerPaste, originalEvent: generateNSEvent(character: "y", characterIgnoringModifiers: "y", modifierFlags: .control), cursorPosition: .zero)
+    }
+    // 矢印の上キーを押した
+    var upKeyAction: Action {
+        Action(keyBind: .up, originalEvent: generateNSEvent(character: "\u{63232}", characterIgnoringModifiers: "\u{63232}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+    }
+    // 矢印の下キーを押した
+    var downKeyAction: Action {
+        Action(keyBind: .down, originalEvent: generateNSEvent(character: "\u{63233}", characterIgnoringModifiers: "\u{63233}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+    }
+    // 矢印の左キーを押した
+    var leftKeyAction: Action {
+        Action(keyBind: .left, originalEvent: generateNSEvent(character: "\u{63234}", characterIgnoringModifiers: "\u{63234}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+    }
+    // 矢印の右キーを押した
+    var rightKeyAction: Action {
+        Action(keyBind: .right, originalEvent: generateNSEvent(character: "\u{63235}", characterIgnoringModifiers: "\u{63235}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+    }
+    // Backspaceを押した
+    var backspaceAction: Action {
+        Action(keyBind: .backspace, originalEvent: generateNSEvent(character: "\u{127}", characterIgnoringModifiers: "\u{127}"), cursorPosition: .zero)
+    }
+    // Deleteを押した
+    var deleteAction: Action {
+        Action(keyBind: .delete, originalEvent: generateNSEvent(character: "\u{63272}", characterIgnoringModifiers: "\u{63272}", modifierFlags: .function), cursorPosition: .zero)
+    }
+    // 英数キーを押した
+    var eisuKeyAction: Action {
+        Action(keyBind: .eisu, originalEvent: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
+    }
+    // かなキーを押した
+    var kanaKeyAction: Action {
+        Action(keyBind: .kana, originalEvent: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
+    }
+
     private func printableKeyEventAction(character: Character, characterIgnoringModifier: Character? = nil, withShift: Bool = false) -> Action {
         let characterIgnoringModifiers = characterIgnoringModifier ?? character
         if withShift {
@@ -2622,7 +2647,7 @@ final class StateMachineTests: XCTestCase {
         }
     }
 
-    private func generateKeyEventWithShift(character: Character) -> NSEvent? {
+    private func generateKeyEventWithShift(character: Character) -> NSEvent {
         return generateNSEvent(
             character: character.uppercased().first!,
             characterIgnoringModifiers: character.lowercased().first!,
@@ -2631,7 +2656,7 @@ final class StateMachineTests: XCTestCase {
 
     private func generateNSEvent(
         character: Character, characterIgnoringModifiers: Character, modifierFlags: NSEvent.ModifierFlags = []
-    ) -> NSEvent? {
+    ) -> NSEvent {
         return NSEvent.keyEvent(
             with: .keyDown,
             location: .zero,
@@ -2643,6 +2668,6 @@ final class StateMachineTests: XCTestCase {
             charactersIgnoringModifiers: String(characterIgnoringModifiers),
             isARepeat: false,
             keyCode: characterIgnoringModifiers.keyCode ?? UInt16(0)
-        )
+        )!
     }
 }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -176,9 +176,9 @@ final class StateMachineTests: XCTestCase {
     @MainActor func testHandleNormalUnregisteredKeyEventWithModifiers() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         // キーバインドとして登録されてないC-kはhandleはfalseを返す
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
         // Cmd-cもhandleせずfalseを返す
-        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
+        XCTAssertFalse(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
     }
 
     @MainActor func testHandleNormalNoAlphabetEisu() {
@@ -519,7 +519,7 @@ final class StateMachineTests: XCTestCase {
             character: "Ω",
             characterIgnoringModifiers: "z",
             modifierFlags: [.option])
-        let action = Action(keyBind: nil, originalEvent: event, cursorPosition: .zero)
+        let action = Action(keyBind: nil, event: event, cursorPosition: .zero)
 
         XCTAssertTrue(stateMachine.handle(action))
         wait(for: [expectation], timeout: 1.0)
@@ -1668,9 +1668,9 @@ final class StateMachineTests: XCTestCase {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
         // キーバインドとして登録されてないC-kはhandleはtrueを返して無視する
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
         // Cmd-cもhandleせずtrueを返して無視する
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
     }
 
     @MainActor func testHandleRegisteringEnter() {
@@ -1872,9 +1872,9 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         // キーバインドとして登録されてないC-kはhandleは単語登録中はtrueを返す (未確定文字列がないときはfalseを返す)
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "k", characterIgnoringModifiers: "k", modifierFlags: .control), cursorPosition: .zero)))
         // Cmd-cも処理せずtrueを返す
-        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, originalEvent: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
+        XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command), cursorPosition: .zero)))
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -2556,63 +2556,63 @@ final class StateMachineTests: XCTestCase {
 
     // Ctrl-jを押した
     var hiraganaAction: Action {
-        Action(keyBind: .hiragana, originalEvent: generateNSEvent(character: "j", characterIgnoringModifiers: "j", modifierFlags: .control), cursorPosition: .zero)
+        Action(keyBind: .hiragana, event: generateNSEvent(character: "j", characterIgnoringModifiers: "j", modifierFlags: .control), cursorPosition: .zero)
     }
     // Ctrl-qを押した
     var hankakuKanaAction: Action {
-        Action(keyBind: .hankakuKana, originalEvent: generateNSEvent(character: "q", characterIgnoringModifiers: "q", modifierFlags: .control), cursorPosition: .zero)
+        Action(keyBind: .hankakuKana, event: generateNSEvent(character: "q", characterIgnoringModifiers: "q", modifierFlags: .control), cursorPosition: .zero)
     }
     // エンターキーを押した
     var enterAction: Action {
-        Action(keyBind: .enter, originalEvent: generateNSEvent(character: "\r", characterIgnoringModifiers: "\r"), cursorPosition: .zero)
+        Action(keyBind: .enter, event: generateNSEvent(character: "\r", characterIgnoringModifiers: "\r"), cursorPosition: .zero)
     }
     // Ctrl-gキーを押した
     var cancelAction: Action {
-        Action(keyBind: .cancel, originalEvent: generateNSEvent(character: "g", characterIgnoringModifiers: "g", modifierFlags: .control), cursorPosition: .zero)
+        Action(keyBind: .cancel, event: generateNSEvent(character: "g", characterIgnoringModifiers: "g", modifierFlags: .control), cursorPosition: .zero)
     }
     // Ctrl-aキーを押した
     var startOfLineAction: Action {
-        Action(keyBind: .startOfLine, originalEvent: generateNSEvent(character: "a", characterIgnoringModifiers: "a", modifierFlags: .control), cursorPosition: .zero)
+        Action(keyBind: .startOfLine, event: generateNSEvent(character: "a", characterIgnoringModifiers: "a", modifierFlags: .control), cursorPosition: .zero)
     }
     // Ctrl-eキーを押した
     var endOfLineAction: Action {
-        Action(keyBind: .endOfLine, originalEvent: generateNSEvent(character: "e", characterIgnoringModifiers: "e", modifierFlags: .control), cursorPosition: .zero)
+        Action(keyBind: .endOfLine, event: generateNSEvent(character: "e", characterIgnoringModifiers: "e", modifierFlags: .control), cursorPosition: .zero)
     }
     // Ctrl-yキーを押した
     var registerPasteAction: Action {
-        Action(keyBind: .registerPaste, originalEvent: generateNSEvent(character: "y", characterIgnoringModifiers: "y", modifierFlags: .control), cursorPosition: .zero)
+        Action(keyBind: .registerPaste, event: generateNSEvent(character: "y", characterIgnoringModifiers: "y", modifierFlags: .control), cursorPosition: .zero)
     }
     // 矢印の上キーを押した
     var upKeyAction: Action {
-        Action(keyBind: .up, originalEvent: generateNSEvent(character: "\u{63232}", characterIgnoringModifiers: "\u{63232}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+        Action(keyBind: .up, event: generateNSEvent(character: "\u{63232}", characterIgnoringModifiers: "\u{63232}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
     }
     // 矢印の下キーを押した
     var downKeyAction: Action {
-        Action(keyBind: .down, originalEvent: generateNSEvent(character: "\u{63233}", characterIgnoringModifiers: "\u{63233}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+        Action(keyBind: .down, event: generateNSEvent(character: "\u{63233}", characterIgnoringModifiers: "\u{63233}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
     }
     // 矢印の左キーを押した
     var leftKeyAction: Action {
-        Action(keyBind: .left, originalEvent: generateNSEvent(character: "\u{63234}", characterIgnoringModifiers: "\u{63234}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+        Action(keyBind: .left, event: generateNSEvent(character: "\u{63234}", characterIgnoringModifiers: "\u{63234}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
     }
     // 矢印の右キーを押した
     var rightKeyAction: Action {
-        Action(keyBind: .right, originalEvent: generateNSEvent(character: "\u{63235}", characterIgnoringModifiers: "\u{63235}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+        Action(keyBind: .right, event: generateNSEvent(character: "\u{63235}", characterIgnoringModifiers: "\u{63235}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
     }
     // Backspaceを押した
     var backspaceAction: Action {
-        Action(keyBind: .backspace, originalEvent: generateNSEvent(character: "\u{127}", characterIgnoringModifiers: "\u{127}"), cursorPosition: .zero)
+        Action(keyBind: .backspace, event: generateNSEvent(character: "\u{127}", characterIgnoringModifiers: "\u{127}"), cursorPosition: .zero)
     }
     // Deleteを押した
     var deleteAction: Action {
-        Action(keyBind: .delete, originalEvent: generateNSEvent(character: "\u{63272}", characterIgnoringModifiers: "\u{63272}", modifierFlags: .function), cursorPosition: .zero)
+        Action(keyBind: .delete, event: generateNSEvent(character: "\u{63272}", characterIgnoringModifiers: "\u{63272}", modifierFlags: .function), cursorPosition: .zero)
     }
     // 英数キーを押した
     var eisuKeyAction: Action {
-        Action(keyBind: .eisu, originalEvent: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
+        Action(keyBind: .eisu, event: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
     }
     // かなキーを押した
     var kanaKeyAction: Action {
-        Action(keyBind: .kana, originalEvent: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
+        Action(keyBind: .kana, event: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
     }
 
     private func printableKeyEventAction(character: Character, characterIgnoringModifier: Character? = nil, withShift: Bool = false) -> Action {
@@ -2621,7 +2621,7 @@ final class StateMachineTests: XCTestCase {
             if let characterIgnoringModifier {
                 return Action(
                     keyBind: keyBind(character: characterIgnoringModifiers, withShift: withShift),
-                    originalEvent: generateNSEvent(character: character,
+                    event: generateNSEvent(character: character,
                                                    characterIgnoringModifiers: characterIgnoringModifier,
                                                    modifierFlags: [.shift]),
                     cursorPosition: .zero
@@ -2629,14 +2629,14 @@ final class StateMachineTests: XCTestCase {
             } else {
                 return Action(
                     keyBind: keyBind(character: characterIgnoringModifiers, withShift: withShift),
-                    originalEvent: generateKeyEventWithShift(character: character),
+                    event: generateKeyEventWithShift(character: character),
                     cursorPosition: .zero
                 )
             }
         } else {
             return Action(
                 keyBind: keyBind(character: characterIgnoringModifiers, withShift: withShift),
-                originalEvent: generateNSEvent(
+                event: generateNSEvent(
                     character: character,
                     characterIgnoringModifiers: characterIgnoringModifier ?? character),
                 cursorPosition: .zero

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -138,7 +138,7 @@ final class StateMachineTests: XCTestCase {
     @MainActor func testHandleNormalEnter() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         // 未入力状態ならfalse
-        XCTAssertFalse(stateMachine.handle(printableKeyEventAction(character: "\r")))
+        XCTAssertFalse(stateMachine.handle(enterAction))
     }
 
     @MainActor func testHandleNormalEisu() {
@@ -420,6 +420,7 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testHandleNormalCtrlQ() {
         var stateMachine = StateMachine(initialState: IMEState(inputMode: .direct))
+        XCTAssertFalse(stateMachine.handle(hankakuKanaAction))
         let expectation = XCTestExpectation()
         stateMachine = StateMachine(initialState: IMEState(inputMode: .katakana))
         stateMachine.inputMethodEvent.collect(3).sink { events in


### PR DESCRIPTION
#148 の修正の第一段。
まだユーザーによるカスタマイズはできませんが、前段階として固定化されていたキーバインドを抽象化して設定として持てるようにします。

設定画面に現状のキーバインドを表示する画面をつけていますが、前述の通りまだカスタマイズはできません。見えるだけ。
キーバインドの名前はやっつけでつけています。あとでddskkなどを見ながらそれっぽい名前に変えるかもしれません。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/a5c35669-af51-4d15-aa41-40393ff55d26">

おまけ機能として、デバッグビルド時のみに見えるキーイベント設定画面に、キー入力イベントが現在のキーバインド設定にあるかどうかを見えるようにしました。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/be028760-369b-4d3d-817e-db27028f1027">
