### PR TITLE
設定のログ表示のためのログ取得は別スレッドで行う

### DIFF
--- a/macSKK/Settings/LogView.swift
+++ b/macSKK/Settings/LogView.swift
@@ -41,7 +41,7 @@ struct LogView: View {
         }
     }
 
-    private func load() async throws -> String {
+    nonisolated private func load() async throws -> String {
         func levelDescription(level: OSLogEntryLog.Level) -> String {
             switch level {
             case .undefined:


### PR DESCRIPTION
設定内のログ表示はOSLogStoreからの取得を行いますが、かなり時間がかかる処理なのでバックグラウンドで行いたいです。
ログ読み込みを行う関数にasyncをつけていたのですが、asyncをつけるだけではメインスレッドで実行されてしまいレインボーカーソルとなってしまっていました。

以前はこの修正がなくても問題なかったような気もしたのですが、Xcode 16からはSwiftUIのView全体が `@mainActor` がついているように修正されたようです。
https://qiita.com/temoki/items/582fc15697d71f931c8e

nonisolated修飾子をつけることで必ずメインスレッド外で実行されるようにします。

#210 の @uhooi さんの https://github.com/mtgto/macSKK/pull/210/commits/caf259c7a6ed5cc532985f22d79c28c02c2cedec を参考にしています。