### PR TITLE
macOSの文字ビューアで入力するとクラッシュするバグを修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -196,6 +196,10 @@ class InputController: IMKInputController {
     }
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+        // 文字ビューアで入力した場合など、eventがnilの場合がありえる
+        if event == nil {
+            return false
+        }
         let keyBind = Global.keyBinding.action(event: event)
         if directMode {
             if let keyBind, keyBind == .kana || keyBind == .eisu {


### PR DESCRIPTION
#199 macOSの文字ビューア https://support.apple.com/ja-jp/guide/mac-help/mchlp1560/mac から入力すると、IMKInputController#handleが呼び出されますが、その際に第一引数のNSEventはnilで渡されるようです。
(著者はmacOS 14.6で確認)

それを知らずにnilを参照しようとするとクラッシュするため、nilチェックを追加します。