### PR TITLE
入力ソース名についての説明が "ひらがな (macSKK)" のように古い説明が残っているのを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Universal Binary (Apple Silicon & Intel Mac) でビルドしていますが、�
 
 2023年現在、Mac App Storeでは日本語入力システムを配布することができないため、[Appleのソフトウェア公証](https://support.apple.com/ja-jp/guide/security/sec3ad8e6e53/1/web/1)を受けたアプリケーションバイナリを[GitHub Releases](https://github.com/mtgto/macSKK/releases/latest)で配布しています。dmgファイルをダウンロードしマウントした中にあるpkgファイルからインストールしてください。
 
-macSKKのインストール後に、システム設定→キーボード→入力ソースから「ひらがな (macSKK)」と「ABC (macSKK)」を追加してください。カタカナ、全角英数、半角カナは追加しなくても問題ありません。
+macSKKのインストール後に、システム設定→キーボード→入力ソースから「ひらがな」(アイコンは`▼あ`)と「ABC」(アイコンは`▼A`)を追加してください。カタカナ、全角英数、半角カナは追加しても追加しなくても問題ありません。
 もしインストール直後に表示されなかったり、バージョンアップしても反映されない場合はログアウト & ログインを試してみてください。
 
 SKK辞書は `~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries` に配置してください。
@@ -215,7 +215,7 @@ skkservサーバーをSKK辞書として使用することができます (macSK
 現在アンインストールする手順は用意していないためお手数ですが手動でお願いします。
 今後、dmg内にアンインストーラを同梱予定です。
 
-手動で行うには、システム設定→キーボード→入力ソースから「ひらがな (macSKK)」「ABC (macSKK)」を削除後、以下のファイルを削除してください。
+手動で行うには、システム設定→キーボード→入力ソースから「ひらがな」「ABC」を削除後、以下のファイルを削除してください。
 
 - `~/Library/Input Methods/macSKK.app`
 - `~/Library/Containers/net.mtgto.inputmethod.macSKK`

--- a/script/welcome.rtf
+++ b/script/welcome.rtf
@@ -1,8 +1,8 @@
 {\rtf1\ansi\ansicpg932\cocoartf2761
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;\f2\fnil\fcharset128 HiraginoSans-W3;
 \f3\fnil\fcharset128 HiraginoSans-W6;\f4\fmodern\fcharset0 Courier;}
-{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
-{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
 {\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid1\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
 {\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
 \paperw11900\paperh16840\margl1440\margr1440\vieww17200\viewh7880\viewkind0
@@ -52,11 +52,9 @@ macSKK
 \f1\b0 \
 \
 
-\f2 \'83\'43\'83\'93\'83\'58\'83\'67\'81\'5b\'83\'8b\'8a\'ae\'97\'b9\'8c\'e3\'82\'c9\'83\'56\'83\'58\'83\'65\'83\'80\'90\'dd\'92\'e8\'81\'a8\'83\'4c\'81\'5b\'83\'7b\'81\'5b\'83\'68\'81\'a8\'93\'fc\'97\'cd\'83\'5c\'81\'5b\'83\'58\'82\'a9\'82\'e7\'81\'75\'82\'d0\'82\'e7\'82\'aa\'82\'c8
-\f1  (macSKK)
-\f2 \'81\'76\'82\'c6\'81\'75
-\f1 ABC (macSKK)
-\f2 \'81\'76\'82\'f0\'92\'c7\'89\'c1\'82\'b5\'82\'c4\'82\'ad\'82\'be\'82\'b3\'82\'a2\'81\'42\'83\'4a\'83\'5e\'83\'4a\'83\'69\'81\'41\'91\'53\'8a\'70\'89\'70\'90\'94\'81\'41\'94\'bc\'8a\'70\'83\'4a\'83\'69\'82\'cd\'92\'c7\'89\'c1\'82\'b5\'82\'c8\'82\'ad\'82\'c4\'82\'e0\'96\'e2\'91\'e8\'82\'a0\'82\'e8\'82\'dc\'82\'b9\'82\'f1\'81\'42
+\f2 \'83\'43\'83\'93\'83\'58\'83\'67\'81\'5b\'83\'8b\'8a\'ae\'97\'b9\'8c\'e3\'82\'c9\'83\'56\'83\'58\'83\'65\'83\'80\'90\'dd\'92\'e8\'81\'a8\'83\'4c\'81\'5b\'83\'7b\'81\'5b\'83\'68\'81\'a8\'93\'fc\'97\'cd\'83\'5c\'81\'5b\'83\'58\'82\'a9\'82\'e7\'81\'75\'82\'d0\'82\'e7\'82\'aa\'82\'c8\'81\'76(\'83\'41\'83\'43\'83\'52\'83\'93\'82\'cd\'81\'75\'81\'a5\'82\'a0\'81\'76)\'82\'c6\'81\'75
+\f1 ABC
+\f2 \'81\'76(\'83\'41\'83\'43\'83\'52\'83\'93\'82\'cd\'81\'75\'81\'a5A\'81\'76) \'82\'f0\'92\'c7\'89\'c1\'82\'b5\'82\'c4\'82\'ad\'82\'be\'82\'b3\'82\'a2\'81\'42\'83\'4a\'83\'5e\'83\'4a\'83\'69\'81\'41\'91\'53\'8a\'70\'89\'70\'90\'94\'81\'41\'94\'bc\'8a\'70\'83\'4a\'83\'69\'82\'cd\'92\'c7\'89\'c1\'82\'b5\'82\'c4\'82\'e0\'92\'c7\'89\'c1\'82\'b5\'82\'c8\'82\'ad\'82\'c4\'82\'e0\'96\'e2\'91\'e8\'82\'a0\'82\'e8\'82\'dc\'82\'b9\'82\'f1\'81\'42
 \f1  
 \f2 \'82\'e0\'82\'b5\'83\'43\'83\'93\'83\'58\'83\'67\'81\'5b\'83\'8b\'92\'bc\'8c\'e3\'82\'c9\'95\'5c\'8e\'a6\'82\'b3\'82\'ea\'82\'c8\'82\'a9\'82\'c1\'82\'bd\'82\'e8\'81\'41\'82\'b3\'82\'b5\'82\'a9\'82\'a6\'82\'c4\'82\'e0\'94\'bd\'89\'66\'82\'b3\'82\'ea\'82\'c8\'82\'a2\'8f\'ea\'8d\'87\'82\'cd\'83\'8d\'83\'4f\'83\'41\'83\'45\'83\'67
 \f1  & 
@@ -72,10 +70,8 @@ macSKK
 \f1 \
 \
 
-\f2 \'8e\'e8\'93\'ae\'82\'c5\'8d\'73\'82\'a4\'82\'c9\'82\'cd\'81\'41\'83\'56\'83\'58\'83\'65\'83\'80\'90\'dd\'92\'e8\'81\'a8\'83\'4c\'81\'5b\'83\'7b\'81\'5b\'83\'68\'81\'a8\'93\'fc\'97\'cd\'83\'5c\'81\'5b\'83\'58\'82\'a9\'82\'e7\'81\'75\'82\'d0\'82\'e7\'82\'aa\'82\'c8
-\f1  (macSKK)
-\f2 \'81\'76\'81\'75
-\f1 ABC (macSKK)
+\f2 \'8e\'e8\'93\'ae\'82\'c5\'8d\'73\'82\'a4\'82\'c9\'82\'cd\'81\'41\'83\'56\'83\'58\'83\'65\'83\'80\'90\'dd\'92\'e8\'81\'a8\'83\'4c\'81\'5b\'83\'7b\'81\'5b\'83\'68\'81\'a8\'93\'fc\'97\'cd\'83\'5c\'81\'5b\'83\'58\'82\'a9\'82\'e7\'81\'75\'82\'d0\'82\'e7\'82\'aa\'82\'c8\'81\'76\'81\'75
+\f1 ABC
 \f2 \'81\'76\'82\'f0\'8d\'ed\'8f\'9c\'8c\'e3\'81\'41\'88\'c8\'89\'ba\'82\'cc\'83\'74\'83\'40\'83\'43\'83\'8b\'82\'f0\'8d\'ed\'8f\'9c\'82\'b5\'82\'c4\'82\'ad\'82\'be\'82\'b3\'82\'a2\'81\'42
 \f1 \
 \
@@ -83,9 +79,8 @@ macSKK
 \ls1\ilvl0\cf0 {\listtext	\uc0\u8226 	}
 \f4\fs26 \expnd0\expndtw0\kerning0
 ~/Library/Input Methods/macSKK.app\
-\pard\tx220\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\li720\fi-720\pardirnatural\partightenfactor0
 \ls1\ilvl0
-\f1\fs24 \cf0 \kerning1\expnd0\expndtw0 {\listtext	\uc0\u8226 	}
+\f1\fs24 \kerning1\expnd0\expndtw0 {\listtext	\uc0\u8226 	}
 \f4\fs26 \expnd0\expndtw0\kerning0
 ~/Library/Containers/net.mtgto.inputmethod.macSKK\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0


### PR DESCRIPTION
#211 READMEやインストーラには

> macSKKのインストール後に、システム設定→キーボード→入力ソースから「ひらがな (macSKK)」と「ABC (macSKK)」を追加してください。

のように説明がありますが、v1.0.0およびそれ以降のバージョンでは #193 で「ひらがな」「ABC」のように `(macSKK)` を含まない名称に変更していたので説明が古くなっていました。

これを修正します。