### PR TITLE
ENローカリゼーション内のタイプミスを修正

### DIFF
--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "Tab Completion" = "Tab Completion";
 "System Dict" = "System Dict";
 "Current Version:" = "Current Version";
-"Latest Version: %@" = "(Latest Verssion: %@)";
+"Latest Version: %@" = "(Latest Version: %@)";
 "Check For Update" = "Check For Update…";
 "Open Release Page" = "Open Release Page";
 "Keyboard Layout" = "Keyboard Layout";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -57,7 +57,7 @@
 "Latest Version: %@" = "(Latest Verssion: %@)";
 "Check For Update" = "Check For Update…";
 "Open Release Page" = "Open Release Page";
-"Keyboard Layout" = "Keybaord Layout";
+"Keyboard Layout" = "Keyboard Layout";
 "Show Annotation" = "Show the annotation of the candidate in current";
 "System Dictionary for annotation" = "System Dictionary for annotation";
 "Keys of selecting candidates" = "Keys of selecting candidates";


### PR DESCRIPTION
表題の通りです。英語版の表記に2点のミスと思しきものがあったので修正しています。

(いつも開発お疲れさまです.ᐟ.ᐟ.ᐟ 
macのSKK使いにとってはmacSKKがほとんど唯一の手段で、毎日ありがたく使わせていただいております。)