### PR TITLE
単語登録中に単語登録削除に遷移しキャンセルしたら単語登録中に戻るように修正

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -558,15 +558,15 @@ struct UnregisterState: SpecialStateProtocol {
 enum SpecialState: SpecialStateProtocol {
     /// 単語登録状態。登録中に登録する再帰可能でその場合はprevの末尾に現在の登録状態を付けて新しい状態に遷移する。
     case register(RegisterState, prev: [RegisterState])
-    /// 単語登録解除
-    case unregister(UnregisterState)
+    /// 単語登録解除。登録中に入力した単語を登録解除したときには登録状態を保持しておく
+    case unregister(UnregisterState, prev: (RegisterState, [RegisterState])?)
 
     func appendText(_ text: String) -> Self {
         switch self {
         case .register(let registerState, let prev):
             return .register(registerState.appendText(text), prev: prev)
-        case .unregister(let unregisterState):
-            return .unregister(unregisterState.appendText(text))
+        case .unregister(let unregisterState, let prev):
+            return .unregister(unregisterState.appendText(text), prev: prev)
         }
     }
 
@@ -574,8 +574,8 @@ enum SpecialState: SpecialStateProtocol {
         switch self {
         case .register(let registerState, let prev):
             return .register(registerState.dropLast(), prev: prev)
-        case .unregister(let unregisterState):
-            return .unregister(unregisterState.dropLast())
+        case .unregister(let unregisterState, let prev):
+            return .unregister(unregisterState.dropLast(), prev: prev)
         }
     }
 
@@ -594,8 +594,8 @@ enum SpecialState: SpecialStateProtocol {
         switch self {
         case .register(let registerState, let prev):
             return .register(registerState.moveCursorLeft(), prev: prev)
-        case .unregister(let unregisterState):
-            return .unregister(unregisterState.moveCursorLeft())
+        case .unregister(let unregisterState, let prev):
+            return .unregister(unregisterState.moveCursorLeft(), prev: prev)
         }
     }
 
@@ -603,8 +603,8 @@ enum SpecialState: SpecialStateProtocol {
         switch self {
         case .register(let registerState, let prev):
             return .register(registerState.moveCursorRight(), prev: prev)
-        case .unregister(let unregisterState):
-            return .unregister(unregisterState.moveCursorRight())
+        case .unregister(let unregisterState, let prev):
+            return .unregister(unregisterState.moveCursorRight(), prev: prev)
         }
     }
 
@@ -612,8 +612,8 @@ enum SpecialState: SpecialStateProtocol {
         switch self {
         case .register(let registerState, let prev):
             return .register(registerState.moveCursorFirst(), prev: prev)
-        case .unregister(let unregisterState):
-            return .unregister(unregisterState.moveCursorFirst())
+        case .unregister(let unregisterState, let prev):
+            return .unregister(unregisterState.moveCursorFirst(), prev: prev)
         }
     }
 
@@ -621,8 +621,8 @@ enum SpecialState: SpecialStateProtocol {
         switch self {
         case .register(let registerState, let prev):
             return .register(registerState.moveCursorLast(), prev: prev)
-        case .unregister(let unregisterState):
-            return .unregister(unregisterState.moveCursorLast())
+        case .unregister(let unregisterState, let prev):
+            return .unregister(unregisterState.moveCursorLast(), prev: prev)
         }
     }
 }
@@ -688,7 +688,7 @@ struct IMEState {
                     }
                     elements += inputMethod.markedTextElements(inputMode: inputMode)
                 }
-            case .unregister(let unregisterState):
+            case .unregister(let unregisterState, _):
                 let selectingState = unregisterState.prev.selecting
                 let selectingCandidate = selectingState.candidates[selectingState.candidateIndex]
                 elements.append(.plain("\(selectingCandidate.toMidashiString(yomi: selectingState.yomi)) /\(selectingCandidate.candidateString)/ を削除します(yes/no)"))

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1040,8 +1040,8 @@ final class StateMachine {
             return true
         case .unregister:
             let prevRegisterState: (RegisterState, [RegisterState])?
-            if case .register(let registerState, _) = specialState {
-                prevRegisterState = (registerState, [])
+            if case .register(let registerState, let prev) = specialState {
+                prevRegisterState = (registerState, prev)
             } else {
                 prevRegisterState = nil
             }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -187,14 +187,16 @@ final class StateMachine {
                         state.inputMethod = .normal
                         state.specialState = nil
                         updateMarkedText()
-                    } else if let prev {
-                        // 登録状態から登録解除状態に行き、また登録状態に戻る
-                        state.specialState = .register(prev.0, prev: prev.1)
                     } else {
                         state.inputMode = unregisterState.prev.mode
                         updateCandidates(selecting: unregisterState.prev.selecting)
                         state.inputMethod = .selecting(unregisterState.prev.selecting)
-                        state.specialState = nil
+                        if let prev {
+                            // 登録状態から登録解除状態に行き、また登録状態に戻る
+                            state.specialState = .register(prev.0, prev: prev.1)
+                        } else {
+                            state.specialState = nil
+                        }
                         updateMarkedText()
                     }
                     return true

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -489,7 +489,7 @@ final class StateTests: XCTestCase {
         let unregisterState = UnregisterState(prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "yes")
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .normal,
-                             specialState: .unregister(unregisterState),
+                             specialState: .unregister(unregisterState, prev: nil),
                              candidates: [])
         let displayText = state.displayText()
         XCTAssertEqual(displayText.elements, [.plain("あr /有/ を削除します(yes/no)"), .plain("yes")])
@@ -515,7 +515,7 @@ final class StateTests: XCTestCase {
         let unregisterState = UnregisterState(prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "yes")
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .normal,
-                             specialState: .unregister(unregisterState),
+                             specialState: .unregister(unregisterState, prev: nil),
                              candidates: [])
         let displayText = state.displayText()
         XCTAssertEqual(displayText.elements, [.plain("だい# /第#/ を削除します(yes/no)"), .plain("yes")])


### PR DESCRIPTION
単語登録中に単語登録解除に遷移してキャンセルしたときに想定された挙動になってなかったのを修正します。

### 再現手順

1. 単語登録を開始
2. 単語登録中に単語変換を開始
3. 単語変換候補選択時にShift-Xで単語登録解除に遷移
4. C-gやESCでキャンセル

### 想定された動作

単語登録中の変換候補の選択中

### 実際の挙動

単語登録中ではない変換候補の選択中