### PR TITLE
未確定のローマ字があっても入力候補を表示する

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -218,7 +218,7 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
         return ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: "", cursor: cursor, prevMode: prevMode)
     }
 
-    /// カーソルより左のtext部分を返す。
+    /// カーソルより左のtext部分を返す。未確定のローマ字部分は含まない。
     func subText() -> [String] {
         if let cursor {
             return Array(text[0..<cursor])

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1247,8 +1247,8 @@ final class StateMachine {
     private func updateMarkedText() {
         inputMethodEventSubject.send(.markedText(state.displayText()))
         // 読み部分を取得してyomiEventに通知する
-        if case let .composing(composing) = state.inputMethod, composing.okuri == nil && composing.romaji.isEmpty {
-            // ComposingState#yomi(for:) との違いは未確定ローマ字が"n"のときに「ん」として扱うか否か
+        if case let .composing(composing) = state.inputMethod, composing.okuri == nil {
+            // ComposingState#yomi(for:) とComposingState#subText()の違いは未確定ローマ字が"n"のときに「ん」として扱うか否か
             yomiEventSubject.send(composing.subText().joined())
         } else {
             yomiEventSubject.send("")

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -633,7 +633,7 @@ final class StateMachineTests: XCTestCase {
         stateMachine.yomiEvent.collect(5).sink { events in
             XCTAssertEqual(events[0], "")
             XCTAssertEqual(events[1], "そ", "カタカナモードでも読みにはひらがなが流れる")
-            XCTAssertEqual(events[2], "", "おnのように2文字目がローマ字の場合は空文字列が送信される")
+            XCTAssertEqual(events[2], "そっ", "tのように未確定のローマ字が入力中の場合はローマ字の前までが送信される")
             XCTAssertEqual(events[3], "そっと", "「そっt」の状態ではローマ字を含むので送信しない")
             XCTAssertEqual(events[4], "")
             expectation.fulfill()
@@ -1395,14 +1395,13 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("ー、<。?")])))
             expectation.fulfill()
         }.store(in: &cancellables)
-        stateMachine.yomiEvent.collect(7).sink { events in
+        stateMachine.yomiEvent.collect(6).sink { events in
             XCTAssertEqual(events[0], "")
             XCTAssertEqual(events[1], "ー")
-            XCTAssertEqual(events[2], "", "確定前のローマ字 (t) が入力されたので一度空文字列が送信される")
-            XCTAssertEqual(events[3], "ー、")
-            XCTAssertEqual(events[4], "ー、<")
-            XCTAssertEqual(events[5], "ー、<。")
-            XCTAssertEqual(events[6], "ー、<。?")
+            XCTAssertEqual(events[2], "ー、")
+            XCTAssertEqual(events[3], "ー、<")
+            XCTAssertEqual(events[4], "ー、<。")
+            XCTAssertEqual(events[5], "ー、<。?")
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s", withShift: true)))

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -82,6 +82,8 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(state.subText(), ["あ"])
         state = state.with(cursor: nil)
         XCTAssertEqual(state.subText(), ["あ", "い"])
+        state = ComposingState(isShift: true, text: ["あ"], okuri: nil, romaji: "k", cursor: nil)
+        XCTAssertEqual(state.subText(), ["あ"], "未確定のローマ字部分は含まない")
     }
 
     func testComposingStateTrim() {


### PR DESCRIPTION
<img width="115" alt="image" src="https://github.com/user-attachments/assets/65182e5c-c45f-4177-b01a-a01adc313657">

タブキーの入力補完候補の表示条件で、"ひらがn" のようにローマ字が入力されているときに補完候補を出さないようにしていたんですが、それを表示するようにします。

かしこく「ひらがn」が入力されているなら変換候補のうち「ひらがな」「ひらがに」「ひらがぬ」「ひらがね」「ひらがの」「ひらがん」で始まるものから探す、とするほうが親切そうとは思ったのですが、とりあえず簡単にローマ字を除外して補完候補を検索するようにします。