### PR TITLE
DelキーはFunctionキーが押されているときに機能する

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -242,7 +242,7 @@ struct KeyBinding: Identifiable {
                 return KeyBinding(action, [Input(key: .code(0x33), displayString: "Backspace", modifierFlags: []),
                                            Input(key: .character("h"), displayString: "H", modifierFlags: .control)])
             case .delete:
-                return KeyBinding(action, [Input(key: .code(0x75), displayString: "Delete", modifierFlags: []),
+                return KeyBinding(action, [Input(key: .code(0x75), displayString: "Delete", modifierFlags: .function),
                                            Input(key: .character("d"), displayString: "D", modifierFlags: .control)])
             case .cancel:
                 return KeyBinding(action, [Input(key: .code(0x35), displayString: "ESC", modifierFlags: []),


### PR DESCRIPTION
#176 で報告があり判明。
v0.23.0からのキーバインドの変数化作業で、(Backspaceとは別の) Delキーの修飾キーにFnがあるのを忘れて作業してしまっていました。