### PR TITLE
確定入力モードで "n-" 入力で "んー" とならず"ん"だけ確定されるバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -815,8 +815,17 @@ final class StateMachine {
                         }
                     } else {
                         addFixedText(moji.string(for: state.inputMode))
-                        state.inputMethod = .composing(
-                            ComposingState(isShift: false, text: [], okuri: nil, romaji: converted.input))
+                        if let inputConverted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: converted.input, input: "") {
+                            return handleComposingPrintable(input: inputConverted.input,
+                                                            converted: inputConverted,
+                                                            action: action,
+                                                            composing: ComposingState(isShift: false, text: [], okuri: nil, romaji: ""),
+                                                            specialState: specialState)
+                        } else {
+                            state.inputMethod = .composing(
+                                ComposingState(isShift: false, text: [], okuri: nil, romaji: converted.input))
+
+                        }
                     }
                 }
                 updateMarkedText()


### PR DESCRIPTION
#179 とほぼ同じ理由で、ひらがなモードでの "n-" という入力で "ん" は確定するが小文字のハイフン "-" が未確定入力に残ってしまうのを修正します。

入力 | 予想される結果 | 修正前
---- | ---- | ----
n- | んー | ん- (ハイフンが未確定文字列になってしまう)