### PR TITLE
選択候補パネルから確定するためのキーを設定可能にする

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -26,6 +26,8 @@ import Combine
     static var defaultKanaRule: Romaji!
     /// 現在のキーバインディング
     static var keyBinding: KeyBindingSet = KeyBindingSet.defaultKeyBindingSet
+    /// 変換候補パネルから選択するときに使用するキーの配列。
+    static var selectCandidateKeys: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     // 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -26,7 +26,7 @@ import Combine
     static var defaultKanaRule: Romaji!
     /// 現在のキーバインディング
     static var keyBinding: KeyBindingSet = KeyBindingSet.defaultKeyBindingSet
-    /// 変換候補パネルから選択するときに使用するキーの配列。
+    /// 変換候補パネルから選択するときに使用するキーの配列。英字の場合は小文字にしておくこと。
     static var selectCandidateKeys: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -17,6 +17,11 @@ struct GeneralView: View {
                 Toggle(isOn: $settingsViewModel.showAnnotation, label: {
                     Text("Show Annotation")
                 })
+                Picker("Keys of selecting candidates", selection: $settingsViewModel.selectCandidateKeys) {
+                    Text("123456789").tag("123456789")
+                    Text("ASDFGHJKL").tag("ASDFGHJKL")
+                    Text("AOEUIDHTN").tag("AOEUIDHTN")
+                }
                 Section {
                     Picker("Number of inline candidates", selection: $settingsViewModel.inlineCandidateCount) {
                         ForEach(0..<10) { count in

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -197,6 +197,7 @@ final class SettingsViewModel: ObservableObject {
 
         // TODO: 設定化。いまはとりあえず固定でデフォルト設定を表示
         self.keyBingings = KeyBinding.defaultKeyBindingSettings
+        Global.selectCandidateKeys = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectCandidateKeys)!.map { $0 }
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 
+// UserDefaultsのキー。camelCaseでの命名を採用しています。
 struct UserDefaultsKeys {
     static let dictionaries = "dictionaries"
     static let directModeBundleIdentifiers = "directModeBundleIdentifiers"
@@ -15,4 +16,7 @@ struct UserDefaultsKeys {
     static let annotationFontSize = "annotationFontSize"
     // SKK辞書サーバーへの接続設定
     static let skkservClient = "skkserv"
+    // 選択候補パネルから決定するショートカットキー。
+    // 初期値は "123456789"。
+    static let selectCandidateKeys = "selectCandidateKeys"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1037,8 +1037,8 @@ final class StateMachine {
                 }
                 return handle(action)
             } else if selecting.candidateIndex >= inlineCandidateCount {
-                if let index = Int(input), 1 <= index && index <= 9 {
-                    let diff = index - 1 - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
+                if let first = input.first, let index = Global.selectCandidateKeys.firstIndex(of: first), index < displayCandidateCount {
+                    let diff = index - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
                     if selecting.candidateIndex + diff < selecting.candidates.count {
                         let newSelecting = selecting.addCandidateIndex(diff: diff)
                         fixCurrentSelect(selecting: newSelecting)

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1037,7 +1037,7 @@ final class StateMachine {
                 }
                 return handle(action)
             } else if selecting.candidateIndex >= inlineCandidateCount {
-                if let first = input.first, let index = Global.selectCandidateKeys.firstIndex(of: first), index < displayCandidateCount {
+                if let first = input.lowercased().first, let index = Global.selectCandidateKeys.firstIndex(of: first), index < displayCandidateCount {
                     let diff = index - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
                     if selecting.candidateIndex + diff < selecting.candidates.count {
                         let newSelecting = selecting.addCandidateIndex(diff: diff)

--- a/macSKK/View/CandidatesView.swift
+++ b/macSKK/View/CandidatesView.swift
@@ -42,7 +42,7 @@ struct CandidatesView: View {
                 VStack(spacing: 0) {
                     List(Array(words.enumerated()), id: \.element, selection: $candidates.selected) { index, candidate in
                         HStack {
-                            Text("\(index + 1)")
+                            Text(String(Global.selectCandidateKeys[index]).uppercased())
                                 // 変換候補の90%のフォントサイズ
                                 .font(.system(size: candidates.candidatesFontSize * 0.9))
                                 .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 0))

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keybaord Layout";
 "Show Annotation" = "Show the annotation of the candidate in current";
+"Keys of selecting candidates" = "Keys of selecting candidates";
 "Copy" = "Copy";
 "Number of inline candidates" = "Number of inline candidates";
 "Candidates font size" = "Candidates font size";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "Open Release Page" = "リリースページを開く";
 "Keyboard Layout" = "キー配列";
 "Show Annotation" = "現在の変換候補の注釈を表示";
+"Keys of selecting candidates" = "変換候補の決定に使用するキー";
 "Copy" = "コピー";
 "Number of inline candidates" = "インラインで表示する変換候補の数";
 "Candidates font size" = "変換候補のフォントサイズ";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -177,6 +177,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.selectedInputSource: InputSource.defaultInputSourceId,
             UserDefaultsKeys.showAnnotation: true,
             UserDefaultsKeys.inlineCandidateCount: 3,
+            UserDefaultsKeys.selectCandidateKeys: "123456789",
             UserDefaultsKeys.workarounds: [
                 ["bundleIdentifier": "net.kovidgoyal.kitty", "insertBlankString": true],
                 ["bundleIdentifier": "jp.naver.line.mac", "insertBlankString": true],

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -21,6 +21,7 @@ final class StateMachineTests: XCTestCase {
         // テストごとにローマ字かな変換ルールをデフォルトに戻す
         // こうしないとテストの中でGlobal.kanaRuleを書き換えるテストと一緒に走らせると違うかな変換ルールのままに実行されてしまう
         Global.kanaRule = Self.defaultKanaRule
+        Global.selectCandidateKeys = "123456789".map { $0 }
     }
 
     @MainActor func testHandleNormalSimple() {


### PR DESCRIPTION
#157 変換候補の確定に使うキーを、これまで "123456789" 固定だったものを設定できるようにします。
これまでの数字の他にQWERTYのホームポジションの列の "ASDFGHJKL" と、それのDvorak配列版の "AOEUIDHTN" から選択可能です。

<img width="406" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/8d10463d-e012-4ba1-ac25-bc085f2805dd">

設定画面の「一般」→「変換候補の決定に使用するキー」から変更可能です。

<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/6fdf5f99-170b-4dc1-97ec-4ec29a6e300a">