### PR TITLE
半角英数入力時はIntelliJ用の特殊処理をしない

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -57,7 +57,7 @@ class InputController: IMKInputController {
             if let self {
                 switch event {
                 case .fixedText(let text):
-                    if textInput.bundleIdentifier() == "com.jetbrains.intellij" {
+                    if stateMachine.state.inputMode != .direct && textInput.bundleIdentifier() == "com.jetbrains.intellij" {
                         // AquaSKKと同様に、非確定文字列に確定予定文字列を先に表示する
                         textInput.setMarkedText(
                             text,


### PR DESCRIPTION
#198 の問題を修正します。

JetBrains IDE + IdeaVimの組み合わせで、ビジュアルモードのためにveなどを入力すると単語の末尾まで選択したいところ、カーソル一の文字が消えてしまいます問題があることがわかりました。
macSKKではこれまでIntelliJ IDEAでaiueoであいうえおが入力できない問題のワークアラウンドを入れていたのですが、これが悪さをしていたようです。
https://github.com/mtgto/macSKK/commit/b3d9350949ac630f4965110fa4a34c7dec6612b0

そもそもこのIntelliJ特別対応自体が意味がなくなっている気がするので、ワークアラウンドごと消すかもしれません。