### PR TITLE
カーソルより右に文字があるとき促音が確定するとカーソル関係なく末尾に文字が追加されるバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -800,9 +800,10 @@ final class StateMachine {
                                                                romaji: converted.input)
                         } else {
                             newComposingState = ComposingState(isShift: true,
-                                                               text: text + [moji.kana],
+                                                               text: composing.subText() + [moji.kana] + (composing.remain() ?? []),
                                                                okuri: action.shiftIsPressed() ? [] : nil,
-                                                               romaji: converted.input)
+                                                               romaji: converted.input,
+                                                               cursor: composing.cursor.map { $0 + 1 })
                         }
                         if let inputConverted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: converted.input, input: "") {
                             return handleComposingPrintable(input: inputConverted.input,

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1577,6 +1577,27 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleComposingCursorSokuon() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(6).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あい")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("あ"), .cursor, .plain("い")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("あk"), .cursor, .plain("い")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.markerCompose, .plain("あっk"), .cursor, .plain("い")])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([.markerCompose, .plain("あっく"), .cursor, .plain("い")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i")))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "k")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleComposingCursorFirst() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()


### PR DESCRIPTION
`Shift-a, 左矢印, kk` のようにカーソルの右に文字がある状態で促音(っ)を入力しようとするとカーソルを無視して `あっk` のように末尾に追加されてしまうバグに気付いたので修正します。