### PR TITLE
辞書からの要素削除で複数の変換候補をもつ読みから削除すると読みリストから消してしまうバグの修正

### DIFF
--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -162,20 +162,22 @@ struct MemoryDict: DictProtocol {
     /// - Returns: エントリを削除できたかどうか
     mutating func delete(yomi: String, word: Word.Word) -> Bool {
         if let words = entries[yomi] {
-            if words.count == 1 {
-                if yomi.isOkuriAri {
-                    if let index = okuriAriYomis.firstIndex(of: yomi) {
-                        okuriAriYomis.remove(at: index)
-                    }
-                } else {
-                    if let index = okuriNashiYomis.firstIndex(of: yomi) {
-                        okuriNashiYomis.remove(at: index)
-                    }
-                }
-            }
             let filtered = words.filter { $0.word != word }
             if words.count != filtered.count {
-                entries[yomi] = filtered
+                if filtered.isEmpty {
+                    entries.removeValue(forKey: yomi)
+                    if yomi.isOkuriAri {
+                        if let index = okuriAriYomis.firstIndex(of: yomi) {
+                            okuriAriYomis.remove(at: index)
+                        }
+                    } else {
+                        if let index = okuriNashiYomis.firstIndex(of: yomi) {
+                            okuriNashiYomis.remove(at: index)
+                        }
+                    }
+                } else {
+                    entries[yomi] = filtered
+                }
                 return true
             }
         }

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -112,6 +112,7 @@ class MemoryDictTests: XCTestCase {
 
     func testDelete() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")], "え": [Word("絵"), Word("柄")]], readonly: false)
+        XCTAssertFalse(dict.entries.isEmpty)
         XCTAssertEqual(dict.okuriAriYomis, ["あr"])
         XCTAssertEqual(dict.okuriNashiYomis, ["え"])
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
@@ -124,10 +125,14 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.refer("あr", option: nil), [Word("有")])
         XCTAssertFalse(dict.delete(yomi: "いいい", word: "いいい"))
         XCTAssertFalse(dict.delete(yomi: "あr", word: "在"), "削除済")
+        XCTAssertEqual(dict.okuriAriYomis, ["あr"])
         XCTAssertTrue(dict.delete(yomi: "あr", word: "有"))
         XCTAssertEqual(dict.okuriAriYomis, [])
+        XCTAssertFalse(dict.delete(yomi: "え", word: "絵"), "削除済")
+        XCTAssertEqual(dict.okuriNashiYomis, ["え"])
         XCTAssertTrue(dict.delete(yomi: "え", word: "柄"))
         XCTAssertEqual(dict.okuriNashiYomis, [])
+        XCTAssertTrue(dict.entries.isEmpty)
     }
 
     func testDeleteOkuriBlock() throws {


### PR DESCRIPTION
辞書からの要素削除で複数の変換候補をもつ読みから削除すると、変換候補がまだ残っていても読み単語リストから消してしまうバグを修正します。
#230 でちゃんと修正できてなかったのでその修正です。

ついでに変換候補がなくなったエントリはSwiftのDictionaryからエントリを削除するようにします (元は空配列が残ってしまっていた)。