### PR TITLE
Enterキーで変換候補の確定 + 改行も行う設定を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -30,6 +30,8 @@ import Combine
     static var keyBinding: KeyBindingSet = KeyBindingSet.defaultKeyBindingSet
     /// 変換候補パネルから選択するときに使用するキーの配列。英字の場合は小文字にしておくこと。
     static var selectCandidateKeys: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+    // Enterキーで変換候補の確定だけでなく改行も行うかどうか
+    static var enterNewLine: Bool!
     // 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     // 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -18,7 +18,7 @@ import Combine
     // マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。
     // FIXME: NotificationCenter経由で設定画面で変更したことを各InputControllerに通知するようにしてこの変数は消すかも。
     static let directModeBundleIdentifiers = CurrentValueSubject<[String], Never>([])
-    // モード変更時に空白文字を一瞬追加するワークアラウンドを適用するBundle Identifierの集合
+    /// モード変更時に空白文字を一瞬追加するワークアラウンドを適用するBundle Identifierの集合
     static let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
     /// ユーザー辞書だけでなくすべての辞書から補完候補を検索するか？
     static let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)
@@ -30,13 +30,14 @@ import Combine
     static var keyBinding: KeyBindingSet = KeyBindingSet.defaultKeyBindingSet
     /// 変換候補パネルから選択するときに使用するキーの配列。英字の場合は小文字にしておくこと。
     static var selectCandidateKeys: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-    // Enterキーで変換候補の確定だけでなく改行も行うかどうか
-    static var enterNewLine: Bool!
-    // 現在のモードを表示するパネル
+    /// Enterキーで変換候補の確定だけでなく改行も行うかどうか
+    /// ddskkの `skk-egg-like-newline` やAquaSKKの `suppress_newline_on_commit` がfalseのときと同じ
+    static var enterNewLine: Bool = false
+    /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
-    // 変換候補を表示するパネル
+    /// 変換候補を表示するパネル
     private let candidatesPanel: CandidatesPanel
-    // 補完候補を表示するパネル
+    /// 補完候補を表示するパネル
     private let completionPanel: CompletionPanel
 
     init() {

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -9,6 +9,9 @@ struct GeneralView: View {
     var body: some View {
         VStack {
             Form {
+                Toggle(isOn: $settingsViewModel.enterNewLine, label: {
+                    Text("Enter Key confirms a candidate & send a newline")
+                })
                 Picker("Keyboard Layout", selection: $settingsViewModel.selectedInputSourceId) {
                     ForEach(settingsViewModel.inputSources) { inputSource in
                         Text(inputSource.localizedName)

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -10,7 +10,7 @@ struct GeneralView: View {
         VStack {
             Form {
                 Toggle(isOn: $settingsViewModel.enterNewLine, label: {
-                    Text("Enter Key confirms a candidate & send a newline")
+                    Text("Enter Key confirms a candidate and sends a newline")
                 })
                 Picker("Keyboard Layout", selection: $settingsViewModel.selectedInputSourceId) {
                     ForEach(settingsViewModel.inputSources) { inputSource in

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -378,6 +378,7 @@ final class SettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $enterNewLine.sink { enterNewLine in
+            logger.log("Enterキーで変換確定と一緒に改行する設定を\(enterNewLine ? "有効" : "無効")にしました")
             Global.enterNewLine = enterNewLine
         }.store(in: &cancellables)
 

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -24,4 +24,6 @@ struct UserDefaultsKeys {
     static let selectedKeyBindingSetId = "selectedKeyBindingSetId"
     // キーバインド設定の配列
     static let keyBindingSets = "keyBindingSets"
+    // Enterキーで変換候補の確定 + 改行も行う
+    static let enterNewLine = "enterNewLine"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -539,6 +539,9 @@ final class StateMachine {
             state.inputMethod = .normal
             addFixedText(fixedText)
             updateModeIfPrevModeExists()
+            if Global.enterNewLine {
+                return handle(action)
+            }
             return true
         case .backspace:
             if let newComposingState = composing.dropLast() {
@@ -957,6 +960,9 @@ final class StateMachine {
         case .enter:
             // 選択中の変換候補で確定
             fixCurrentSelect()
+            if Global.enterNewLine {
+                return handle(action)
+            }
             return true
         case .backspace:
             let diff: Int

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 "Candidates font size" = "Candidates font size";
 "Annotation font size" = "Annotation font size";
 "Find completion from all dictionaries" = "Find completion from all dictionaries";
+"Enter Key confirms a candidate & send a newline" = "Enter Key confirms a candidate & send a newline";
 "Insert Blank String" = "Insert Blank String";
 "Enabled" = "Enabled";
 "Disabled" = "Disabled";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -63,7 +63,7 @@
 "Candidates font size" = "Candidates font size";
 "Annotation font size" = "Annotation font size";
 "Find completion from all dictionaries" = "Find completion from all dictionaries";
-"Enter Key confirms a candidate & send a newline" = "Enter Key confirms a candidate & send a newline";
+"Enter Key confirms a candidate and sends a newline" = "Enter Key confirms a candidate and sends a newline";
 "Insert Blank String" = "Insert Blank String";
 "Enabled" = "Enabled";
 "Disabled" = "Disabled";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -63,7 +63,7 @@
 "Candidates font size" = "変換候補のフォントサイズ";
 "Annotation font size" = "注釈のフォントサイズ";
 "Find completion from all dictionaries" = "ユーザー辞書だけでなくすべての辞書から補完を探す";
-"Enter Key confirms a candidate & send a newline" = "Enterキーで変換候補確定後に改行を入力";
+"Enter Key confirms a candidate and sends a newline" = "Enterキーで変換候補確定後に改行を入力";
 "Insert Blank String" = "空文字挿入";
 "Enabled" = "有効";
 "Disabled" = "無効";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 "Candidates font size" = "変換候補のフォントサイズ";
 "Annotation font size" = "注釈のフォントサイズ";
 "Find completion from all dictionaries" = "ユーザー辞書だけでなくすべての辞書から補完を探す";
+"Enter Key confirms a candidate & send a newline" = "Enterキーで変換候補確定後に改行を入力";
 "Insert Blank String" = "空文字挿入";
 "Enabled" = "有効";
 "Disabled" = "無効";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -196,6 +196,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.findCompletionFromAllDicts: false,
             UserDefaultsKeys.keyBindingSets: [],
             UserDefaultsKeys.selectedKeyBindingSetId: KeyBindingSet.defaultKeyBindingSet.id,
+            UserDefaultsKeys.enterNewLine: false,
         ])
     }
 


### PR DESCRIPTION
#189 ddskkの[skk-egg-like-newline](https://ddskk.readthedocs.io/ja/latest/06_apps.html#variable-skk-egg-like-newline) やAquaSKKの「Enter による確定で改行しない」と同じような設定を追加します。
初期値はこれまでの挙動に合わせて「未確定文字列入力中のEnterは確定のみを行い改行は行わない」とします。

macSKK独自仕様として、読みの入力中にカーソルを動かしてカーソルの左側だけ変換して変換候補が確定したらカーソルの右側の変換を行うことができる機能 #113 がありますが、「Enterキーを変換候補の確定 + 改行とする設定」が有効な場合にEnterを押した場合、カーソルの右側はかなのまま確定されます。

ddskk/AquaSKKと違って「改行する」ときをtrueにしています。

<img width="640" alt="image" src="https://github.com/user-attachments/assets/a12e6d7a-39e2-46af-91b9-b388e4a29a60">
