### PR TITLE
`build_restart.sh`ではデバッグ版を使う

### DIFF
--- a/build_restart.sh
+++ b/build_restart.sh
@@ -2,7 +2,7 @@
 
 set -e
 # ビルド
-xcodebuild -workspace macSKK.xcodeproj/project.xcworkspace -scheme macSKK DEVELOPMENT_TEAM= clean archive -archivePath build/archive.xcarchive
+xcodebuild -workspace macSKK.xcodeproj/project.xcworkspace -scheme macSKK -configuration Debug DEVELOPMENT_TEAM= clean archive -archivePath build/archive.xcarchive
 # 上書き
 rm -rf ~/Library/Input\ Methods/macSKK.app
 cp -r build/archive.xcarchive/Products/Library/Input\ Methods/macSKK.app ~/Library/Input\ Methods/


### PR DESCRIPTION
- [x] 下記のようなコードを`InputController.swift`に追加して`DEBUG!`がコンソールで表示されることを確認した 
    ```swift
    override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
        #if DEBUG
            logger.log("DEBUG!")
        #endif
    ```
    - <img width="377" alt="image" src="https://github.com/user-attachments/assets/9913107e-4a17-4d35-ab43-0bb4131d0fd4">
- もともとの`-configuration Debug`を指定していないバージョンでは表示されないことも確認した