### PR TITLE
補完（`completion`）を辞書からも検索できるようにする

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -20,6 +20,8 @@ import Combine
     static let directModeBundleIdentifiers = CurrentValueSubject<[String], Never>([])
     // モード変更時に空白文字を一瞬追加するワークアラウンドを適用するBundle Identifierの集合
     static let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
+    /// ユーザー辞書だけでなくすべての辞書から補完候補を検索するか？
+    static let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)
     /// 現在のローマ字かな変換ルール
     static var kanaRule: Romaji!
     /// デフォルトでもってるローマ字かな変換ルール
@@ -34,8 +36,6 @@ import Combine
     private let candidatesPanel: CandidatesPanel
     // 補完候補を表示するパネル
     private let completionPanel: CompletionPanel
-    /// 一般辞書を補完で検索するか？
-    static let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
 
     init() {
         inputModePanel = InputModePanel()

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -34,7 +34,7 @@ import Combine
     private let candidatesPanel: CandidatesPanel
     // 補完候補を表示するパネル
     private let completionPanel: CompletionPanel
-    /// 一般辞書を保管で検索するか？
+    /// 一般辞書を補完で検索するか？
     static let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
 
     init() {

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -34,6 +34,8 @@ import Combine
     private let candidatesPanel: CandidatesPanel
     // 補完候補を表示するパネル
     private let completionPanel: CompletionPanel
+    /// 一般辞書を保管で検索するか？
+    static let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
 
     init() {
         inputModePanel = InputModePanel()

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -187,6 +187,12 @@ class InputController: IMKInputController {
                     Global.candidatesPanel.setAnnotationFontSize(annotationFontSize)
                 }
             }.store(in: &cancellables)
+        NotificationCenter.default.publisher(for: notificationNameFindCompletionFromNonUserDict)
+            .sink { notification in
+                if let findCompletionFromNonUserDict = notification.object as? Bool {
+                    Global.findCompletionFromNonUserDict.send(findCompletionFromNonUserDict)
+                }
+            }.store(in: &cancellables)
     }
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -187,10 +187,10 @@ class InputController: IMKInputController {
                     Global.candidatesPanel.setAnnotationFontSize(annotationFontSize)
                 }
             }.store(in: &cancellables)
-        NotificationCenter.default.publisher(for: notificationNameFindCompletionFromNonUserDict)
+        NotificationCenter.default.publisher(for: notificationNameFindCompletionFromAllDicts)
             .sink { notification in
-                if let findCompletionFromNonUserDict = notification.object as? Bool {
-                    Global.findCompletionFromNonUserDict.send(findCompletionFromNonUserDict)
+                if let findCompletionFromAllDicts = notification.object as? Bool {
+                    Global.findCompletionFromAllDicts.send(findCompletionFromAllDicts)
                 }
             }.store(in: &cancellables)
     }

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -68,13 +68,11 @@ struct MemoryDict: DictProtocol {
         self.readonly = readonly
         self.entries = entries
         failedEntryCount = 0
-        if !readonly {
-            for yomi in entries.keys {
-                if yomi.isOkuriAri {
-                    okuriAriYomis.append(yomi)
-                } else {
-                    okuriNashiYomis.append(yomi)
-                }
+        for yomi in entries.keys {
+            if yomi.isOkuriAri {
+                okuriAriYomis.append(yomi)
+            } else {
+                okuriNashiYomis.append(yomi)
             }
         }
     }

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -41,6 +41,11 @@ struct GeneralView: View {
                         }
                     }
                 }
+                Section {
+                    Toggle(isOn: $settingsViewModel.findCompletionFromNonUserDict, label: {
+                        Text("Find completion from non user dictionaries")
+                    })
+                }
             }
             .formStyle(.grouped)
         }.onAppear {

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -42,8 +42,8 @@ struct GeneralView: View {
                     }
                 }
                 Section {
-                    Toggle(isOn: $settingsViewModel.findCompletionFromNonUserDict, label: {
-                        Text("Find completion from non user dictionaries")
+                    Toggle(isOn: $settingsViewModel.findCompletionFromAllDicts, label: {
+                        Text("Find completion from all dictionaries")
                     })
                 }
             }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -166,7 +166,7 @@ final class SettingsViewModel: ObservableObject {
     @Published var keyBingings: [KeyBinding]
     /// 変換候補パネルで表示されている候補を決定するキーの集合
     @Published var selectCandidateKeys: String
-    /// 一般辞書を保管で検索するか？
+    /// 一般辞書を補完で検索するか？
     @Published var findCompletionFromNonUserDict: Bool
 
     // 辞書ディレクトリ

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -167,7 +167,7 @@ final class SettingsViewModel: ObservableObject {
     /// 変換候補パネルで表示されている候補を決定するキーの集合
     @Published var selectCandidateKeys: String
     /// 一般辞書を補完で検索するか？
-    @Published var findCompletionFromNonUserDict: Bool
+    @Published var findCompletionFromAllDicts: Bool
 
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
@@ -187,7 +187,7 @@ final class SettingsViewModel: ObservableObject {
         inlineCandidateCount = UserDefaults.standard.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
         candidatesFontSize = UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidatesFontSize)
         annotationFontSize = UserDefaults.standard.integer(forKey: UserDefaultsKeys.annotationFontSize)
-        findCompletionFromNonUserDict = UserDefaults.standard.bool(forKey: UserDefaultsKeys.findCompletionFromNonUserDict)
+        findCompletionFromAllDicts = UserDefaults.standard.bool(forKey: UserDefaultsKeys.findCompletionFromAllDicts)
         workaroundApplications = UserDefaults.standard.array(forKey: UserDefaultsKeys.workarounds)?.compactMap { workaround in
             if let workaround = workaround as? Dictionary<String, Any>, let bundleIdentifier = workaround["bundleIdentifier"] as? String, let insertBlankString = workaround["insertBlankString"] as? Bool {
                 WorkaroundApplication(bundleIdentifier: bundleIdentifier, insertBlankString: insertBlankString)
@@ -342,10 +342,10 @@ final class SettingsViewModel: ObservableObject {
             logger.log("変換候補決定のキーを\"\(selectCandidateKeys, privacy: .public)\"に変更しました")
         }.store(in: &cancellables)
 
-        $findCompletionFromNonUserDict.dropFirst().sink { findCompletionFromNonUserDict in
-            UserDefaults.standard.set(findCompletionFromNonUserDict, forKey: UserDefaultsKeys.findCompletionFromNonUserDict)
-            NotificationCenter.default.post(name: notificationNameFindCompletionFromNonUserDict, object: findCompletionFromNonUserDict)
-            logger.log("一般の辞書を使って補完するかを\(findCompletionFromNonUserDict)に変更しました")
+        $findCompletionFromAllDicts.dropFirst().sink { findCompletionFromAllDicts in
+            UserDefaults.standard.set(findCompletionFromAllDicts, forKey: UserDefaultsKeys.findCompletionFromAllDicts)
+            NotificationCenter.default.post(name: notificationNameFindCompletionFromAllDicts, object: findCompletionFromAllDicts)
+            logger.log("一般の辞書を使って補完するかを\(findCompletionFromAllDicts)に変更しました")
         }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameDictLoad).receive(on: RunLoop.main).sink { [weak self] notification in
@@ -382,7 +382,7 @@ final class SettingsViewModel: ObservableObject {
         skkservDictSetting = SKKServDictSetting(enabled: true, address: "127.0.0.1", port: 1178, encoding: .japaneseEUC)
         keyBingings = []
         selectCandidateKeys = "123456789"
-        findCompletionFromNonUserDict = false
+        findCompletionFromAllDicts = false
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -345,8 +345,8 @@ final class SettingsViewModel: ObservableObject {
         $findCompletionFromNonUserDict.dropFirst().sink { findCompletionFromNonUserDict in
             UserDefaults.standard.set(findCompletionFromNonUserDict, forKey: UserDefaultsKeys.findCompletionFromNonUserDict)
             NotificationCenter.default.post(name: notificationNameFindCompletionFromNonUserDict, object: findCompletionFromNonUserDict)
-            logger.log("一般辞書を保管で検索するかを\(findCompletionFromNonUserDict)に変更しました")
-        }
+            logger.log("一般の辞書を使って補完するかを\(findCompletionFromNonUserDict)に変更しました")
+        }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameDictLoad).receive(on: RunLoop.main).sink { [weak self] notification in
             if let loadEvent = notification.object as? DictLoadEvent, let self {

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -19,5 +19,5 @@ struct UserDefaultsKeys {
     // 選択候補パネルから決定するショートカットキー。
     // 初期値は "123456789"。
     static let selectCandidateKeys = "selectCandidateKeys"
-    static let findCompletionFromNonUserDict = "findCompletionFromNonUserDict"
+    static let findCompletionFromAllDicts = "findCompletionFromAllDicts"
 }

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -19,4 +19,5 @@ struct UserDefaultsKeys {
     // 選択候補パネルから決定するショートカットキー。
     // 初期値は "123456789"。
     static let selectCandidateKeys = "selectCandidateKeys"
+    static let findCompletionFromNonUserDict = "findCompletionFromNonUserDict"
 }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -235,6 +235,7 @@ class UserDict: NSObject, DictProtocol {
      *
      * - prefixが空文字列ならnilを返す
      * - ユーザー辞書の送りなしの読みのうち、最近変換したものから選択する。
+     *   - ユーザー辞書に存在しない場合は、有効になっている辞書から優先度順に検索する
      * - prefixと読みが完全に一致する場合は補完候補とはしない
      * - 数値変換用の読みは補完候補としない
      */
@@ -245,10 +246,16 @@ class UserDict: NSObject, DictProtocol {
             }
         }
         if let userDict {
-            return userDict.findCompletion(prefix: prefix)
-        } else {
-            return nil
+            if let completion = userDict.findCompletion(prefix: prefix) {
+                return completion
+            }
         }
+        for dict in dicts {
+            if let completion = dict.findCompletion(prefix: prefix) {
+                return completion
+            }
+        }
+        return nil
     }
 
     /// ユーザー辞書を永続化する

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -31,17 +31,17 @@ class UserDict: NSObject, DictProtocol {
     private let savePublisher = PassthroughSubject<Void, Never>()
     private let privateMode: CurrentValueSubject<Bool, Never>
     private var cancellables: Set<AnyCancellable> = []
-    // 一般辞書を補完で検索するか？
-    private let findCompletionFromNonUserDict: CurrentValueSubject<Bool, Never>
+    // ユーザー辞書だけでなくすべての辞書から補完候補を検索するか？
+    private let findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>
 
     // MARK: NSFilePresenter
     let presentedItemURL: URL?
     let presentedItemOperationQueue: OperationQueue = OperationQueue()
 
-    init(dicts: [any DictProtocol], userDictEntries: [String: [Word]]? = nil, privateMode: CurrentValueSubject<Bool, Never>, findCompletionFromNonUserDict: CurrentValueSubject<Bool, Never>) throws {
+    init(dicts: [any DictProtocol], userDictEntries: [String: [Word]]? = nil, privateMode: CurrentValueSubject<Bool, Never>, findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>) throws {
         self.dicts = dicts
         self.privateMode = privateMode
-        self.findCompletionFromNonUserDict = findCompletionFromNonUserDict
+        self.findCompletionFromAllDicts = findCompletionFromAllDicts
         dictionariesDirectoryURL = try FileManager.default.url(
             for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false
         ).appending(path: "Dictionaries")
@@ -253,7 +253,7 @@ class UserDict: NSObject, DictProtocol {
                 return completion
             }
         }
-        if findCompletionFromNonUserDict.value {
+        if findCompletionFromAllDicts.value {
             for dict in dicts {
                 if let completion = dict.findCompletion(prefix: prefix) {
                     return completion

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -31,7 +31,7 @@ class UserDict: NSObject, DictProtocol {
     private let savePublisher = PassthroughSubject<Void, Never>()
     private let privateMode: CurrentValueSubject<Bool, Never>
     private var cancellables: Set<AnyCancellable> = []
-    // 一般辞書を保管で検索するか？
+    // 一般辞書を補完で検索するか？
     private let findCompletionFromNonUserDict: CurrentValueSubject<Bool, Never>
 
     // MARK: NSFilePresenter

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "Number of inline candidates" = "Number of inline candidates";
 "Candidates font size" = "Candidates font size";
 "Annotation font size" = "Annotation font size";
-"Find completion from non user dictionaries" = "Find completion from non user dictionaries";
+"Find completion from all dictionaries" = "Find completion from all dictionaries";
 "Insert Blank String" = "Insert Blank String";
 "Enabled" = "Enabled";
 "Disabled" = "Disabled";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "Number of inline candidates" = "Number of inline candidates";
 "Candidates font size" = "Candidates font size";
 "Annotation font size" = "Annotation font size";
+"Find completion from non user dictionaries" = "Find completion from non user dictionaries";
 "Insert Blank String" = "Insert Blank String";
 "Enabled" = "Enabled";
 "Disabled" = "Disabled";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "Number of inline candidates" = "インラインで表示する変換候補の数";
 "Candidates font size" = "変換候補のフォントサイズ";
 "Annotation font size" = "注釈のフォントサイズ";
-"Find completion from non user dictionaries" = "一般の辞書を使って補完する";
+"Find completion from all dictionaries" = "ユーザー辞書だけでなくすべての辞書から補完を探す";
 "Insert Blank String" = "空文字挿入";
 "Enabled" = "有効";
 "Disabled" = "無効";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "Number of inline candidates" = "インラインで表示する変換候補の数";
 "Candidates font size" = "変換候補のフォントサイズ";
 "Annotation font size" = "注釈のフォントサイズ";
+"Find completion from non user dictionaries" = "一般の辞書を使って補完する";
 "Insert Blank String" = "空文字挿入";
 "Enabled" = "有効";
 "Disabled" = "無効";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -21,7 +21,7 @@ let notificationNameCandidatesFontSize = Notification.Name("candidatesFontSize")
 // 注釈のフォントサイズが変更されたときに通知される通知の名前
 let notificationNameAnnotationFontSize = Notification.Name("annotationFontSize")
 // 一般辞書を補完で検索するかが変更されたときに通知される通知の名前
-let notificationNameFindCompletionFromNonUserDict =  Notification.Name("findCompletionFromNonUserDict")
+let notificationNameFindCompletionFromAllDicts =  Notification.Name("findCompletionFromAllDicts")
 
 func isTest() -> Bool {
     return ProcessInfo.processInfo.environment["MACSKK_IS_TEST"] == "1"
@@ -59,7 +59,7 @@ struct macSKKApp: App {
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
             
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
-            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode, findCompletionFromNonUserDict: Global.findCompletionFromNonUserDict)
+            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode, findCompletionFromAllDicts: Global.findCompletionFromAllDicts)
             settingsWindowController = NSWindowController(window: settingsWindow)
             self.settingsViewModel = settingsViewModel
             settingsWindowController.windowFrameAutosaveName = "Settings"
@@ -193,7 +193,7 @@ struct macSKKApp: App {
                 address: "127.0.0.1",
                 port: 1178,
                 encoding: .japaneseEUC).encode(),
-            UserDefaultsKeys.findCompletionFromNonUserDict: false,
+            UserDefaultsKeys.findCompletionFromAllDicts: false,
         ])
     }
 

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -193,6 +193,7 @@ struct macSKKApp: App {
                 address: "127.0.0.1",
                 port: 1178,
                 encoding: .japaneseEUC).encode(),
+            UserDefaultsKeys.findCompletionFromNonUserDict: false,
         ])
     }
 

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -20,7 +20,7 @@ let notificationNameInlineCandidateCount = Notification.Name("inlineCandidateCou
 let notificationNameCandidatesFontSize = Notification.Name("candidatesFontSize")
 // 注釈のフォントサイズが変更されたときに通知される通知の名前
 let notificationNameAnnotationFontSize = Notification.Name("annotationFontSize")
-// 一般辞書を保管で検索するかが変更されたときに通知される通知の名前
+// 一般辞書を補完で検索するかが変更されたときに通知される通知の名前
 let notificationNameFindCompletionFromNonUserDict =  Notification.Name("findCompletionFromNonUserDict")
 
 func isTest() -> Bool {

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -20,6 +20,8 @@ let notificationNameInlineCandidateCount = Notification.Name("inlineCandidateCou
 let notificationNameCandidatesFontSize = Notification.Name("candidatesFontSize")
 // 注釈のフォントサイズが変更されたときに通知される通知の名前
 let notificationNameAnnotationFontSize = Notification.Name("annotationFontSize")
+// 一般辞書を保管で検索するかが変更されたときに通知される通知の名前
+let notificationNameFindCompletionFromNonUserDict =  Notification.Name("findCompletionFromNonUserDict")
 
 func isTest() -> Bool {
     return ProcessInfo.processInfo.environment["MACSKK_IS_TEST"] == "1"
@@ -57,7 +59,7 @@ struct macSKKApp: App {
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
             
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
-            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode)
+            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode, findCompletionFromNonUserDict: Global.findCompletionFromNonUserDict)
             settingsWindowController = NSWindowController(window: settingsWindow)
             self.settingsViewModel = settingsViewModel
             settingsWindowController.windowFrameAutosaveName = "Settings"

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2553,10 +2553,9 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
         let dict = MemoryDict(entries: ["と": [Word("都")]], readonly: true)
-        Global.dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
+        Global.dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode, findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2553,9 +2553,10 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
         let dict = MemoryDict(entries: ["と": [Word("都")]], readonly: true)
-        Global.dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode)
+        Global.dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -68,4 +68,14 @@ final class UserDictTests: XCTestCase {
         privateMode.send(false)
         XCTAssertTrue(userDict.privateUserDict.entries.isEmpty)
     }
+    func testFindCompletion() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
+        let dict2 = MemoryDict(entries: ["にほんご": [Word("日本語")]], readonly: false)
+        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["にふ": [Word("二歩")]], privateMode: privateMode)
+        XCTAssertEqual(userDict.findCompletion(prefix: "に"), .some("にふ"))
+        XCTAssertEqual(userDict.findCompletion(prefix: "にほ"), .some("にほん"))
+        XCTAssertEqual(userDict.findCompletion(prefix: "にほん"), .some("にほんご"))
+        XCTAssertEqual(userDict.findCompletion(prefix: "にほんご"), .none)
+    }
 }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -9,17 +9,19 @@ import Combine
 final class UserDictTests: XCTestCase {
     func testRefer() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true)
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]], privateMode: privateMode)
+        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]], privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊", "胃", "意"])
     }
 
     @MainActor func testReferMergeAnnotation() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: [:], privateMode: privateMode)
+        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: [:], privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
         XCTAssertEqual(userDict.refer("い").map({ $0.word }), ["胃", "伊", "胃", "意"], "dict1, dict2に胃が1つずつある")
         XCTAssertEqual(userDict.refer("い").compactMap({ $0.annotation?.dictId }), ["dict1", "dict2"])
         XCTAssertEqual(userDict.referDicts("い").map({ $0.word }), ["胃", "伊", "意"])
@@ -28,6 +30,7 @@ final class UserDictTests: XCTestCase {
 
     func testReferWithOption() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
         let dict = MemoryDict(entries: ["あき>": [Word("空き")],
                                         "あき": [Word("秋")],
                                         ">し": [Word("氏")],
@@ -38,7 +41,7 @@ final class UserDictTests: XCTestCase {
                                                       "あき": [Word("安芸")],
                                                       ">し": [Word("詞")],
                                                       "し": [Word("士")]],
-                                    privateMode: privateMode)
+                                    privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
         XCTAssertEqual(userDict.refer("あき", option: nil), [Word("安芸"), Word("秋")])
         XCTAssertEqual(userDict.refer("あき", option: .prefix), [Word("飽き"), Word("空き")])
         XCTAssertEqual(userDict.refer("あき", option: .suffix), [])
@@ -49,7 +52,8 @@ final class UserDictTests: XCTestCase {
 
     func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(true)
-        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode)
+        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
+        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
         let word1 = Word("井")
         let word2 = Word("伊")
         // addのテスト
@@ -68,11 +72,17 @@ final class UserDictTests: XCTestCase {
         privateMode.send(false)
         XCTAssertTrue(userDict.privateUserDict.entries.isEmpty)
     }
-    func testFindCompletion() throws {
+    func testFindCompletionFromNonUserDict() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let findCompletionFromNonUserDict = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
         let dict2 = MemoryDict(entries: ["にほんご": [Word("日本語")]], readonly: false)
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["にふ": [Word("二歩")]], privateMode: privateMode)
+        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["にふ": [Word("二歩")]], privateMode: privateMode, findCompletionFromNonUserDict: findCompletionFromNonUserDict)
+        XCTAssertEqual(userDict.findCompletion(prefix: "に"), .some("にふ"))
+        XCTAssertEqual(userDict.findCompletion(prefix: "にほ"), .none)
+        XCTAssertEqual(userDict.findCompletion(prefix: "にほん"), .none)
+        XCTAssertEqual(userDict.findCompletion(prefix: "にほんご"), .none)
+        findCompletionFromNonUserDict.send(true)
         XCTAssertEqual(userDict.findCompletion(prefix: "に"), .some("にふ"))
         XCTAssertEqual(userDict.findCompletion(prefix: "にほ"), .some("にほん"))
         XCTAssertEqual(userDict.findCompletion(prefix: "にほん"), .some("にほんご"))


### PR DESCRIPTION
- ユーザー辞書だけでなく辞書からも補完を検索できるようにした
- AquaSKKを参考に設定でユーザー辞書だけの補完（現行の動作）か、他の辞書も含めるかを設定で変更できるようにした
    - AquaSKK: <img src="https://github.com/mtgto/macSKK/assets/612043/ae020605-5002-4284-8501-a64cf089ee4a" width="50%">
    - macSKK: <img width="40%" alt="image" src="https://github.com/mtgto/macSKK/assets/612043/b441d7c1-fd69-49d6-acc4-fb324a500044">
- `MemoryDict.init(entries: [String: [Word]], readonly: Bool)`のコンストラクターを使った場合、`readonly == false`であると`okuriAriYomis`/`okuriNashiYomis`が初期化されないようになっていたが、しかし`init(dictId: FileDict.ID, source: String, readonly: Bool)`側のコンストラクターであると`readonly`に関係なく`okuriAriYomis`/`okuriNashiYomis`を初期化しているため、`readonly`による分岐は一貫性がないと考えて消去した
    - この制約によってテストでつかっている 👇 このインスタシエーション時に`readonly == false`となり`okuriNashiYomis`が作られず、補完の単体テストが面倒になってしまう 😇 
    - https://github.com/mtgto/macSKK/blob/b022cee164f80fe76af5fcbee6c5c0251582baa5/macSKK/UserDict.swift#L52
