### PR TITLE
入力元のウィンドウレベルより1大きいレベルで補完候補パネルを表示する

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -159,7 +159,7 @@ class InputController: IMKInputController {
                     Global.completionPanel.viewModel.completion = completion
                     // 下線分1ピクセル下に余白を設ける
                     let cursorPosition = self.cursorPosition.offsetBy(dx: 0, dy: -1)
-                    Global.completionPanel.show(at: cursorPosition.origin)
+                    Global.completionPanel.show(at: cursorPosition.origin, windowLevel: self.windowLevel)
                 } else {
                     self.stateMachine.completion = nil
                     Global.completionPanel.orderOut(nil)

--- a/macSKK/View/CompletionPanel.swift
+++ b/macSKK/View/CompletionPanel.swift
@@ -13,10 +13,10 @@ class CompletionPanel: NSPanel {
         let viewController = NSHostingController(rootView: rootView)
         super.init(contentRect: .zero, styleMask: [.nonactivatingPanel], backing: .buffered, defer: true)
         contentViewController = viewController
-        level = .floating
     }
 
-    func show(at point: NSPoint) {
+    func show(at point: NSPoint, windowLevel: NSWindow.Level) {
+        level = windowLevel
         setFrameTopLeftPoint(point)
         orderFrontRegardless()
     }


### PR DESCRIPTION
#123 と同様に、補完候補パネルも入力元のウィンドウレベルより1大きいレベルで表示するようにします。