### PR TITLE
セミコロンを含む変換候補の読み込み・スラッシュやセミコロンを含む変換候補の永続化・送りありエントリではないカッコが読み込めない問題の解決

### DIFF
--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -59,10 +59,18 @@ struct Entry: Sendable {
 
     private func serializeWord(_ word: Word) -> String {
         if let annotation = word.annotation {
-            return word.word + ";" + annotation.text
+            return serializeSpecialCharacters(word.word) + ";" + serializeSpecialCharacters(annotation.text)
         } else {
-            return word.word
+            return serializeSpecialCharacters(word.word)
         }
+    }
+
+    /// "/" と ";" は辞書の変換候補内では使用できないので `(concat "...\057...")` `(concat "...\073...")` のように変換する
+    private func serializeSpecialCharacters(_ string: String) -> String {
+        if string.contains("/") || string.contains(";") {
+            return "(concat \"" + string.replacingOccurrences(of: "/", with: "\\057").replacingOccurrences(of: ";", with: "\\073") + "\")"
+        }
+        return string
     }
 
     /**

--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -85,17 +85,22 @@ struct Entry: Sendable {
                 if array.count != 2 || array[1].first != "/" {
                     return nil
                 }
-                guard let index = array[0].firstIndex(of: "/") else { return nil }
-                if index == array[0].startIndex || index == array[0].endIndex {
-                    return nil
+                if let index = array[0].firstIndex(of: "/") {
+                    if index == array[0].startIndex || index == array[0].endIndex {
+                        return nil
+                    }
+                    let yomi = array[0].prefix(upTo: index)
+                    let words = parseWords(array[0].suffix(from: index).dropFirst(), dictId: dictId)?.map { word in
+                        Word(word.word, okuri: String(yomi), annotation: word.annotation)
+                    }
+                    guard let words else { return nil }
+                    result.append(contentsOf: words)
+                    wordsText = array[1].dropFirst()
+                } else {
+                    // スラッシュが含まれないときは送り仮名ブロックではない
+                    result.append(parseWord(wordsText.dropLast(), dictId: dictId))
+                    wordsText = array[1].dropFirst()
                 }
-                let yomi = array[0].prefix(upTo: index)
-                let words = parseWords(array[0].suffix(from: index).dropFirst(), dictId: dictId)?.map { word in
-                    Word(word.word, okuri: String(yomi), annotation: word.annotation)
-                }
-                guard let words else { return nil }
-                result.append(contentsOf: words)
-                wordsText = array[1].dropFirst()
             } else {
                 let array = wordsText.split(separator: "/", maxSplits: 1)
                 switch array.count {

--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -164,7 +164,7 @@ struct Entry: Sendable {
 
     static func decode(_ word: String) -> String {
         if word.hasPrefix(#"(concat ""#) && word.hasSuffix(#"")"#) {
-            return String(word.dropFirst(9).dropLast(2).replacingOccurrences(of: "\\057", with: "/"))
+            return String(word.dropFirst(9).dropLast(2).replacingOccurrences(of: "\\057", with: "/").replacingOccurrences(of: "\\073", with: ";"))
         } else {
             return word
         }

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -28,6 +28,8 @@ final class EntryTests: XCTestCase {
         XCTAssertEqual(Entry(line: "おおk /大/多/[く/多/]/[き/大/]/", dictId: "")?.candidates.map { $0.word }, ["大", "多", "多", "大"])
         XCTAssertEqual(Entry(line: "いt /[った/行/言/]/", dictId: "")?.candidates.map { $0.word }, ["行", "言"])
         XCTAssertEqual(Entry(line: "いt /[った/行/]/[った/言/]/", dictId: "")?.candidates.map { $0.okuri }, ["った", "った"])
+        // 変換候補にスラッシュを含まない場合は送りありブロックではないと解釈する
+        XCTAssertEqual(Entry(line: "ぶろっく /[ぶろっく]/", dictId: "")?.candidates.map { $0.word }, ["[ぶろっく]"])
     }
 
     func testInvalidLine() {

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -14,6 +14,7 @@ final class EntryTests: XCTestCase {
 
     func testDecode() {
         XCTAssertEqual(Entry(line: #"ao /(concat "and\057or")/"#, dictId: "")?.candidates.first?.word, "and/or")
+        XCTAssertEqual(Entry(line: #"ao /(concat "and\073or")/"#, dictId: "")?.candidates.first?.word, "and;or")
     }
 
     func testAnnotation() throws {

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -55,6 +55,9 @@ final class EntryTests: XCTestCase {
             "おおk /大/多/[く/多/]/[き/大/]/",
             "いt /[った/行/言/]/入/",
             "ふくm /含/[め/含/]/[む/含/]/[ま/含/]/[み/含/]/[も/含/]/",
+            "すらっしゅ /(concat \"a\\057b\")/",
+            "せみころん /(concat \"a\\073b\")/",
+            "すらっしゅとせみころんがふくすう /(concat \"a\\073b\\057c\\073d\\057\\073e\")/",
         ].forEach { line in
             XCTAssertEqual(Entry(line: line, dictId: "")?.serialize(), line)
         }

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -33,18 +33,20 @@ class MemoryDictTests: XCTestCase {
     }
 
     func testParseSpecialSource() throws {
-        // Sampling from SKK-JISYO.L
+        // スラッシュの使用例はSKK-JISYO.Lから。
         let source = """
             わi /湧;(spring) 泉が湧く/沸;(boil) お湯が沸く/涌;≒湧く/
             ao /(concat "and\\057or")/
             GPL /GNU General Public License;(concat "http:\\057\\057www.gnu.org\\057licenses\\057gpl.ja.html")/
+            しゅたいんずげーと /(concat "Steins\\073Gate")/
 
             """
         let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
         XCTAssertEqual(dict.entries["わi"]?.map { $0.word }, ["湧", "沸", "涌"])
         XCTAssertEqual(dict.entries["ao"]?.map { $0.word }, ["and/or"])
         XCTAssertEqual(dict.entries["GPL"]?.map { $0.annotation?.text }, ["http://www.gnu.org/licenses/gpl.ja.html"])
-        XCTAssertEqual(dict.okuriNashiYomis, ["GPL", "ao"], "abbrev辞書の読みは末尾がアルファベットだが送り無し扱い")
+        XCTAssertEqual(dict.entries["しゅたいんずげーと"]?.map { $0.word }, ["Steins;Gate"])
+        XCTAssertEqual(dict.okuriNashiYomis, ["しゅたいんずげーと", "GPL", "ao"], "abbrev辞書の読みは末尾がアルファベットだが送り無し扱い")
     }
 
     func testParseDuplicatedYomi() throws {

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -49,6 +49,15 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.okuriNashiYomis, ["しゅたいんずげーと", "GPL", "ao"], "abbrev辞書の読みは末尾がアルファベットだが送り無し扱い")
     }
 
+    func testParseOkurikanaBlockAndExcpetions() throws {
+        let source = """
+            あれきさんどろす /[Alexandros]/
+
+            """
+        let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
+        XCTAssertEqual(dict.entries["あれきさんどろす"]?.map { $0.word }, ["[Alexandros]"])
+    }
+
     func testParseDuplicatedYomi() throws {
         let source = """
             あお /青/


### PR DESCRIPTION
#183

- `あれきさんどろす /[Alexandros]/` のようにブラケット記号で囲まれただけの、送りありエントリではないエントリが読み込めないバグを修正します。

#184

- セミコロンを変換候補に含む辞書の場合、 `(concat "Steins\073Gate")` のようにエスケープされるのが事実上の標準のようです。スラッシュだけ特別に対応していたのですがセミコロンにも対応します。
  - 固定で `\057` と `\073` だけ見ており、ほんとはちゃんと数値を見てデコードするようにしてもいいかもしれないけどとりあえず保留
- スラッシュやセミコロンを変換候補に含むエントリをユーザー辞書に永続化するときにconcatを使った記法で永続化するようにします。