### PR TITLE
`SKK-JISYO.L`の文字エンコーディングの変更を禁止にした

### DIFF
--- a/macSKK/Settings/DictionaryView.swift
+++ b/macSKK/Settings/DictionaryView.swift
@@ -21,6 +21,20 @@ struct DictionaryView: View {
                         }
                     }
                     .pickerStyle(.radioGroup)
+                    .disabled(
+                        // SKK-JISYO.Lは特定の文字コードでmacSKKに同梱される。（Makefileでビルド時にダウンロードしている）
+                        // ユーザーがこれをnkfなどでUTF-8に変更したとしても、macSKKのバージョンをアップデートするたびに
+                        // 上書きされて文字コードが異なって読み込みエラーとなる可能性がある。
+                        // 従ってファイル名が`SKK-JISYO.L`な場合は文字コードの変更を禁止する。
+                        // （文字コードを変更したい場合は、SKK-JISYO.Lをdisableにして別名で辞書ディレクトリーに設置するべきと思われる）
+                        filename == "SKK-JISYO.L"
+                    )
+                    if filename == "SKK-JISYO.L" {
+                        HStack {
+                            Image(systemName: "exclamationmark.triangle")
+                            Text("Unable to change encoding SKK-JISYO.L")
+                        }
+                    }
                 }
             }
             .formStyle(.grouped)
@@ -46,6 +60,15 @@ struct DictionaryView: View {
 
 struct DictionaryView_Previews: PreviewProvider {
     static var previews: some View {
-        DictionaryView(dictSetting: .constant(nil), filename: "SKK-JISYO.sample.utf-8", encoding: .utf8)
+        DictionaryView(
+            dictSetting: .constant(nil),
+            filename: "SKK-JISYO.sample.utf-8",
+            encoding: .utf8
+        ).previewDisplayName("SKK-JISYO.sample.utf-8")        
+        DictionaryView(
+            dictSetting: .constant(nil),
+            filename: "SKK-JISYO.L",
+            encoding: .japaneseEUC
+        ).previewDisplayName("SKK-JISYO.L")
     }
 }

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "Filename" = "Filename";
 "Dictionary Setting" = "Dictionary Setting";
 "Encoding" = "Encoding";
+"Unable to change encoding SKK-JISYO.L" = "Unable to change encoding of SKK-JISYO.L because it's bundled with macSKK.";
 "UNNewVersionTitle" = "A new version is available";
 "UNNewVersionBody" = "macSKK %@ is now available.";
 "UNUserDictReadErrorTitle" = "Error";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "Filename" = "ファイル名";
 "Dictionary Setting" = "辞書の設定";
 "Encoding" = "エンコーディング";
+"Unable to change encoding SKK-JISYO.L" = "SKK-JISYO.LはmacSKKに同梱されているためエンコーディングを変更できません";
 "UNNewVersionTitle" = "新しいバージョンがあります";
 "UNNewVersionBody" = "macSKKの新しいバージョン %@ がリリースされています。";
 "UNUserDictReadErrorTitle" = "エラー";


### PR DESCRIPTION
- コメントの通りで`SKK-JISYO.L`の文字エンコーディングを変更してたとえば`nkf`コマンドなどでUTF-8にすると、バージョンアップのたびにmacSKKが 👇 ここで持ってきた`SKK-JISYO.L`に置換されてEUCに戻ってしまう 😇 
    - https://github.com/mtgto/macSKK/blob/18db2f0fe429ccebc37504b98037a62826ab9f99/Makefile#L43
- よって`SKK-JISYO.L`の場合は文字エンコーディングの変更を禁止にした次のような文言を表示するようにした
    - <img width="500" alt="image" src="https://github.com/mtgto/macSKK/assets/612043/e970ced4-50a4-4775-8a87-6eb45e39df44">
