### PR TITLE
変換候補の選択中にバックスペースで一文字後退 + 確定する設定を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -35,6 +35,8 @@ import Combine
     static var enterNewLine: Bool = false
     /// 注釈で使用するシステム辞書
     static var systemDict: SystemDict.Kind = .daijirin
+    /// 変換候補選択中のバックスペースの挙動
+    static var selectingBackspace: SelectingBackspace = .default
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -35,6 +35,11 @@ struct GeneralView: View {
                             Text("\(count)")
                         }
                     }
+                    Picker("Backspace in selecting candidates", selection: $settingsViewModel.selectingBackspace) {
+                        ForEach(SelectingBackspace.allCases, id: \.id) { selectingBackspace in
+                            Text(selectingBackspace.description).tag(selectingBackspace)
+                        }
+                    }
                 }
                 Section {
                     Picker("Candidates font size", selection: $settingsViewModel.candidatesFontSize) {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -158,7 +158,9 @@ struct WorkaroundApplication: Identifiable, Equatable {
 }
 
 /// 変換候補選択中のバックスペースの挙動の列挙
-enum SelectingBackspace: Int {
+enum SelectingBackspace: Int, CaseIterable, Identifiable {
+    typealias ID = Int
+    var id: ID { rawValue }
     /// インラインでの変換候補の選択時もしくは変換候補リストの1ページの時、
     /// 変換候補の選択状態をキャンセルし、変換開始前に戻す。
     /// 変換候補リストの2ページ目以降のときは1ページ前に戻す。
@@ -174,6 +176,17 @@ enum SelectingBackspace: Int {
 
     // v1.2.0までの挙動
     static let `default` = cancel
+
+    var description: String {
+        switch self {
+        case .cancel:
+            return String(localized: "SelectingBackspaceCancel")
+        case .dropLastInlineOnly:
+            return String(localized: "SelectingBackspaceDropLastInlineOnly")
+        case .dropLastAlways:
+            return String(localized: "SelectingBackspaceDropLastAlways")
+        }
+    }
 }
 
 @MainActor

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -157,6 +157,25 @@ struct WorkaroundApplication: Identifiable, Equatable {
     }
 }
 
+/// 変換候補選択中のバックスペースの挙動の列挙
+enum SelectingBackspace: Int {
+    /// インラインでの変換候補の選択時もしくは変換候補リストの1ページの時、
+    /// 変換候補の選択状態をキャンセルし、変換開始前に戻す。
+    /// 変換候補リストの2ページ目以降のときは1ページ前に戻す。
+    /// AquaSKKの「インライン変換: 後退で確定する」がオフのときの挙動。
+    case cancel = 0
+    /// インライン時は変換候補の末尾一字を削除して確定し、
+    /// 変換候補リストの表示時は前ページへ戻るキーとして機能する。
+    /// ddskkやAquaSKKの「インライン変換: 後退で確定する」がオンのときの挙動。
+    case dropLastInlineOnly = 1
+    /// インライン時、変換候補リスト表示時を問わず変換候補の末尾一字を削除して確定する。
+    /// skkeletonのデフォルトの挙動。
+    case dropLastAlways = 2
+
+    // v1.2.0までの挙動
+    static let `default` = cancel
+}
+
 @MainActor
 final class SettingsViewModel: ObservableObject {
     /// CheckUpdaterで取得した最新のリリース。取得前はnil
@@ -198,6 +217,7 @@ final class SettingsViewModel: ObservableObject {
     /// Enterキーで変換候補の確定だけでなく改行も行うかどうか
     @Published var enterNewLine: Bool
     @Published var systemDict: SystemDict.Kind
+    @Published var selectingBackspace: SelectingBackspace
 
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
@@ -250,8 +270,10 @@ final class SettingsViewModel: ObservableObject {
 
         selectCandidateKeys = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectCandidateKeys)!
         enterNewLine = UserDefaults.standard.bool(forKey: UserDefaultsKeys.enterNewLine)
+        selectingBackspace = SelectingBackspace(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.selectingBackspace)) ?? SelectingBackspace.default
         Global.selectCandidateKeys = selectCandidateKeys.lowercased().map { $0 }
         Global.systemDict = systemDict
+        Global.selectingBackspace = selectingBackspace
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -312,6 +334,10 @@ final class SettingsViewModel: ObservableObject {
 
         $workaroundApplications.sink { applications in
             Global.insertBlankStringBundleIdentifiers.send(applications.filter { $0.insertBlankString }.map { $0.bundleIdentifier })
+        }.store(in: &cancellables)
+
+        $selectingBackspace.sink { selectingBackspace in
+            Global.selectingBackspace = selectingBackspace
         }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameToggleDirectMode)
@@ -458,6 +484,7 @@ final class SettingsViewModel: ObservableObject {
         selectedKeyBindingSet = KeyBindingSet.defaultKeyBindingSet
         enterNewLine = false
         systemDict = .daijirin
+        selectingBackspace = SelectingBackspace.default
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -31,4 +31,6 @@ struct UserDefaultsKeys {
     static let enterNewLine = "enterNewLine"
     // 注釈に使用するシステム辞書のID。SystemDict.Kindで定義。
     static let systemDict = "systemDict"
+    // 変換候補選択中のバックスペースの挙動
+    static let selectingBackspace = "selectingBackspace"
 }

--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -378,13 +378,18 @@ struct SelectingState: Equatable, MarkedTextProtocol {
     }
 
     /// 現在選択されている変換候補を文字列を返す
-    var fixedText: String {
+    func fixedText(dropLast: Bool) -> String {
         let text = candidates[candidateIndex].word
         let okuri = prev.composing.okuri?.map { $0.string(for: prev.mode) }
-        if let okuri {
-            return text + okuri.joined()
+        let joined: String = if let okuri {
+            text + okuri.joined()
         } else {
-            return text
+            text
+        }
+        if dropLast {
+            return String(joined.dropLast())
+        } else {
+            return joined
         }
     }
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -995,16 +995,10 @@ final class StateMachine {
             }
             return true
         case .backspace:
-            if selecting.candidateIndex < inlineCandidateCount {
-                // インライン選択中は変換候補の末尾を一字消して確定
-                // (AquaSKKは選択候補を1つ戻す挙動だったが、ddskk, skkeleton, libskkなどに挙動を合わせています)
-                fixCurrentSelect(dropLast: true)
-                return true
-            } else {
-                // 前ページの先頭
-               let diff = -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
-                return handleSelectingPrevious(diff: diff, selecting: selecting)
-            }
+            // インライン選択中は変換候補の末尾を一字消して確定
+            // (AquaSKKは選択候補を1つ戻す挙動だったが、ddskk, skkeleton, libskkなどに挙動を合わせています)
+            fixCurrentSelect(dropLast: true)
+            return true
         case .up:
             return handleSelectingPrevious(diff: -1, selecting: selecting)
         case .space, .down:
@@ -1057,9 +1051,24 @@ final class StateMachine {
             updateCandidates(selecting: nil)
             updateMarkedText()
             return true
-        case .left, .right:
-            // AquaSKKと同様に何もしない (IMKCandidates表示時はそちらの移動に使われる)
-            return true
+        case .left:
+            if selecting.candidateIndex >= inlineCandidateCount {
+                // 前ページの先頭
+                let diff = -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
+                return handleSelectingPrevious(diff: diff, selecting: selecting)
+            } else {
+                // AquaSKKと同様に何もしない (IMKCandidates表示時はそちらの移動に使われる)
+                return true
+            }
+        case .right:
+            if selecting.candidateIndex >= inlineCandidateCount {
+                // 次ページの先頭
+                let diff = displayCandidateCount - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
+                return handleSelectingPrevious(diff: diff, selecting: selecting)
+            } else {
+                // AquaSKKと同様に何もしない (IMKCandidates表示時はそちらの移動に使われる)
+                return true
+            }
         case .startOfLine:
             // 現ページの先頭
             let diff = -(selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -995,10 +995,33 @@ final class StateMachine {
             }
             return true
         case .backspace:
-            // インライン選択中は変換候補の末尾を一字消して確定
-            // (AquaSKKは選択候補を1つ戻す挙動だったが、ddskk, skkeleton, libskkなどに挙動を合わせています)
-            fixCurrentSelect(dropLast: true)
-            return true
+            switch Global.selectingBackspace {
+            case .cancel:
+                let diff: Int
+                if selecting.candidateIndex >= inlineCandidateCount {
+                    // 前ページの先頭
+                    diff =
+                        -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
+                } else {
+                    diff = -1
+                }
+                return handleSelectingPrevious(diff: diff, selecting: selecting)
+            case .dropLastInlineOnly:
+                if selecting.candidateIndex >= inlineCandidateCount {
+                    // 前ページの先頭
+                    let diff =
+                        -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
+                    return handleSelectingPrevious(diff: diff, selecting: selecting)
+                } else {
+                    // インライン選択中は変換候補の末尾を一字消して確定
+                    fixCurrentSelect(dropLast: true)
+                    return true
+                }
+            case .dropLastAlways:
+                // 変換候補の末尾を一字消して確定
+                fixCurrentSelect(dropLast: true)
+                return true
+            }
         case .up:
             return handleSelectingPrevious(diff: -1, selecting: selecting)
         case .space, .down:

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 "Keys of selecting candidates" = "Keys of selecting candidates";
 "Copy" = "Copy";
 "Number of inline candidates" = "Number of inline candidates";
+"Backspace in selecting candidates" = "Backspace in selecting candidates";
 "Candidates font size" = "Candidates font size";
 "Annotation font size" = "Annotation font size";
 "Find completion from all dictionaries" = "Find completion from all dictionaries";
@@ -112,3 +113,7 @@
 
 "KeyEisu" = "Eisu";
 "KeyKana" = "Kana";
+
+"SelectingBackspaceCancel" = "Go back one step";
+"SelectingBackspaceDropLastInlineOnly" = "Delete a last character & commit in Inline";
+"SelectingBackspaceDropLastAlways" = "Delete a last character & commit always";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 "Keys of selecting candidates" = "変換候補の決定に使用するキー";
 "Copy" = "コピー";
 "Number of inline candidates" = "インラインで表示する変換候補の数";
+"Backspace in selecting candidates" = "変換候補選択中のバックスペース";
 "Candidates font size" = "変換候補のフォントサイズ";
 "Annotation font size" = "注釈のフォントサイズ";
 "Find completion from all dictionaries" = "ユーザー辞書だけでなくすべての辞書から補完を探す";
@@ -112,3 +113,7 @@
 
 "KeyEisu" = "英数";
 "KeyKana" = "かな";
+
+"SelectingBackspaceCancel" = "一つ前の状態に戻す";
+"SelectingBackspaceDropLastInlineOnly" = "インライン時は一文字削除して確定";
+"SelectingBackspaceDropLastAlways" = "常に一文字削除して確定";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -194,6 +194,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.selectedKeyBindingSetId: KeyBindingSet.defaultKeyBindingSet.id,
             UserDefaultsKeys.enterNewLine: false,
             UserDefaultsKeys.systemDict: SystemDict.Kind.daijirin.rawValue,
+            UserDefaultsKeys.selectingBackspace: SelectingBackspace.default.rawValue,
         ])
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2321,27 +2321,27 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    @MainActor func testHandleSelectingBackspace() {
-        Global.dictionary.setEntries(["と": [Word("戸"), Word("都")]])
-
+    @MainActor func testHandleSelectingBackspace() throws {
+        let dict = MemoryDict(entries: ["あu": [Word("会"), Word("合")]], readonly: true)
+        Global.dictionary = try UserDict(dicts: [dict],
+                                         privateMode: CurrentValueSubject<Bool, Never>(false),
+                                         findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
+        Global.dictionary.setEntries([:])
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(6).sink { events in
-            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("t")])))
-            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("と")])))
-            XCTAssertEqual(events[2], .markedText(MarkedText([.markerSelect, .emphasized("戸")])))
-            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("都")])))
-            XCTAssertEqual(events[4], .markedText(MarkedText([.markerSelect, .emphasized("戸")])))
-            XCTAssertEqual(events[5], .markedText(MarkedText([.markerCompose, .plain("と")])))
+        stateMachine.inputMethodEvent.collect(4).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerSelect, .emphasized("会う")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerSelect, .emphasized("合う")])))
+            XCTAssertEqual(events[3], .fixedText("合"))
             expectation.fulfill()
         }.store(in: &cancellables)
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t", withShift: true)))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(backspaceAction))
-        XCTAssertTrue(stateMachine.handle(backspaceAction))
-        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        // バックスペースで確定した場合も送り仮名ありでユーザー辞書に登録される (ddskkと同様)
+        XCTAssertEqual(Global.dictionary.userDict?.refer("あu", option: nil), [Word("合", okuri: "う")])
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -2423,7 +2423,7 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[10], .markedText(MarkedText([.markerSelect, .emphasized("M")])), "Vの9個前のMを表示")
             expectation.fulfill()
         }.store(in: &cancellables)
-        stateMachine.candidateEvent.collect(10).sink { events in
+        stateMachine.candidateEvent.collect(11).sink { events in
             XCTAssertEqual(events[0]?.selected.word, "1")
             XCTAssertEqual(events[1]?.selected.word, "2")
             XCTAssertEqual(events[2]?.selected.word, "3")
@@ -2442,6 +2442,8 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[8]?.page?.current, 3)
             XCTAssertEqual(events[9]?.selected.word, "M")
             XCTAssertEqual(events[9]?.page?.current, 2)
+            XCTAssertEqual(events[10]?.selected.word, "D")
+            XCTAssertEqual(events[10]?.page?.current, 1)
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
@@ -2454,7 +2456,7 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(downKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(downKeyAction))
-        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(backspaceAction)) // 選択候補が表示中は前ページ移動
         XCTAssertTrue(stateMachine.handle(backspaceAction))
         wait(for: [expectation], timeout: 1.0)
     }
@@ -2668,10 +2670,10 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(leftKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
-        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "r", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u")))
-        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
         XCTAssertTrue(stateMachine.handle(leftKeyAction)) // 何もinputMethodEventには流れない
         wait(for: [expectation], timeout: 1.0)
     }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2456,8 +2456,8 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(downKeyAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(downKeyAction))
-        XCTAssertTrue(stateMachine.handle(backspaceAction)) // 選択候補が表示中は前ページ移動
-        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction)) // 前ページ移動
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -285,7 +285,6 @@ final class StateTests: XCTestCase {
             remain: nil
         )
         XCTAssertNil(selectingState.okuri)
-
     }
 
     func testRegisterStateAppendText() throws {

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -191,7 +191,8 @@ final class StateTests: XCTestCase {
             cursorPosition: .zero,
             remain: nil
         )
-        XCTAssertEqual(selectingState.fixedText, "亜")
+        XCTAssertEqual(selectingState.fixedText(dropLast: false), "亜")
+        XCTAssertEqual(selectingState.fixedText(dropLast: true), "")
     }
 
     func testSelectingStateFixedTextOkuriari() throws {
@@ -211,7 +212,8 @@ final class StateTests: XCTestCase {
             cursorPosition: .zero,
             remain: nil
         )
-        XCTAssertEqual(selectingState.fixedText, "有る")
+        XCTAssertEqual(selectingState.fixedText(dropLast: false), "有る")
+        XCTAssertEqual(selectingState.fixedText(dropLast: true), "有")
     }
 
     func testSelectingStateMarkedTextElements() {


### PR DESCRIPTION
#215 変換候補選択中のバックスペースの挙動を設定可能にします。

- 前に戻る (v1.2.0時点のデフォルト動作)
  - インライン時は変換開始前に戻る、変換候補リスト表示時は前ページに戻る
- インライン時は末尾の一文字削除してから確定、変換候補リスト表示時は前に戻る
- 常に末尾の一文字削除してから確定する

<img width="634" alt="backspace-setting" src="https://github.com/user-attachments/assets/cd0b19d4-1961-4341-b1e2-088ad14ccc4e">

これまではC-gやESCと同様の挙動、つまり変換開始前に戻るようにしていました (AquaSKKに合わせていた)。

また将来挙動を変えるかもしれませんが、変換候補の選択中に変換候補パネルが表示されているときに左右キーでページを戻る・進むできるようにしました。
主目的はユニットテストを通すためなので将来例えば変換候補パネルが水平方向に候補パネルを表示するようにしたら挙動を変えるかもしれません。