### PR TITLE
コンパイル時の警告を減らす

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -642,7 +642,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					CE5ECF312957034B00E7BE7D = {
 						CreatedOnToolsVersion = 14.2;
@@ -1035,7 +1035,6 @@
 		CE5ECF582957034D00E7BE7D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
@@ -1071,7 +1070,6 @@
 		CE5ECF592957034D00E7BE7D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
@@ -1107,7 +1105,6 @@
 		CE5ECF5B2957034D00E7BE7D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
@@ -1125,7 +1122,6 @@
 		CE5ECF5C2957034D00E7BE7D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;

--- a/macSKK.xcodeproj/xcshareddata/xcschemes/macSKK.xcscheme
+++ b/macSKK.xcodeproj/xcshareddata/xcschemes/macSKK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -33,7 +33,7 @@ class InputController: IMKInputController {
     /// 最後にイベントを受け取ったときのウィンドウレベル + 1
     private var windowLevel: NSWindow.Level = .floating
 
-    override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
+    @MainActor override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         super.init(server: server, delegate: delegate, client: inputClient)
 
         guard let textInput = inputClient as? any IMKTextInput else {
@@ -195,7 +195,7 @@ class InputController: IMKInputController {
             }.store(in: &cancellables)
     }
 
-    override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+    @MainActor override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         // 文字ビューアで入力した場合など、eventがnilの場合がありえる
         if event == nil {
             return false
@@ -225,7 +225,7 @@ class InputController: IMKInputController {
         return stateMachine.handle(Action(keyBind: keyBind, event: event, cursorPosition: cursorPosition))
     }
 
-    override func menu() -> NSMenu! {
+    @MainActor override func menu() -> NSMenu! {
         let preferenceMenu = NSMenu()
         preferenceMenu.addItem(
             withTitle: String(localized: "MenuItemPreference", comment: "Preferences…"),
@@ -259,7 +259,7 @@ class InputController: IMKInputController {
     }
 
     // MARK: - IMKStateSetting
-    override func activateServer(_ sender: Any!) {
+    @MainActor override func activateServer(_ sender: Any!) {
         if let textInput = sender as? any IMKTextInput {
             setCustomInputSource(textInput: textInput)
         } else {
@@ -267,7 +267,7 @@ class InputController: IMKInputController {
         }
     }
 
-    override func deactivateServer(_ sender: Any!) {
+    @MainActor override func deactivateServer(_ sender: Any!) {
         // 他の入力に切り替わるときには入力候補や補完候補は消す + 現在表示中の候補を確定させる
         Global.candidatesPanel.orderOut(sender)
         Global.completionPanel.orderOut(sender)
@@ -275,12 +275,12 @@ class InputController: IMKInputController {
     }
 
     /// クライアントが入力中状態を即座に確定してほしいときに呼ばれる
-    override func commitComposition(_ sender: Any!) {
+    @MainActor override func commitComposition(_ sender: Any!) {
         // 現在未確定の入力を強制的に確定させて状態を入力前の状態にする
         stateMachine.commitComposition()
     }
 
-    override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
+    @MainActor override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
         guard let value = value as? String else { return }
         guard let inputMode = InputMode(rawValue: value) else { return }
         logger.debug("入力モードが変更されました \(inputMode.rawValue)")

--- a/macSKK/NumberEntry.swift
+++ b/macSKK/NumberEntry.swift
@@ -7,7 +7,7 @@ import Foundation
  * 数値変換用のユーザーが入力した読み部分。"だい1" のような入力を受け取り、整数部分と非整数部分に分ける。
  */
 struct NumberYomi {
-    static let pattern = /#([01234589])/
+    nonisolated(unsafe) static let pattern = /#([01234589])/
 
     // TODO: Stringを作るコストをなくしyomiのSubstringでもっておく。Substringだとユニットテストが書きにくくなるしこれでもいいかも。
     enum Element: Equatable {
@@ -84,7 +84,7 @@ struct NumberYomi {
 
 // 数値入りの変換候補
 struct NumberCandidate {
-    static let pattern = /#([01234589])/
+    nonisolated(unsafe) static let pattern = /#([01234589])/
     static let kanjiFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.locale = Locale(identifier: "ja-JP")

--- a/macSKK/Pasteboard.swift
+++ b/macSKK/Pasteboard.swift
@@ -5,7 +5,7 @@ import AppKit
 
 /// クリップボード関係の処理。ユニットテスト実行時に実際のNSPasteboardを更新しなくていいようにしてある。
 struct Pasteboard {
-    static var stringForTest: String? = nil
+    nonisolated(unsafe) static var stringForTest: String? = nil
 
     static func getString() -> String? {
         if isTest() {

--- a/macSKK/ReleaseVersion.swift
+++ b/macSKK/ReleaseVersion.swift
@@ -14,8 +14,6 @@ struct ReleaseVersion: Comparable, CustomStringConvertible, Sendable {
         return "\(major).\(minor).\(patch)"
     }
 
-    static let pattern = /([0-9]+)\.([0-9]+)\.([0-9]+)/
-
     // Comparable
     static func < (lhs: Self, rhs: Self) -> Bool {
         if lhs.major != rhs.major {
@@ -34,7 +32,7 @@ struct ReleaseVersion: Comparable, CustomStringConvertible, Sendable {
     }
 
     init?(string: String) {
-        if let match = string.wholeMatch(of: Self.pattern) {
+        if let match = string.wholeMatch(of: /([0-9]+)\.([0-9]+)\.([0-9]+)/) {
             if let major = Int(match.1), let minor = Int(match.2), let patch = Int(match.3) {
                 self.major = major
                 self.minor = minor

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UserNotifications
 import os
 
-nonisolated(unsafe) let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "main")
+let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "main")
 // 直接入力モードを切り替えたいときに通知される通知の名前。
 let notificationNameToggleDirectMode = Notification.Name("toggleDirectMode")
 // 空文字挿入のワークアラウンドの有効無効を切り替えたいときに通知される通知の名前。


### PR DESCRIPTION
Swift 6に向けて、Swift Concurrency回りのコンパイル時警告が出ているためいくつかを修正します。
#210 で書いてくれた一部の修正を採用しており、そのコミットには Co-authorとして @uhooi さんを記載しています。
https://docs.github.com/ja/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors

### IMKInputControllerの派生クラスの各メソッドに `@MainActor` を設定
パッケージ IMKMethodKitのIMKInputControllerの各メソッドはおそらく `@MainActor` 扱いだと思うのですが、macOS 15 SDKの現状ではそうなっていないため各overrideしたメソッドに `@MainActor` をつけています。これはこれで基底クラスと合ってないよと言われるんですが↓、 `@preconcurrency import InputMethodKit` しても効果なかったので、いったんこれでいきます。

> Main actor-isolated instance method 'deactivateServer' has different actor isolation from nonisolated overridden declaration; this is an error in the Swift 6 language mode

### class内で `NotificationCenter.default.notifications` を使っているところはCombineで受信するようにする

次のようなコードはNotificationがSendableでないため警告が出ます。

```swift
for await notification in NotificationCenter.default.notifications(named: notificationNameOpenSettings) {
    settingsWindowController.showWindow(notification.object)
    NSApp.activate(ignoringOtherApps: true)
}
```

> Non-sendable type 'Notification?' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary; this is an error in the Swift 6 language mode

class内で受信したNotificationを処理しているところはCombineで処理するようにします。

https://developer.apple.com/documentation/foundation/notificationcenter/3813137-notifications#discussion
にNotificationからSendableな別の値にcompactMapで変換すればいい例があったのですが、macSKKAppではSendableな型に変換できなかったのでそのままになっています。
CombineでやるにもAnyCancellableなmutable要素を持たせたくなかったので妥協してそのままです。

### FileDict, UserDictは別PRで対応する

FileDictでたくさんの警告が残っています。

> Main actor-isolated property 'dict' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode

現在はclass FileDict内でpropertyへの書き込みを行っているためさくっと直すのは難しいためこのPRで修正するのは見送ります。NSDocumentのサブクラスにして読み込みは並列可、書き込みだけ直列になるようにできるといいなと思っています。