### PR TITLE
キーバインドで必須と任意の修飾キーを設定できるようにし、Option + Enterを .enterとして扱うようにする

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 				CEADA44C2B025A8A0026E2BD /* EntryTests.swift */,
 				CE84A3E8295DA504009394C4 /* RomajiTests.swift */,
 				CE2F3B122C030C9A00CE342B /* KeyBindingTests.swift */,
+				CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */,
 				CED7CA3D2A8397E4004EF988 /* UpdateCheckerTests.swift */,
 				CE6DBA902A846C1700F5A227 /* ReleaseVersionTests.swift */,
 				CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */,
@@ -440,7 +441,6 @@
 				CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */,
 				CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */,
 				CED7CA572A83BFE9004EF988 /* fixture */,
-				CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */,
 			);
 			path = macSKKTests;
 			sourceTree = "<group>";

--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		CE496C932B440B9B001C623C /* euc-jis-2004.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE496C922B440B9B001C623C /* euc-jis-2004.txt */; };
 		CE496C952B440BBD001C623C /* Data+EucJis2004Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE496C942B440BBD001C623C /* Data+EucJis2004Tests.swift */; };
 		CE496C982B440CDA001C623C /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE496C972B440CCA001C623C /* libiconv.tbd */; };
+		CE49A2782C19E07800D53CFE /* KeyBindingSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */; };
 		CE4CB5CC2AD557D90046FA34 /* NumberEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */; };
 		CE4CB5CE2AD55DF90046FA34 /* NumberEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4CB5CD2AD55DF90046FA34 /* NumberEntryTests.swift */; };
 		CE5EB6AD2AAC0DE000389B98 /* FileDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5EB6AC2AAC0DE000389B98 /* FileDict.swift */; };
@@ -189,6 +190,7 @@
 		CE496C922B440B9B001C623C /* euc-jis-2004.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "euc-jis-2004.txt"; sourceTree = "<group>"; };
 		CE496C942B440BBD001C623C /* Data+EucJis2004Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+EucJis2004Tests.swift"; sourceTree = "<group>"; };
 		CE496C972B440CCA001C623C /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
+		CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingSetTests.swift; sourceTree = "<group>"; };
 		CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberEntry.swift; sourceTree = "<group>"; };
 		CE4CB5CD2AD55DF90046FA34 /* NumberEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberEntryTests.swift; sourceTree = "<group>"; };
 		CE5EB6AC2AAC0DE000389B98 /* FileDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDict.swift; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 				CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */,
 				CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */,
 				CED7CA572A83BFE9004EF988 /* fixture */,
+				CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */,
 			);
 			path = macSKKTests;
 			sourceTree = "<group>";
@@ -791,6 +794,7 @@
 				CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */,
 				CE84A3E9295DA504009394C4 /* RomajiTests.swift in Sources */,
 				CE4CB5CE2AD55DF90046FA34 /* NumberEntryTests.swift in Sources */,
+				CE49A2782C19E07800D53CFE /* KeyBindingSetTests.swift in Sources */,
 				CEADA44D2B025A8A0026E2BD /* EntryTests.swift in Sources */,
 				CEA78FAA295EBCAC00B67E25 /* StateMachineTests.swift in Sources */,
 				CE496C952B440BBD001C623C /* Data+EucJis2004Tests.swift in Sources */,

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -155,7 +155,7 @@ struct KeyBinding: Identifiable {
         }
 
         /// このキーバインド設定がキーイベントをこのキーバインドの入力として受理するかどうかを返す。
-        func accept(event: NSEvent) -> Bool {
+        func accepts(event: NSEvent) -> Bool {
             if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
                 if key != .character(character) {
                     return false

--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -94,64 +94,43 @@ struct KeyBinding: Identifiable {
         }
     }
 
-    struct Input: Hashable, Equatable {
+    struct Input: Equatable {
         let key: Key
-        /// 入力時に押されている修飾キー。
-        /// keyがcode形式の場合 (スペース、タブ、バックスペース、矢印キーなど) はmodifierFlagsは
+        /// 入力時に押されていないといけない修飾キー。
+        /// keyがcode形式の場合 (スペース、タブ、バックスペース、矢印キーなど) はmodifierFlagsはShiftのみ許可する
+        /// keyがcharacter形式の場合は
         let modifierFlags: NSEvent.ModifierFlags
+
+        /// 入力時に押されていてもよい修飾キー。
+        let optionalModifierFlags: NSEvent.ModifierFlags
+
         /**
          * 設定画面の表示用文字
          */
         let displayString: String
 
-        init(event: NSEvent) {
-            if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
-                key = .character(character)
-            } else {
-                key = .code(event.keyCode)
-            }
-            // 使用する可能性があるものだけを抽出する。じゃないとrawValueで256が入ってしまうっぽい?
-            modifierFlags = event.modifierFlags.intersection([.shift, .control, .function, .option, .command])
-            displayString = (event.charactersIgnoringModifiers ?? event.characters) ?? ""
-        }
-
-        init(key: KeyBinding.Key, displayString: String, modifierFlags: NSEvent.ModifierFlags) {
+        init(key: KeyBinding.Key, displayString: String, modifierFlags: NSEvent.ModifierFlags, optionalModifierFlags: NSEvent.ModifierFlags = []) {
             self.key = key
             self.modifierFlags = modifierFlags
             self.displayString = displayString
+            self.optionalModifierFlags = optionalModifierFlags
         }
 
         init?(dict: [String: Any]) {
             guard let keyValue = dict["key"], let key = Key(rawValue: keyValue),
             let modifierFlagsValue = dict["modifierFlags"] as? UInt,
+            let optionalModifierFlagsValue = dict["optionalModifierFlags"] as? UInt,
             let displayString = dict["displayString"] as? String else {
                 return nil
             }
             self.key = key
             self.modifierFlags = NSEvent.ModifierFlags(rawValue: modifierFlagsValue)
+            self.optionalModifierFlags = NSEvent.ModifierFlags(rawValue: optionalModifierFlagsValue)
             self.displayString = displayString
         }
 
-        func hash(into hasher: inout Hasher) {
-            // NOTE: keyCodeで定義されているときはハッシュ値の計算にシフトキーをmodifierFlagsに入れていません。
-            // 矢印キーとShift押しながら矢印キーをどちらも矢印キーと扱うようにしたいためです。
-            hasher.combine(key)
-            switch key {
-            case .character:
-                hasher.combine(modifierFlags.rawValue)
-            case .code:
-                hasher.combine(modifierFlags.subtracting(.shift).rawValue)
-            }
-        }
-
         static func == (lhs: Self, rhs: Self) -> Bool {
-            // NOTE: keyCodeで定義されているときはmodifierFlagsを比較しません。
-            // 矢印キーとShift押しながら矢印キーをどちらも矢印キーと扱うようにしたいためです。
-            if case .code = lhs.key, case .code = rhs.key {
-                return lhs.key == rhs.key && lhs.modifierFlags.subtracting(.shift) == rhs.modifierFlags.subtracting(.shift)
-            } else {
-                return lhs.key == rhs.key && lhs.modifierFlags == rhs.modifierFlags
-            }
+            return lhs.key == rhs.key && lhs.modifierFlags == rhs.modifierFlags && lhs.optionalModifierFlags == rhs.optionalModifierFlags
         }
 
         var localized: String {
@@ -167,7 +146,24 @@ struct KeyBinding: Identifiable {
         }
 
         func encode() -> [String: Any] {
-            return ["key": key.encode(), "modifierFlags": modifierFlags.rawValue, "displayString": displayString]
+            return [
+                "key": key.encode(),
+                "modifierFlags": modifierFlags.rawValue,
+                "optionalModifierFlags": optionalModifierFlags.rawValue,
+                "displayString": displayString,
+            ]
+        }
+
+        /// このキーバインド設定がキーイベントをこのキーバインドの入力として受理するかどうかを返す。
+        func accept(event: NSEvent) -> Bool {
+            if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
+                if key != .character(character) {
+                    return false
+                }
+            } else if key != .code(event.keyCode) {
+                return false
+            }
+            return modifierFlags.isSubset(of: event.modifierFlags) && modifierFlags.union(optionalModifierFlags).isSuperset(of: event.modifierFlags)
         }
     }
 
@@ -232,7 +228,7 @@ struct KeyBinding: Identifiable {
             case .stickyShift:
                 return KeyBinding(action, [Input(key: .character(";"), displayString: ";", modifierFlags: [])])
             case .enter:
-                return KeyBinding(action, [Input(key: .code(0x24), displayString: "Enter", modifierFlags: [])])
+                return KeyBinding(action, [Input(key: .code(0x24), displayString: "Enter", modifierFlags: [], optionalModifierFlags: [.shift, .option])])
             case .space:
                 return KeyBinding(action, [Input(key: .code(0x31), displayString: "Space", modifierFlags: [])])
             case .tab:
@@ -247,16 +243,16 @@ struct KeyBinding: Identifiable {
                 return KeyBinding(action, [Input(key: .code(0x35), displayString: "ESC", modifierFlags: []),
                                            Input(key: .character("g"), displayString: "G", modifierFlags: .control)])
             case .left:
-                return KeyBinding(action, [Input(key: .code(0x7b), displayString: "←", modifierFlags: .function),
+                return KeyBinding(action, [Input(key: .code(0x7b), displayString: "←", modifierFlags: .function, optionalModifierFlags: [.shift]),
                                            Input(key: .character("b"), displayString: "B", modifierFlags: .control)])
             case .right:
-                return KeyBinding(action, [Input(key: .code(0x7c), displayString: "→", modifierFlags: .function),
+                return KeyBinding(action, [Input(key: .code(0x7c), displayString: "→", modifierFlags: .function, optionalModifierFlags: [.shift]),
                                            Input(key: .character("f"), displayString: "F", modifierFlags: .control)])
             case .down:
-                return KeyBinding(action, [Input(key: .code(0x7d), displayString: "↓", modifierFlags: .function),
+                return KeyBinding(action, [Input(key: .code(0x7d), displayString: "↓", modifierFlags: .function, optionalModifierFlags: [.shift]),
                                            Input(key: .character("n"), displayString: "N", modifierFlags: .control)])
             case .up:
-                return KeyBinding(action, [Input(key: .code(0x7e), displayString: "↑", modifierFlags: .function),
+                return KeyBinding(action, [Input(key: .code(0x7e), displayString: "↑", modifierFlags: .function, optionalModifierFlags: [.shift]),
                                            Input(key: .character("p"), displayString: "P", modifierFlags: .control)])
             case .startOfLine:
                 return KeyBinding(action, [Input(key: .character("a"), displayString: "A", modifierFlags: .control)])

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -35,11 +35,6 @@ struct KeyBindingSet {
     }
 
     func action(event: NSEvent) -> KeyBinding.Action? {
-        for keyBind in sorted {
-            if keyBind.0.accept(event: event) {
-                return keyBind.1
-            }
-        }
-        return nil
+        sorted.first(where: { $0.0.accepts(event: event) })?.1
     }
 }

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -4,19 +4,42 @@
 import AppKit
 
 struct KeyBindingSet {
-    let values: [KeyBinding.Action: [KeyBinding.Input]]
-    let dict: [KeyBinding.Input: KeyBinding.Action]
+    /**
+     * 修飾キーを除いたキー入力が同じ場合は修飾キーが多いものが前に来るように並べた配列。
+     * 入力に一番合致するキー入力を返すために最初にソートしてもっておく。
+     */
+    let sorted: [(KeyBinding.Input, KeyBinding.Action)]
 
     static let defaultKeyBindingSet = KeyBindingSet(KeyBinding.defaultKeyBindingSettings)
 
     init(_ values: [KeyBinding]) {
-        self.values = Dictionary(uniqueKeysWithValues: values.map { ($0.action, $0.inputs) })
-        self.dict = Dictionary(uniqueKeysWithValues: values.flatMap { keyValue in
+        sorted = values.flatMap { keyValue in
             keyValue.inputs.map { ($0, keyValue.action) }
+        }.sorted(by: { lts, rts in
+            if lts.0.key == rts.0.key {
+                return lts.0.modifierFlags.rawValue > rts.0.modifierFlags.rawValue
+            } else {
+                switch (lts.0.key, rts.0.key) {
+                case let (.character(l), .character(r)):
+                    return l < r
+                case let (.code(l), .code(r)):
+                    return l < r
+                case (.character, .code):
+                    return false
+                case (.code, .character):
+                    return true
+                }
+            }
         })
     }
 
     func action(event: NSEvent) -> KeyBinding.Action? {
-        return dict[KeyBinding.Input(event: event)]
+        let input = KeyBinding.Input(event: event)
+        for keyBind in sorted {
+            if keyBind.0.key == input.key && input.modifierFlags.contains(keyBind.0.modifierFlags) {
+                return keyBind.1
+            }
+        }
+        return nil
     }
 }

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -39,11 +39,11 @@ struct KeyBindingSet {
         for keyBind in sorted {
             if keyBind.0.key == input.key {
                 switch input.key {
-                case .character(let c):
-                    if KeyBinding.Key.characters.contains(c) && keyBind.0.modifierFlags == input.modifierFlags {
+                case .character:
+                    if keyBind.0.modifierFlags == input.modifierFlags {
                         return keyBind.1
                     }
-                case .code(let code):
+                case .code:
                     if input.modifierFlags.contains(keyBind.0.modifierFlags) {
                         return keyBind.1
                     }

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -24,6 +24,7 @@ struct KeyBindingSet {
                     return l < r
                 case let (.code(l), .code(r)):
                     return l < r
+                // .character, .codeはどういう順序で並んでいてもいいので、いったん`.code < .character`としておく。
                 case (.character, .code):
                     return false
                 case (.code, .character):

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -36,8 +36,17 @@ struct KeyBindingSet {
     func action(event: NSEvent) -> KeyBinding.Action? {
         let input = KeyBinding.Input(event: event)
         for keyBind in sorted {
-            if keyBind.0.key == input.key && input.modifierFlags.contains(keyBind.0.modifierFlags) {
-                return keyBind.1
+            if keyBind.0.key == input.key {
+                switch input.key {
+                case .character(let c):
+                    if KeyBinding.Key.characters.contains(c) && keyBind.0.modifierFlags == input.modifierFlags {
+                        return keyBind.1
+                    }
+                case .code(let code):
+                    if input.modifierFlags.contains(keyBind.0.modifierFlags) {
+                        return keyBind.1
+                    }
+                }
             }
         }
         return nil

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -35,19 +35,9 @@ struct KeyBindingSet {
     }
 
     func action(event: NSEvent) -> KeyBinding.Action? {
-        let input = KeyBinding.Input(event: event)
         for keyBind in sorted {
-            if keyBind.0.key == input.key {
-                switch input.key {
-                case .character:
-                    if keyBind.0.modifierFlags == input.modifierFlags {
-                        return keyBind.1
-                    }
-                case .code:
-                    if input.modifierFlags.contains(keyBind.0.modifierFlags) {
-                        return keyBind.1
-                    }
-                }
+            if keyBind.0.accept(event: event) {
+                return keyBind.1
             }
         }
         return nil

--- a/macSKKTests/KeyBindingSetTests.swift
+++ b/macSKKTests/KeyBindingSetTests.swift
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+
+@testable import macSKK
+
+final class KeyBindingSetTests: XCTestCase {
+    func testInit() throws {
+        let set = KeyBindingSet([
+            KeyBinding(.toggleKana, [.init(key: .character("q"), displayString: "Q", modifierFlags: [])]),
+            KeyBinding(.japanese, [.init(key: .character("q"), displayString: "Q", modifierFlags: .shift)]),
+            KeyBinding(.hiragana, [.init(key: .character("j"), displayString: "J", modifierFlags: .control)]),
+            KeyBinding(.direct, [.init(key: .character("l"), displayString: "L", modifierFlags: [])]),
+            KeyBinding(.unregister, [.init(key: .character("x"), displayString: "X", modifierFlags: .shift)]),
+            KeyBinding(.enter, [.init(key: .code(0x24), displayString: "Enter", modifierFlags: [])]),
+            KeyBinding(.left, [.init(key: .code(0x7b), displayString: "←", modifierFlags: .function)]),
+            KeyBinding(.left, [.init(key: .character("b"), displayString: "B", modifierFlags: .control)]),
+        ])
+        // まず修飾キー以外のキーの順でソートして、同じキーのときは修飾キーが多い方が前に来るようにソートされる
+        // キーの順のソートはcodeが前、characterが後で、同じcodeやcharacterなら小さい方が前に来るようにソートされる
+        XCTAssertEqual(set.sorted.map { $0.1 }, [.enter, .left, .left, .hiragana, .direct, .japanese, .toggleKana, .unregister])
+    }
+}

--- a/macSKKTests/KeyBindingTests.swift
+++ b/macSKKTests/KeyBindingTests.swift
@@ -52,7 +52,7 @@ final class KeyBindingTests: XCTestCase {
         XCTAssertNil(KeyBinding(dict: ["inputs": []]))
     }
 
-    func testInputAccept() {
+    func testInputAccepts() {
         func generateKeyEvent(modifierFlags: NSEvent.ModifierFlags, characters: String, charactersIgnoringModifiers: String? = nil, keyCode: UInt16 = 0) -> NSEvent {
             NSEvent.keyEvent(with: .keyDown,
                              location: .zero,
@@ -69,21 +69,21 @@ final class KeyBindingTests: XCTestCase {
         let inputShiftQ = KeyBinding.Input(key: .character("q"), displayString: "Q", modifierFlags: .shift)
         let eventQ = generateKeyEvent(modifierFlags: [], characters: "q")
         let eventShiftQ = generateKeyEvent(modifierFlags: .shift, characters: "q")
-        XCTAssertTrue(inputQ.accept(event: eventQ))
-        XCTAssertFalse(inputShiftQ.accept(event: eventQ))
-        XCTAssertFalse(inputQ.accept(event: eventShiftQ))
-        XCTAssertTrue(inputShiftQ.accept(event: eventShiftQ))
+        XCTAssertTrue(inputQ.accepts(event: eventQ))
+        XCTAssertFalse(inputShiftQ.accepts(event: eventQ))
+        XCTAssertFalse(inputQ.accepts(event: eventShiftQ))
+        XCTAssertTrue(inputShiftQ.accepts(event: eventShiftQ))
         let inputLeft = KeyBinding.Input(key: .code(0x7b), displayString: "←", modifierFlags: .function, optionalModifierFlags: .shift)
         let eventLeft = generateKeyEvent(modifierFlags: [.function], characters: "\u{63234}", keyCode: 0x7b)
         let eventShiftLeft = generateKeyEvent(modifierFlags: [.function, .shift], characters: "\u{63234}", keyCode: 0x7b)
-        XCTAssertTrue(inputLeft.accept(event: eventLeft))
-        XCTAssertTrue(inputLeft.accept(event: eventShiftLeft))
-        XCTAssertFalse(inputLeft.accept(event: eventQ))
+        XCTAssertTrue(inputLeft.accepts(event: eventLeft))
+        XCTAssertTrue(inputLeft.accepts(event: eventShiftLeft))
+        XCTAssertFalse(inputLeft.accepts(event: eventQ))
         let inputEnter = KeyBinding.Input(key: .code(0x24), displayString: "Enter", modifierFlags: [], optionalModifierFlags: .option)
         let eventEnter = generateKeyEvent(modifierFlags: [], characters: "\r", keyCode: 0x24)
         let eventOptionEnter = generateKeyEvent(modifierFlags: .option, characters: "\r", keyCode: 0x24)
-        XCTAssertTrue(inputEnter.accept(event: eventEnter))
-        XCTAssertTrue(inputEnter.accept(event: eventOptionEnter))
-        XCTAssertFalse(inputEnter.accept(event: eventLeft))
+        XCTAssertTrue(inputEnter.accepts(event: eventEnter))
+        XCTAssertTrue(inputEnter.accepts(event: eventOptionEnter))
+        XCTAssertFalse(inputEnter.accepts(event: eventLeft))
     }
 }


### PR DESCRIPTION
#172 で問題となった、Option + Enterがv0.23.0からIMEで拾われるようになってしまったことへの対処として、KeyBinding.Inputに「必須の修飾キーの集合」と「押していてもよい任意の修飾キーの集合」を設定するようにします。

2024-06-15: 既存のキーバインドは、矢印キーはShiftあり、エンターはOptionありとしていますがマージする前にもう少し考えます。