### PR TITLE
`Option`+`Enter`を`.enter`として扱うため`defaultKeyBindingSettings`に追加

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -232,7 +232,14 @@ struct KeyBinding: Identifiable {
             case .stickyShift:
                 return KeyBinding(action, [Input(key: .character(";"), displayString: ";", modifierFlags: [])])
             case .enter:
-                return KeyBinding(action, [Input(key: .code(0x24), displayString: "Enter", modifierFlags: [])])
+                return KeyBinding(
+                    action,
+                    [
+                        Input(key: .code(0x24), displayString: "Enter", modifierFlags: []),
+                        // IntelliJで利用するAlt + Enterを.enterとして認識されるようにする
+                        Input(key: .code(0x24), displayString: "Alt + Enter", modifierFlags: .option)
+                    ]
+                )
             case .space:
                 return KeyBinding(action, [Input(key: .code(0x31), displayString: "Space", modifierFlags: [])])
             case .tab:


### PR DESCRIPTION
- 入力された`Input`と`KeyBinding.defaultKeyBindingSettings`はディクショナリー形式で突合が行なわれ、`Key`が決定される
    - https://github.com/mtgto/macSKK/blob/18db2f0fe429ccebc37504b98037a62826ab9f99/macSKK/InputController.swift#L193
    - https://github.com/mtgto/macSKK/blob/18db2f0fe429ccebc37504b98037a62826ab9f99/macSKK/KeyBindingSet.swift#L19-L21
    - https://github.com/mtgto/macSKK/blob/18db2f0fe429ccebc37504b98037a62826ab9f99/macSKK/Global.swift#L28
    - https://github.com/mtgto/macSKK/blob/18db2f0fe429ccebc37504b98037a62826ab9f99/macSKK/KeyBindingSet.swift#L10
    - https://github.com/mtgto/macSKK/blob/18db2f0fe429ccebc37504b98037a62826ab9f99/macSKK/KeyBinding.swift#L215
- ディクショナリーから索引されるためには、基本的に`modifierFlags`が完璧に一致している必要がある
    - `.shift`に関しては例外的な処理があったりもするが…… 👀 
- よって、現状の設定であると`Option + Enter`は`.enter`に進入せず、`handleNormalPrintable`に進入していると考えられる
- IntelliJでは`Option + Enter`によって補完を行うため、`Option + Enter`がIMEに捕捉されてほしくない
- よって`modifierFlags`に`.option`を指定した`Enter`を追加した
    - 本当は`.shift`などすべての`modifierFlags`のパワーセットを作成した追加したかったが、そうしたところ量が多すぎたのかIMEが壊れてしまった 😇 
    - https://github.com/mtgto/macSKK/compare/main...y-yu:add-powerset
- そもそもとして`modifierFlags`を含めた`Input`を完全一致なディクショナリーのキーとして突合するのは無理があるか？ 🤔 
    - 理想的には指定した`modifierFlags`が立っていれば他はなんでもいい（`.contains`してればOK）としたいが、そういう性質を`hash`や`==`で実現するのは無理そう？ 🤔 

