### PR TITLE
インストーラでバージョンチェックしないようにしてダウングレード可能にする

### DIFF
--- a/script/app.plist
+++ b/script/app.plist
@@ -8,7 +8,7 @@
 		<key>BundleIsRelocatable</key>
 		<true/>
 		<key>BundleIsVersionChecked</key>
-		<true/>
+		<false/>
 		<key>BundleOverwriteAction</key>
 		<string>upgrade</string>
 		<key>RootRelativeBundlePath</key>


### PR DESCRIPTION
たとえばv0.23.0を使っている人がv0.22.1をインストールしようとするとインストールには成功するが、`~/Library/Input Methods/macSKK.app` はv0.23.0のままになってしまう。
これはおそらくインストーラの設定でBundleIsVersionCheckedがtrueになっているため。

`man pkgbuild` より。

```
BundleIsVersionChecked             Don't install bundle if newer version on disk? (bool)
```