### PR TITLE
単語登録中のモード変更時に空文字列でsetMarkedTextするのを修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -80,7 +80,7 @@ class InputController: IMKInputController {
                     // KittyやAlacrittyなど、q/lによるモード切り替えでq/lが入力されたり、C-jで改行が入力されるのを回避するワークアラウンド
                     // AquaSKKの空文字列挿入を参考にしています。
                     // https://github.com/codefirst/aquaskk/blob/4.7.5/platform/mac/src/server/SKKInputController.mm#L405-L412
-                    if self.insertBlankString {
+                    if self.stateMachine.state.specialState == nil && self.insertBlankString {
                         textInput.setMarkedText(String(format: "%c", 0x0c), selectionRange: Self.notFoundRange, replacementRange: Self.notFoundRange)
                         textInput.setMarkedText("", selectionRange: Self.notFoundRange, replacementRange: Self.notFoundRange)
                     }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -84,6 +84,9 @@ final class StateMachine {
             } else {
                 state.inputMode = .hiragana
                 inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
+                if specialState != nil {
+                    updateMarkedText()
+                }
                 return true
             }
         case .japanese:
@@ -101,10 +104,16 @@ final class StateMachine {
             case .hiragana:
                 state.inputMode = .katakana
                 inputMethodEventSubject.send(.modeChanged(.katakana, action.cursorPosition))
+                if specialState != nil {
+                    inputMethodEventSubject.send(.markedText(state.displayText()))
+                }
                 return true
             case .katakana, .hankaku:
                 state.inputMode = .hiragana
                 inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
+                if specialState != nil {
+                    inputMethodEventSubject.send(.markedText(state.displayText()))
+                }
                 return true
             case .eisu, .direct:
                 break
@@ -114,10 +123,16 @@ final class StateMachine {
             case .hiragana, .katakana:
                 state.inputMode = .hankaku
                 inputMethodEventSubject.send(.modeChanged(.hankaku, action.cursorPosition))
+                if specialState != nil {
+                    inputMethodEventSubject.send(.markedText(state.displayText()))
+                }
                 return true
             case .hankaku:
                 state.inputMode = .hiragana
                 inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
+                if specialState != nil {
+                    inputMethodEventSubject.send(.markedText(state.displayText()))
+                }
                 return true
             default:
                 break
@@ -127,6 +142,9 @@ final class StateMachine {
             case .hiragana, .katakana, .hankaku:
                 state.inputMode = .direct
                 inputMethodEventSubject.send(.modeChanged(.direct, action.cursorPosition))
+                if specialState != nil {
+                    inputMethodEventSubject.send(.markedText(state.displayText()))
+                }
                 return true
             case .eisu, .direct:
                 break
@@ -136,6 +154,9 @@ final class StateMachine {
             case .hiragana, .katakana, .hankaku:
                 state.inputMode = .eisu
                 inputMethodEventSubject.send(.modeChanged(.eisu, action.cursorPosition))
+                if specialState != nil {
+                    inputMethodEventSubject.send(.markedText(state.displayText()))
+                }
                 return true
             case .eisu, .direct:
                 break
@@ -146,7 +167,7 @@ final class StateMachine {
                 state.inputMethod = .composing(ComposingState(isShift: true, text: [], okuri: nil, romaji: "", prevMode: state.inputMode))
                 state.inputMode = .direct
                 inputMethodEventSubject.send(.modeChanged(.direct, action.cursorPosition))
-                updateMarkedText()
+                inputMethodEventSubject.send(.markedText(state.displayText()))
                 return true
             case .eisu, .direct:
                 break

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1822,14 +1822,15 @@ final class StateMachineTests: XCTestCase {
     @MainActor func testHandleRegisteringStickyShift() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(7).sink { events in
+        stateMachine.inputMethodEvent.collect(8).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
             XCTAssertEqual(events[1], .modeChanged(.hiragana, .zero))
             XCTAssertEqual(events[2], .markedText(MarkedText([.plain("[登録：あ]")])))
             XCTAssertEqual(events[3], .markedText(MarkedText([.plain("[登録：あ]"), .markerCompose])))
             XCTAssertEqual(events[4], .markedText(MarkedText([.plain("[登録：あ]")])))
             XCTAssertEqual(events[5], .modeChanged(.direct, .zero))
-            XCTAssertEqual(events[6], .markedText(MarkedText([.plain("[登録：あ]"), .plain(";")])))
+            XCTAssertEqual(events[6], .markedText(MarkedText([.plain("[登録：あ]")])))
+            XCTAssertEqual(events[7], .markedText(MarkedText([.plain("[登録：あ]"), .plain(";")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))


### PR DESCRIPTION
WezTermで単語登録中にqやlなどで入力モードを変更すると表示されている未確定文字列が表示されなくなってしまうバグに気付きました。その状態でなにか文字を入力すると復活します。
単語登録中にsetMarkedTextで空文字列を間違って設定しているためなので、これを修正します。

WezTerm以外でも同じように未確定文字列が表示されなくなる気がするのですが気付いたのはWezTermでだけです。