### PR TITLE
複数の変換候補があるエントリから1候補を削除すると読み配列から問答無用で削除していたのを修正

### DIFF
--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -154,6 +154,7 @@ struct MemoryDict: DictProtocol {
     /// 辞書からエントリを削除する。
     ///
     /// 辞書にないエントリ (ファイル辞書) の削除は無視されます。
+    /// 読みの配列の順序は変更されません。
     ///
     /// - Parameters:
     ///   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
@@ -161,13 +162,15 @@ struct MemoryDict: DictProtocol {
     /// - Returns: エントリを削除できたかどうか
     mutating func delete(yomi: String, word: Word.Word) -> Bool {
         if let words = entries[yomi] {
-            if yomi.isOkuriAri {
-                if let index = okuriAriYomis.firstIndex(of: yomi) {
-                    okuriAriYomis.remove(at: index)
-                }
-            } else {
-                if let index = okuriNashiYomis.firstIndex(of: yomi) {
-                    okuriNashiYomis.remove(at: index)
+            if words.count == 1 {
+                if yomi.isOkuriAri {
+                    if let index = okuriAriYomis.firstIndex(of: yomi) {
+                        okuriAriYomis.remove(at: index)
+                    }
+                } else {
+                    if let index = okuriNashiYomis.firstIndex(of: yomi) {
+                        okuriNashiYomis.remove(at: index)
+                    }
                 }
             }
             let filtered = words.filter { $0.word != word }

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -111,15 +111,23 @@ class MemoryDictTests: XCTestCase {
     }
 
     func testDelete() throws {
-        var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")]], readonly: false)
+        var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")], "え": [Word("絵"), Word("柄")]], readonly: false)
         XCTAssertEqual(dict.okuriAriYomis, ["あr"])
+        XCTAssertEqual(dict.okuriNashiYomis, ["え"])
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
+        XCTAssertFalse(dict.delete(yomi: "いr", word: "居"), "存在しないエントリを削除しようとする")
+        XCTAssertFalse(dict.delete(yomi: "お", word: "尾"), "存在しないエントリを削除しようとする")
         XCTAssertTrue(dict.delete(yomi: "あr", word: "在"))
+        XCTAssertTrue(dict.delete(yomi: "え", word: "絵"))
+        XCTAssertEqual(dict.okuriAriYomis, ["あr"], "「有」がまだ残っている")
+        XCTAssertEqual(dict.okuriNashiYomis, ["え"], "「柄」がまだ残っている")
         XCTAssertEqual(dict.refer("あr", option: nil), [Word("有")])
         XCTAssertFalse(dict.delete(yomi: "いいい", word: "いいい"))
-        XCTAssertFalse(dict.delete(yomi: "あr", word: "在"))
+        XCTAssertFalse(dict.delete(yomi: "あr", word: "在"), "削除済")
         XCTAssertTrue(dict.delete(yomi: "あr", word: "有"))
         XCTAssertEqual(dict.okuriAriYomis, [])
+        XCTAssertTrue(dict.delete(yomi: "え", word: "柄"))
+        XCTAssertEqual(dict.okuriNashiYomis, [])
     }
 
     func testDeleteOkuriBlock() throws {


### PR DESCRIPTION
MemoryDict#deleteでエントリが存在するときに必ず読みの配列からも読みを削除していました。
しかし変換候補が複数ある読みの場合は削除してはいけないので修正します。