### PR TITLE
ウィズダム英和・和英辞書を注釈として表示する設定を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -33,6 +33,8 @@ import Combine
     /// Enterキーで変換候補の確定だけでなく改行も行うかどうか
     /// ddskkの `skk-egg-like-newline` やAquaSKKの `suppress_newline_on_commit` がfalseのときと同じ
     static var enterNewLine: Bool = false
+    /// 注釈で使用するシステム辞書
+    static var systemDict: SystemDict.Kind = .daijirin
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -136,7 +136,7 @@ class InputController: IMKInputController {
         }.store(in: &cancellables)
         selectedWord.removeDuplicates().compactMap({ $0 }).sink { [weak self] word in
             if UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation) {
-                if let self, let systemAnnotation = SystemDict.lookup(word, for: .daijirin), !systemAnnotation.isEmpty {
+                if let self, let systemAnnotation = SystemDict.lookup(word, for: Global.systemDict), !systemAnnotation.isEmpty {
                     Global.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
                     Global.candidatesPanel.show(windowLevel: self.windowLevel)
                 }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -136,7 +136,7 @@ class InputController: IMKInputController {
         }.store(in: &cancellables)
         selectedWord.removeDuplicates().compactMap({ $0 }).sink { [weak self] word in
             if UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation) {
-                if let self, let systemAnnotation = SystemDict.lookup(word), !systemAnnotation.isEmpty {
+                if let self, let systemAnnotation = SystemDict.lookup(word, for: .daijirin), !systemAnnotation.isEmpty {
                     Global.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
                     Global.candidatesPanel.show(windowLevel: self.windowLevel)
                 }

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -20,6 +20,10 @@ struct GeneralView: View {
                 Toggle(isOn: $settingsViewModel.showAnnotation, label: {
                     Text("Show Annotation")
                 })
+                Picker("System Dictionary for annotation", selection: $settingsViewModel.systemDict) {
+                    Text("SystemDictDaijirin").tag(SystemDict.Kind.daijirin)
+                    Text("SystemDictWisdom").tag(SystemDict.Kind.wisdom)
+                }.disabled(!settingsViewModel.showAnnotation)
                 Picker("Keys of selecting candidates", selection: $settingsViewModel.selectCandidateKeys) {
                     Text("123456789").tag("123456789")
                     Text("ASDFGHJKL").tag("ASDFGHJKL")

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -226,6 +226,7 @@ final class SettingsViewModel: ObservableObject {
         selectCandidateKeys = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectCandidateKeys)!
         enterNewLine = UserDefaults.standard.bool(forKey: UserDefaultsKeys.enterNewLine)
         Global.selectCandidateKeys = selectCandidateKeys.lowercased().map { $0 }
+        Global.systemDict = systemDict
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -386,6 +387,12 @@ final class SettingsViewModel: ObservableObject {
         $enterNewLine.sink { enterNewLine in
             logger.log("Enterキーで変換確定と一緒に改行する設定を\(enterNewLine ? "有効" : "無効")にしました")
             Global.enterNewLine = enterNewLine
+        }.store(in: &cancellables)
+
+        $systemDict.dropFirst().sink { systemDict in
+            logger.log("注釈で使用するシステム辞書を \(systemDict.rawValue, privacy: .public) に変更しました")
+            UserDefaults.standard.set(systemDict.rawValue, forKey: UserDefaultsKeys.systemDict)
+            Global.systemDict = systemDict
         }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameDictLoad).receive(on: RunLoop.main).sink { [weak self] notification in

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -172,6 +172,7 @@ final class SettingsViewModel: ObservableObject {
     @Published var selectedKeyBindingSet: KeyBindingSet
     /// Enterキーで変換候補の確定だけでなく改行も行うかどうか
     @Published var enterNewLine: Bool
+    @Published var systemDict: SystemDict.Kind
 
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
@@ -216,6 +217,11 @@ final class SettingsViewModel: ObservableObject {
         let selectedKeyBindingSetId = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedKeyBindingSetId) ?? KeyBindingSet.defaultId
         self.keyBindingSets = keyBindingSets
         self.selectedKeyBindingSet = keyBindingSets.first(where: { $0.id == selectedKeyBindingSetId }) ?? KeyBindingSet.defaultKeyBindingSet
+        if let systemDictId = UserDefaults.standard.string(forKey: UserDefaultsKeys.systemDict), let systemDict = SystemDict.Kind(rawValue: systemDictId) {
+            self.systemDict = systemDict
+        } else {
+            self.systemDict = .daijirin
+        }
 
         selectCandidateKeys = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectCandidateKeys)!
         enterNewLine = UserDefaults.standard.bool(forKey: UserDefaultsKeys.enterNewLine)
@@ -419,6 +425,7 @@ final class SettingsViewModel: ObservableObject {
         keyBindingSets = [KeyBindingSet.defaultKeyBindingSet]
         selectedKeyBindingSet = KeyBindingSet.defaultKeyBindingSet
         enterNewLine = false
+        systemDict = .daijirin
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/SystemDictView.swift
+++ b/macSKK/Settings/SystemDictView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// システム辞書で引いてみるデバッグ機能。
 struct SystemDictView: View {
     @State private var word: String = ""
+    @State private var selectedDict: SystemDict.Kind = SystemDict.Kind.daijirin
     @State private var displayText: String = ""
 
     var body: some View {
@@ -17,12 +18,18 @@ struct SystemDictView: View {
                     .onChange(of: word) { newValue in
                         if newValue.isEmpty {
                             displayText = ""
-                        } else if let found = SystemDict.lookup(newValue) {
+                        } else if let found = SystemDict.lookup(newValue, for: selectedDict) {
                             displayText = found
                         } else {
                             displayText = "見つかりませんでした"
                         }
                     }
+            }
+            Section(header: Text("辞書")) {
+                Picker("", selection: $selectedDict) {
+                    Text("スーパー大辞林").tag(SystemDict.Kind.daijirin)
+                    Text("ウィズダム英和・和英").tag(SystemDict.Kind.wisdom)
+                }
             }
             Section(header: Text("結果")) {
                 TextEditor(text: .constant(displayText))

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -3,7 +3,10 @@
 
 import Foundation
 
-// UserDefaultsのキー。camelCaseでの命名を採用しています。
+/**
+ * UserDefaultsのキー。camelCaseでの命名を採用しています。
+ * キーを追加するときは macSKKApp#setupUserDefaults で初期設定を設定するようにしてください。
+ */
 struct UserDefaultsKeys {
     static let dictionaries = "dictionaries"
     static let directModeBundleIdentifiers = "directModeBundleIdentifiers"
@@ -26,4 +29,6 @@ struct UserDefaultsKeys {
     static let keyBindingSets = "keyBindingSets"
     // Enterキーで変換候補の確定 + 改行も行う
     static let enterNewLine = "enterNewLine"
+    // 注釈に使用するシステム辞書のID。SystemDict.Kindで定義。
+    static let systemDict = "systemDict"
 }

--- a/macSKK/SystemDict.swift
+++ b/macSKK/SystemDict.swift
@@ -10,6 +10,7 @@ import Foundation
         case wisdom = "com.apple.dictionary.ja-en.WISDOM"
         var id: Self { self }
     }
+
     private static let dictionaries: [Kind: DCSDictionary] = {
         return Dictionary(Kind.allCases.compactMap { kind in
             if let dictionary = findSystemDict(identifier: kind.rawValue) {
@@ -43,4 +44,3 @@ import Foundation
         }
     }
 }
-

--- a/macSKK/SystemDict.swift
+++ b/macSKK/SystemDict.swift
@@ -5,29 +5,42 @@ import Foundation
 
 /// Dictionary Serviceを使ってシステム辞書から検索する
 @MainActor class SystemDict {
-    private static let dictionary: DCSDictionary? = findSystemJapaneseDict()
+    enum Kind: String, CaseIterable, Identifiable {
+        case daijirin = "com.apple.dictionary.ja.Daijirin"
+        case wisdom = "com.apple.dictionary.ja-en.WISDOM"
+        var id: Self { self }
+    }
+    private static let dictionaries: [Kind: DCSDictionary] = {
+        return Dictionary(Kind.allCases.compactMap { kind in
+            if let dictionary = findSystemDict(identifier: kind.rawValue) {
+                return (kind, dictionary)
+            } else {
+                return nil
+            }
+        }, uniquingKeysWith: { (first, _) in first })
+    }()
 
-    class func lookup(_ word: String) -> String? {
-        if let result = DCSCopyTextDefinition(dictionary, word as NSString, CFRangeMake(0, word.count)) {
+    class func lookup(_ word: String, for kind: Kind) -> String? {
+        if let dictionary = dictionaries[kind], let result = DCSCopyTextDefinition(dictionary, word as NSString, CFRangeMake(0, word.count)) {
             return result.takeRetainedValue() as String
         }
         return nil
     }
 
-    class func findSystemJapaneseDict() -> DCSDictionary? {
+    class func findSystemDict(identifier: String) -> DCSDictionary? {
         guard let dictionaries = DCSCopyAvailableDictionaries() as? Set<DCSDictionary> else {
             logger.error("システム辞書が見つかりません")
             return nil
         }
         let dictionary = dictionaries.first {
-            // DCSDictionaryGetNameは "スーパー大辞林"
-            DCSDictionaryGetIdentifier($0) == "com.apple.dictionary.ja.Daijirin"
+            DCSDictionaryGetIdentifier($0) == identifier
         }
         if let dictionary {
             return dictionary
         } else {
-            logger.warning("スーパー大辞林が利用可能な辞書にありませんでした")
+            logger.warning("システム辞書 \(identifier, privacy: .public) が利用可能な辞書にありませんでした")
             return nil
         }
     }
 }
+

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -33,6 +33,8 @@
 "SKKServClientConnectionRefused" = "Failed to connect to skkserv.";
 "SKKServClientConnectionTimeout" = "Timeout error to connect to skkserv.";
 "SKKServClientTimeout" = "Timeout error to skkserv.";
+"SystemDictDaijirin" = "Daijirin";
+"SystemDictWisdom" = "Wisdom";
 "Done" = "Done";
 "Filename" = "Filename";
 "Dictionary Setting" = "Dictionary Setting";
@@ -57,6 +59,7 @@
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keybaord Layout";
 "Show Annotation" = "Show the annotation of the candidate in current";
+"System Dictionary for annotation" = "System Dictionary for annotation";
 "Keys of selecting candidates" = "Keys of selecting candidates";
 "Copy" = "Copy";
 "Number of inline candidates" = "Number of inline candidates";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -33,6 +33,8 @@
 "SKKServClientConnectionRefused" = "skkservに接続できませんでした";
 "SKKServClientConnectionTimeout" = "skkservへの接続がタイムアウトしました";
 "SKKServClientTimeout" = "skkservへの通信がタイムアウトしました";
+"SystemDictDaijirin" = "スーパー大辞林";
+"SystemDictWisdom" = "ウィズダム英和・和英";
 "Done" = "完了";
 "Filename" = "ファイル名";
 "Dictionary Setting" = "辞書の設定";
@@ -57,6 +59,7 @@
 "Open Release Page" = "リリースページを開く";
 "Keyboard Layout" = "キー配列";
 "Show Annotation" = "現在の変換候補の注釈を表示";
+"System Dictionary for annotation" = "注釈に使用するシステム辞書";
 "Keys of selecting candidates" = "変換候補の決定に使用するキー";
 "Copy" = "コピー";
 "Number of inline candidates" = "インラインで表示する変換候補の数";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -193,6 +193,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.keyBindingSets: [],
             UserDefaultsKeys.selectedKeyBindingSetId: KeyBindingSet.defaultKeyBindingSet.id,
             UserDefaultsKeys.enterNewLine: false,
+            UserDefaultsKeys.systemDict: SystemDict.Kind.daijirin.rawValue,
         ])
     }
 


### PR DESCRIPTION
<img width="338" alt="スクリーンショット 2024-08-14 23 21 08" src="https://github.com/user-attachments/assets/22509a83-a96a-41d4-91a6-9a20a1137ed5">

需要があるのかよくわからないんですが、現在注釈として使っている「スーパー大辞林」の代わりに「ウィズダム英和辞典 / ウィズダム和英辞典」を使える設定を追加してみます。

<img width="634" alt="スクリーンショット 2024-08-14 23 23 49" src="https://github.com/user-attachments/assets/ee5e8dec-8d03-48ca-b97a-b3120fcf786c">
