### PR TITLE
ディスクイメージのボリューム名にバージョンをつける

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ $(INSTALLER_PKG): $(APP_PKG) $(DICT_PKG)
 $(TARGET_DMG): $(INSTALLER_PKG)
 	if [ -f $(TARGET_DMG) ]; then rm $(TARGET_DMG); fi
 	cp LICENSE $(WORKDIR)/pkg
-	hdiutil create -srcfolder $(WORKDIR)/pkg -volname macSKK -fs HFS+ $(TARGET_DMG)
+	hdiutil create -srcfolder $(WORKDIR)/pkg -volname macSKK-$(VERSION) $(TARGET_DMG)
 
-# zipが-rするときの作業ディレクトリを指定できないので雑な相対指定をしている
+# `zip -r` するときの作業ディレクトリを指定できないので雑な相対指定をしている
 $(TARGET_DSYM_ARCHIVE): $(APP)
 	rm -f $(TARGET_DSYM_ARCHIVE)
 	pushd $(XCARCHIVE)/dSYMs; zip ../../../../$(TARGET_DSYM_ARCHIVE) -r .; popd


### PR DESCRIPTION
dmgファイルをマウントしたときのボリューム名はこれまで "macSKK" 固定だったのですが、うっかりアンマウントし忘れててどのバージョンかわかりづらいときがあったのでボリューム名にバージョンをつけるようにします。
ついでに `HFS+` -> `APFS` に変更していますが、特に理由はないです。 `APFS` じゃ駄目な理由が特にないのでそうしただけです。

<img width="349" alt="image" src="https://github.com/user-attachments/assets/a2ed85df-25b3-437c-88b2-72cd2ef4d953">
