### PR TITLE
変換候補削除のShift-Xをキーバインドに追加

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -53,6 +53,8 @@ struct KeyBinding: Identifiable {
         case endOfLine
         /// 単語登録時のみクリップボードからテキストをペーストする。デフォルトはCtrl-yキー
         case registerPaste
+        /// 変換候補選択時に入力することで登録解除確認へ遷移する。デフォルトはShift-xキー
+        case unregister
         /// 英数キー
         /// TODO: カスタマイズできなくする?
         case eisu
@@ -63,6 +65,7 @@ struct KeyBinding: Identifiable {
 
     enum Key: Hashable, Equatable {
         /// jやqやlなど、キーに印字されているテキスト。
+        /// シフトを押しながら入力する場合は英字は小文字、!や#など記号はそのまま。
         case character(Character)
         /// keyCode形式。矢印キーなど表記できないキーを表現するために使用する。
         /// 設定でDvorak配列を選んでいる場合などもkeyCodeはQwerty配列の位置のままなので基本的にはcharacterで設定すること。
@@ -81,7 +84,7 @@ struct KeyBinding: Identifiable {
         let displayString: String
 
         init(event: NSEvent) {
-            if let character = event.charactersIgnoringModifiers?.first, Key.characters.contains(character) {
+            if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
                 key = .character(character)
             } else {
                 key = .code(event.keyCode)
@@ -189,6 +192,8 @@ struct KeyBinding: Identifiable {
                 return KeyBinding(action, [Input(key: .character("a"), displayString: "A", modifierFlags: .control)])
             case .endOfLine:
                 return KeyBinding(action, [Input(key: .character("e"), displayString: "E", modifierFlags: .control)])
+            case .unregister:
+                return KeyBinding(action, [Input(key: .character("x"), displayString: "X", modifierFlags: .shift)])
             case .registerPaste:
                 return KeyBinding(action, [Input(key: .character("y"), displayString: "Y", modifierFlags: .control)])
             case .eisu:

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -92,6 +92,7 @@
 "KeyBindingActionUp" = "Up";
 "KeyBindingActionStartofline" = "Go start of line";
 "KeyBindingActionEndofline" = "Go end of line";
+"KeyBindingActionUnregister" = "Unregister selected candidate";
 "KeyBindingActionRegisterpaste" = "Paste on register";
 "KeyBindingActionEisu" = "Eisu Key";
 "KeyBindingActionKana" = "Kana Key";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -92,6 +92,7 @@
 "KeyBindingActionUp" = "上";
 "KeyBindingActionStartofline" = "行頭へ移動";
 "KeyBindingActionEndofline" = "行末へ移動";
+"KeyBindingActionUnregister" = "選択中の変換候補の削除";
 "KeyBindingActionRegisterpaste" = "登録モードでペースト";
 "KeyBindingActionEisu" = "英数キー";
 "KeyBindingActionKana" = "かなキー";


### PR DESCRIPTION
#158 変換候補が表示されているときにShift-Xで変換候補から削除できます。
このキーバインドも変更可能にできるようにするため、まずはKeyBindingとして登録します。