### PR TITLE
不要な `try` の削除

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -308,12 +308,7 @@ class InputController: IMKInputController {
     }
 
     @objc func saveDict() {
-        do {
-            try Global.dictionary.save()
-        } catch {
-            // TODO: NotificationCenterでユーザーに通知する
-            logger.error("ユーザー辞書保存中にエラーが発生しました")
-        }
+        Global.dictionary.save()
     }
 
     @objc func togglePrivateMode() {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -74,12 +74,7 @@ class UserDict: NSObject, DictProtocol {
             .sink { [weak self] _ in
                 if let fileDict = self?.userDict as? FileDict {
                     logger.log("ユーザー辞書を永続化します。現在のエントリ数は \(fileDict.dict.entries.count)")
-                    do {
-                        try fileDict.save()
-                    } catch {
-                        logger.error("ユーザー辞書の永続化でエラーが発生しました")
-                        UNNotifier.sendNotificationForUserDict(writeError: error)
-                    }
+                    fileDict.save()
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
表題の通り。
不要に `try` が付いていて警告が発生していたので削除しました。