### PR TITLE
記号をかな入力に割り当てているときシフト入力と判定してしまうバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -391,7 +391,7 @@ final class StateMachine {
                     }
                     let result = Global.kanaRule.convert(characters)
                     if let moji = result.kakutei {
-                        if moji.kana.isHiragana {
+                        if action.shiftIsPressed() && moji.kana.isHiragana {
                             state.inputMethod = .composing(
                                 ComposingState(isShift: true, text: moji.kana.map { String($0) }, romaji: result.input))
                             updateMarkedText()


### PR DESCRIPTION
#225 への対応
#226 での対応が不十分だったのを修正します。
例えば ";" を促音「っ」の入力に割り当てているときシフトを押さずに ";" を入力したときにシフトを押しつつ入力した (= 読みの入力開始と扱っていた) 問題がありました。
これを修正します。