### PR TITLE
キーバインド設定で右クリックから設定をリセットできるようにする

### DIFF
--- a/macSKK/Settings/KeyBinding/KeyBindingInputsView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingInputsView.swift
@@ -66,7 +66,7 @@ final class KeyBindingInput: ObservableObject, Identifiable, Hashable {
 // あるキーバインドを変更するビュー。
 struct KeyBindingInputsView: View {
     @StateObject var settingsViewModel: SettingsViewModel
-    @Environment (\.dismiss) var dismiss
+    @Environment(\.dismiss) var dismiss
     @Binding var action: KeyBinding.Action
     @Binding var inputs: [KeyBindingInput]
     @State var selectedInput: KeyBindingInput?

--- a/macSKK/Settings/KeyBinding/KeyBindingView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingView.swift
@@ -78,6 +78,11 @@ struct KeyBindingView: View {
                     }
                 }
                 .disabled(!settingsViewModel.selectedKeyBindingSet.canEdit)
+                Button("Reset") {
+                    if let action = keyBindingActions.first {
+                        settingsViewModel.resetKeyBindingInputs(action: action)
+                    }
+                }
             } primaryAction: { keyBindingActions in
                 if settingsViewModel.selectedKeyBindingSet.canEdit {
                     if let action = keyBindingActions.first, let keyBinding = settingsViewModel.selectedKeyBindingSet.values.first(where: { $0.action == action }) {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -584,6 +584,19 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
+    // 選択中のKeyBindingSetのactionへの割り当てをデフォルトのものにリセットする
+    func resetKeyBindingInputs(action: KeyBinding.Action) {
+        if let index = keyBindingSets.firstIndex(of: selectedKeyBindingSet) {
+            if let defaultKeyBinding = KeyBindingSet.defaultKeyBindingSet.values.first(where: { $0.action == action }) {
+                logger.log("キーバインドのセット \"\(self.selectedKeyBindingSet.id, privacy: .public)\" の \"\(action.localizedAction, privacy: .public)\" のキーバインドをリセットしました")
+                keyBindingSets[index] = selectedKeyBindingSet.update(for: action, inputs: defaultKeyBinding.inputs)
+                selectedKeyBindingSet = keyBindingSets[index]
+            } else {
+                logger.error("キーバインドのセット \"\(self.selectedKeyBindingSet.id, privacy: .public)\" が見つかりません")
+            }
+        }
+    }
+
     /// 利用可能なキー配列を読み込む
     func loadInputSources() {
         if let inputSources = InputSource.fetch() {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 "Are you sure you want to delete %@?" = "Are you sure you want to delete %@?";
 "Modifier Flags (Required)" = "Modifier Flags (Required)";
 "Modifier Flags (Optional)" = "Modifier Flags (Optional)";
+"Reset" = "Reset";
 
 "KeyBindingActionHiragana" = "Hiragana Mode";
 "KeyBindingActionTogglekana" = "Toggle Kana";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 "Are you sure you want to delete %@?" = "%@を本当に削除しますか?";
 "Modifier Flags (Required)" = "修飾キー (必須)";
 "Modifier Flags (Optional)" = "修飾キー (任意)";
+"Reset" = "リセット";
 
 "KeyBindingActionHiragana" = "ひらがなモード";
 "KeyBindingActionTogglekana" = "かなカナ切り替え";


### PR DESCRIPTION
設定のキーバインドで右クリックから特定のアクションのキー設定を初期状態にリセットできるようにします。

<img width="631" alt="reset-keybinding" src="https://github.com/user-attachments/assets/dc4da39e-1c0c-4389-97d1-5adce049ecee">
