### PR TITLE
キーバインド設定でカスタマイズされたものを太字で表示する

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -354,4 +354,9 @@ struct KeyBinding: Identifiable, Hashable {
             }
         }
     }
+
+    // デフォルトのキーバインディングと同じキー入力かどうかを返す
+    var isDefault: Bool {
+        inputs == Self.defaultKeyBindingSettings.first(where: { $0.action == action })?.inputs
+    }
 }

--- a/macSKK/Settings/KeyBinding/KeyBindingView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingView.swift
@@ -66,7 +66,9 @@ struct KeyBindingView: View {
         }
         Form {
             Table(settingsViewModel.selectedKeyBindingSet.values, selection: $selectingKeyBindingAction) {
-                TableColumn("Action", value: \.action.localizedAction)
+                TableColumn("Action") { keyBinding in
+                    Text(keyBinding.action.localizedAction).fontWeight(keyBinding.isDefault ? nil : .bold)
+                }
                 TableColumn("Key", value: \.localizedInputs)
             }
             .contextMenu(forSelectionType: KeyBinding.ID.self) { keyBindingActions in

--- a/macSKKTests/KeyBindingTests.swift
+++ b/macSKKTests/KeyBindingTests.swift
@@ -90,4 +90,11 @@ final class KeyBindingTests: XCTestCase {
         XCTAssertTrue(inputEnter.accepts(event: eventOptionEnter))
         XCTAssertFalse(inputEnter.accepts(event: eventLeft))
     }
+
+    func testIsDefault() {
+        XCTAssertFalse(KeyBinding(.toggleKana, []).isDefault)
+        XCTAssertTrue(KeyBinding(.toggleKana, [KeyBinding.Input(key: .character("q"), modifierFlags: [])]).isDefault)
+        XCTAssertFalse(KeyBinding(.toggleKana, [KeyBinding.Input(key: .character("q"), modifierFlags: [.shift])]).isDefault)
+        XCTAssertFalse(KeyBinding(.toggleKana, [KeyBinding.Input(key: .character("l"), modifierFlags: [])]).isDefault)
+    }
 }


### PR DESCRIPTION
キーバインドの設定画面で、どれがデフォルト設定から変更されたものかをわかりやすくするため、アクション名を太字にします。
↓ではStickyShiftが無効になっているため太字になっています。

<img width="640" alt="customized-keybindings" src="https://github.com/user-attachments/assets/dfd94aff-7f81-430b-8eed-c5cd5673a9d0">
