### PR TITLE
単語登録中に未確定文字列をC-jで入力すると▽が表示されてしまうバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -433,8 +433,8 @@ final class StateMachine {
                 break
             }
             // 入力中文字列を確定させてひらがなモードにする
-            addFixedText(composing.string(for: state.inputMode, convertHatsuon: true))
             state.inputMethod = .normal
+            addFixedText(composing.string(for: state.inputMode, convertHatsuon: true))
             state.inputMode = .hiragana
             inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
             return true


### PR DESCRIPTION
単語登録中にC-jで未確定文字列を確定させると `[登録：ほげほげ]あ▽あ` のように▽が表示されてしまうのを修正します。