### PR TITLE
辞書ファイル操作をOperationQueueを使って直列化する

### DIFF
--- a/macSKK/AppDelegate.swift
+++ b/macSKK/AppDelegate.swift
@@ -6,7 +6,7 @@ import Cocoa
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")
-        try? Global.dictionary.save()
+        Global.dictionary.save()
         return .terminateNow
     }
 }

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -133,6 +133,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
                 do {
                     try data.write(to: newURL)
                     self.hasUnsavedChanges = false
+                    logger.log("辞書を永続化しました (\(data.count)バイト)")
                 } catch {
                     logger.error("辞書 \(self.id, privacy: .public) の書き込みに失敗しました: \(error)")
                     writingError = error as NSError
@@ -237,7 +238,11 @@ extension FileDict: NSFilePresenter {
     // どちらも同じ辞書ファイルを監視しているので、Aが保存してもAのpresentedItemDidChangeは呼び出されないが、
     // BのpresentedItemDidChangeは呼び出される。
     func presentedItemDidChange() {
-        if let version = NSFileVersion.currentVersionOfItem(at: fileURL), version == self.version {
+        guard let version = NSFileVersion.currentVersionOfItem(at: fileURL) else {
+            logger.error("辞書 \(self.id, privacy: .public) のバージョンが存在しません")
+            return
+        }
+        if version == self.version {
             logger.log("辞書 \(self.id, privacy: .public) がアプリ外で変更されたため読み込みます")
         } else {
             logger.log("辞書 \(self.id, privacy: .public) が変更されたので読み込みます")

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -19,7 +19,13 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     let id: String
     let fileURL: URL
     let encoding: String.Encoding
-    var version: NSFileVersion?
+    private var version: NSFileVersion?
+    /// ファイルの書き込み・読み込みを直列で実行するためのキュー
+    private let fileOperationQueue = {
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
     /// 保存してない変更があるかどうか (UIDocumentのパクり)
     private(set) var hasUnsavedChanges: Bool = false
     private(set) var dict: MemoryDict
@@ -54,40 +60,48 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         self.version = NSFileVersion.currentVersionOfItem(at: fileURL)
         self.readonly = readonly
         super.init()
-        try load()
+        load()
         NSFileCoordinator.addFilePresenter(self)
     }
 
-    func load() throws {
-        var coordinationError: NSError?
-        var readingError: NSError?
-        let fileCoordinator = NSFileCoordinator(filePresenter: self)
-        NotificationCenter.default.post(name: notificationNameDictLoad,
-                                        object: DictLoadEvent(id: self.id,
-                                                              status: .loading))
-        fileCoordinator.coordinate(readingItemAt: fileURL, error: &coordinationError) { [weak self] url in
-            if let self {
-                do {
-                    let source = try self.loadString(url)
-                    let memoryDict = MemoryDict(dictId: self.id, source: source, readonly: readonly)
-                    self.dict = memoryDict
-                    self.version = NSFileVersion.currentVersionOfItem(at: url)
-                    logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")
-                    NotificationCenter.default.post(name: notificationNameDictLoad,
-                                                    object: DictLoadEvent(id: self.id,
-                                                                          status: .loaded(success: dict.entryCount, failure: dict.failedEntryCount)))
-                } catch {
-                    logger.error("辞書 \(self.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")
-                    NotificationCenter.default.post(name: notificationNameDictLoad,
-                                                    object: DictLoadEvent(id: self.id,
-                                                                          status: .fail(error)))
-                    readingError = error as NSError
+    func load() {
+        let operation = BlockOperation {
+            var coordinationError: NSError?
+            var readingError: NSError?
+            let fileCoordinator = NSFileCoordinator(filePresenter: self)
+            NotificationCenter.default.post(name: notificationNameDictLoad,
+                                            object: DictLoadEvent(id: self.id,
+                                                                  status: .loading))
+            fileCoordinator.coordinate(readingItemAt: self.fileURL, error: &coordinationError) { [weak self] url in
+                if let self {
+                    do {
+                        let source = try self.loadString(url)
+                        if source.isEmpty {
+                            // 辞書ファイルを書き込み中に読み込んでしまった?
+                            logger.warning("辞書 \(self.id) を読み込んだところ0バイトだったため更新を無視します")
+                        }
+                        let memoryDict = MemoryDict(dictId: self.id, source: source, readonly: readonly)
+                        self.dict = memoryDict
+                        self.version = NSFileVersion.currentVersionOfItem(at: url)
+                        logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")
+                        NotificationCenter.default.post(name: notificationNameDictLoad,
+                                                        object: DictLoadEvent(id: self.id,
+                                                                              status: .loaded(success: dict.entryCount, failure: dict.failedEntryCount)))
+                    } catch {
+                        logger.error("辞書 \(self.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")
+                        NotificationCenter.default.post(name: notificationNameDictLoad,
+                                                        object: DictLoadEvent(id: self.id,
+                                                                              status: .fail(error)))
+                        readingError = error as NSError
+                    }
                 }
             }
+            if let error = coordinationError ?? readingError {
+                logger.error("辞書 \(self.id, privacy: .public) の読み込み中にエラーが発生しました: \(error)")
+            }
         }
-        if let error = coordinationError ?? readingError {
-            throw error
-        }
+        fileOperationQueue.addOperation(operation)
+        operation.waitUntilFinished()
     }
 
     private func loadString(_ url: URL) throws -> String {
@@ -113,40 +127,44 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         return try String(contentsOf: url, encoding: encoding)
     }
 
-    func save() throws {
+    func save() {
         if !hasUnsavedChanges {
             logger.log("辞書 \(self.id, privacy: .public) は変更されていないため保存は行いません")
             return
         }
-        guard let data = serialize().data(using: encoding) else {
-            fatalError("辞書 \(self.id) のシリアライズに失敗しました")
-        }
-        var coordinationError: NSError?
-        var writingError: NSError?
-        let fileCoordinator = NSFileCoordinator(filePresenter: self)
-        fileCoordinator.coordinate(writingItemAt: fileURL, error: &coordinationError) { [weak self] newURL in
-            if let self {
-                do {
-                    self.version = try NSFileVersion.addOfItem(at: newURL, withContentsOf: newURL)
-                    logger.log("辞書のバージョンを作成しました")
-                } catch {
-                    logger.error("辞書のバージョン作成でエラーが発生しました: \(error)")
-                    writingError = error as NSError
-                    return
-                }
-                do {
-                    try data.write(to: newURL)
-                    self.hasUnsavedChanges = false
-                    logger.log("辞書を永続化しました。現在のエントリ数は \(dict.entries.count)、シリアライズ後のファイルサイズは\(data.count)バイトです")
-                } catch {
-                    logger.error("辞書 \(self.id, privacy: .public) の書き込みに失敗しました: \(error)")
-                    writingError = error as NSError
+        let operation = BlockOperation {
+            guard let data = self.serialize().data(using: self.encoding) else {
+                fatalError("辞書 \(self.id) のシリアライズに失敗しました")
+            }
+            var coordinationError: NSError?
+            var writingError: NSError?
+            let fileCoordinator = NSFileCoordinator(filePresenter: self)
+            fileCoordinator.coordinate(writingItemAt: self.fileURL, error: &coordinationError) { [weak self] newURL in
+                if let self {
+                    do {
+                        self.version = try NSFileVersion.addOfItem(at: newURL, withContentsOf: newURL)
+                        logger.log("辞書のバージョンを作成しました")
+                    } catch {
+                        logger.error("辞書のバージョン作成でエラーが発生しました: \(error)")
+                        writingError = error as NSError
+                        return
+                    }
+                    do {
+                        try data.write(to: newURL)
+                        self.hasUnsavedChanges = false
+                        logger.log("辞書を永続化しました。現在のエントリ数は \(dict.entries.count)、シリアライズ後のファイルサイズは\(data.count)バイトです")
+                    } catch {
+                        logger.error("辞書 \(self.id, privacy: .public) の書き込みに失敗しました: \(error)")
+                        writingError = error as NSError
+                    }
                 }
             }
+            if let error = coordinationError ?? writingError {
+                logger.error("辞書 \(self.id, privacy: .public) の読み込み中にエラーが発生しました: \(error)")
+            }
         }
-        if let error = coordinationError ?? writingError {
-            throw error
-        }
+        fileOperationQueue.addOperation(operation)
+        operation.waitUntilFinished()
     }
 
     deinit {
@@ -228,13 +246,13 @@ extension FileDict: NSFilePresenter {
             logger.log("辞書 \(self.id, privacy: .public) のバージョンが自分自身に更新されたため何もしません")
         } else {
             logger.log("辞書 \(self.id, privacy: .public) のバージョンが更新されたので読み込みます")
-            try? load()
+            load()
         }
     }
 
     func presentedItemDidLose(_ version: NSFileVersion) {
         logger.log("辞書 \(self.id, privacy: .public) が更新されたので読み込みます (バージョン情報が消失)")
-        try? load()
+        load()
     }
 
     // NOTE: save() で保存した場合はバージョンが必ず更新されるのでこのメソッドは呼ばれない
@@ -251,6 +269,6 @@ extension FileDict: NSFilePresenter {
         } else {
             logger.log("辞書 \(self.id, privacy: .public) が変更されたので読み込みます")
         }
-        try? load()
+        load()
     }
 }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -73,7 +73,7 @@ class UserDict: NSObject, DictProtocol {
             .debounce(for: .seconds(60), scheduler: DispatchQueue.global(qos: .background))
             .sink { [weak self] _ in
                 if let fileDict = self?.userDict as? FileDict {
-                    logger.log("ユーザー辞書を永続化します")
+                    logger.log("ユーザー辞書を永続化します。現在のエントリ数は \(fileDict.dict.entries.count)")
                     do {
                         try fileDict.save()
                     } catch {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -264,7 +264,7 @@ class UserDict: NSObject, DictProtocol {
     }
 
     /// ユーザー辞書を永続化する
-    func save() throws {
+    func save() {
         // XcodeのEdit Scheme…でRun時とTest時の環境変数で設定しています。
         // 普段利用しているmacSKKプロセスの書き込みと競合するのを回避するのが目的です。
         if ProcessInfo.processInfo.environment["DISABLE_USER_DICT_SAVE"] == "1" {
@@ -273,7 +273,7 @@ class UserDict: NSObject, DictProtocol {
         }
         if let userDict {
             if let dict = userDict as? FileDict {
-                try dict.save()
+                dict.save()
             } else {
                 // ユニットテストなど特殊な場合のみ
                 logger.info("永続化が要求されましたが、ユーザー辞書がファイル形式でないため無視されます")
@@ -318,6 +318,9 @@ extension UserDict: NSFilePresenter {
             logger.log("変更されたファイル \(url.lastPathComponent, privacy: .public) が見つからないため削除されたと扱います")
             NotificationCenter.default.post(name: notificationNameDictFileDidMove, object: url)
             return
+        } else if url.lastPathComponent == Self.userDictFilename {
+            // ユーザー辞書ファイル自体はFileDictで監視しているため無視する
+            return
         }
 
         var relationship: FileManager.URLRelationship = .same
@@ -332,7 +335,6 @@ extension UserDict: NSFilePresenter {
                     // 辞書ファイルが別フォルダに移動したときにはpresentedSubitem:at:didMoveToも呼ばれる
                     logger.log("ファイル \(url.lastPathComponent, privacy: .public) が更新されましたが辞書フォルダ外なので無視します")
                 }
-
             } else {
                 logger.log("辞書フォルダで \(url.lastPathComponent, privacy: .public) が更新されました (無視)")
             }
@@ -356,9 +358,6 @@ extension UserDict: NSFilePresenter {
 
     // 辞書ファイルとして問題があるファイルでないかを判定する
     private func isValidFile(_ fileURL: URL) throws -> Bool {
-        if fileURL.lastPathComponent == Self.userDictFilename {
-            return false
-        }
         return try fileURL.isReadable()
     }
 }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -121,11 +121,7 @@ struct macSKKApp: App {
                     NotificationCenter.default.post(name: notificationNameOpenSettings, object: nil)
                 }
                 Button("Save User Directory") {
-                    do {
-                        try Global.dictionary.save()
-                    } catch {
-                        print(error)
-                    }
+                    Global.dictionary.save()
                 }.keyboardShortcut("S")
                 #if DEBUG
                 Button("AnnotationsPanel") {


### PR DESCRIPTION
#203 ユーザー辞書が空エントリに戻るバグの修正を試みます。
Issueにあるログにある順番から、おそらくユーザー辞書の書き込みと読み込みがほぼ同時に起こったものと推測します。

1. ユーザー辞書をファイルに書き込みを開始する (0バイトに戻る?)
2. ユーザー辞書が更新されたというイベントを受け取り読み込みを開始する
    a. おそらくここで0バイトだけ読み込んでしまって0エントリに戻った?
3. 書き込みが正常に完了する

このあと書き込みを行う時は0エントリとして書き込んでしまい、それ以降は正常に読み込んでも既存のエントリが消失してしまったと思われます。

macSKKの定期的に保存する処理をバックグラウンド (非mainスレッド) で実行しており、またmacOS 14.6.1では辞書が更新されたイベントを受け取るのもバックグラウンド (非mainスレッド) で呼び出されているようでした。

このPRでは同時実行数を1に制限したOperationQueueを使い読み込みと書き込みを直列化することで、書き込み中に読み込もうとしても書き込みが完了するまでは読み込めないようにします。
また、上記の推測が正しいとして、念の為に0バイトしか読み込めなかったときは読み込みをなかったことにします。