### PR TITLE
互換性の設定のアイコンをmacOS 13で使えるものに変更

### DIFF
--- a/macSKK/Settings/SettingsView.swift
+++ b/macSKK/Settings/SettingsView.swift
@@ -41,7 +41,7 @@ struct SettingsView: View {
                     case .directMode:
                         Label(section.localizedStringKey, systemImage: "hand.raised.app")
                     case .workaround:
-                        Label(section.localizedStringKey, systemImage: "shield.checkered")
+                        Label(section.localizedStringKey, systemImage: "shield.lefthalf.filled")
                     case .log:
                         Label(section.localizedStringKey, systemImage: "doc.plaintext")
                     #if DEBUG


### PR DESCRIPTION
互換性の設定のアイコンに指定していた `shield.checkered` は SF Symbols 5.0から導入されており、macOS 13では表示されていませんでした。
macOS 13でも表示可能な `shield.lefthalf.filled` (SF Symbols 3.0) に変更します。

before | after
------ | -----
<img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/b51994e0-6340-45c3-8fd1-e646289b21ca"> | <img width="640" alt="image" src="https://github.com/mtgto/macSKK/assets/1213991/5b3ddc32-09b4-4185-93c6-c10334ce39df">
