### PR TITLE
文字を持たない変換候補をもつエントリでのクラッシュの解消・不正ではないエントリ扱いにする

### DIFF
--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -84,7 +84,7 @@ struct Entry: Sendable {
         while true {
             if wordsText.isEmpty {
                 return result
-            } else if wordsText.first == "/" || wordsText.last != "/" {
+            } else if wordsText.first == "/" || wordsText.first == ";" || wordsText.last != "/" {
                 return nil
             }
             if wordsText.first == "[" {

--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -10,6 +10,17 @@ struct Entry: Sendable {
     let yomi: String
     let candidates: [Word]
 
+    /**
+     * SKK辞書の一行を受け取り、パースする
+     *
+     * スラッシュで終わらないなど、変換候補エントリとして壊れている場合はnilを返す。
+     * 空文字列の変換候補を含む場合、現状の実装では除外して返す。
+     * 空文字列の変換候補には今後対応する予定。
+     *
+     * 例
+     * - "あ //": 空文字列の変換候補はフィルタされて candidates = [] となる
+     * - "あ /亜": セミコロンで終わってないのでnilを返す
+     */
     init?(line: String, dictId: FileDict.ID) {
         if line.first == ";" {
             // コメント行
@@ -21,7 +32,8 @@ struct Entry: Sendable {
         }
         yomi = String(words[0])
         guard let candidates = Self.parseWords(words[1], dictId: dictId) else { return nil }
-        self.candidates = candidates
+        // TODO: いまは空の変換候補をスキップしているが扱えるようにしたい
+        self.candidates = candidates.filter { !$0.word.isEmpty }
     }
 
     init(yomi: String, candidates: [Word]) {
@@ -84,7 +96,7 @@ struct Entry: Sendable {
         while true {
             if wordsText.isEmpty {
                 return result
-            } else if wordsText.first == "/" || wordsText.first == ";" || wordsText.last != "/" {
+            } else if wordsText.last != "/" {
                 return nil
             }
             if wordsText.first == "[" {
@@ -119,7 +131,8 @@ struct Entry: Sendable {
                     result.append(parseWord(array[0], dictId: dictId))
                     wordsText = array[1]
                 default:
-                    return nil
+                    result.append(Word(""))
+                    return result
                 }
             }
         }
@@ -165,14 +178,24 @@ struct Entry: Sendable {
     static func parseWord(_ wordText: Substring, dictId: FileDict.ID) -> Word {
         let words = wordText.split(separator: Character(";"), maxSplits: 1)
         let annotation: Annotation?
-        if words.count == 2 {
-            // 注釈の先頭に "*" がついていたらユーザー独自の注釈を表す
-            let annotationText = words[1].first == "*" ? words[1].dropFirst() : words[1]
-            annotation = Annotation(dictId: dictId, text: Self.decode(String(annotationText)))
+        if words.isEmpty {
+            return Word("", annotation: nil)
+        } else if words.count == 2 {
+            annotation = parseAnnotation(words[1], dictId: dictId)
+        } else if words.count == 1 && wordText.first == ";" {
+            // 変換候補が空文字列で注釈だけある場合
+            annotation = parseAnnotation(words[0], dictId: dictId)
+            return Word("", annotation: annotation)
         } else {
             annotation = nil
         }
         return Word(Self.decode(String(words[0])), annotation: annotation)
+    }
+
+    static func parseAnnotation(_ text: Substring, dictId: FileDict.ID) -> Annotation {
+        // 注釈の先頭に "*" がついていたらユーザー独自の注釈を表す
+        let annotationText = text.first == "*" ? text.dropFirst() : text
+        return Annotation(dictId: dictId, text: Self.decode(String(annotationText)))
     }
 
     static func decode(_ word: String) -> String {

--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -136,43 +136,6 @@ struct Entry: Sendable {
                 }
             }
         }
-
-
-        if wordsText.isEmpty {
-            return []
-        } else if wordsText.first == "/" || wordsText.last != "/" {
-            return nil
-        }
-        if wordsText.first == "[" {
-            // 送り仮名ブロックのパース ややこしいからリファクタしたい
-            let array = wordsText.dropFirst().split(separator: "]", maxSplits: 1)
-            if array.count != 2 || array[1].first != "/" {
-                return nil
-            }
-            guard let index = array[0].firstIndex(of: "/") else { return nil }
-            if index == array[0].startIndex || index == array[0].endIndex {
-                return nil
-            }
-            let yomi = array[0].prefix(upTo: index)
-            let words = parseWords(array[0].suffix(from: index).dropFirst(), dictId: dictId)?.map { word in
-                Word(word.word, okuri: String(yomi), annotation: word.annotation)
-            }
-            guard let words else { return nil }
-            guard let rest = parseWords(array[1].dropFirst(), dictId: dictId) else { return nil }
-            return words + rest
-        } else {
-            let array = wordsText.split(separator: "/", maxSplits: 1)
-            switch array.count {
-            case 1:
-                return [parseWord(array[0], dictId: dictId)]
-            case 2:
-                let word = parseWord(array[0], dictId: dictId)
-                guard let words = parseWords(array[1], dictId: dictId) else { return nil }
-                return [word] + words
-            default:
-                return nil
-            }
-        }
     }
 
     static func parseWord(_ wordText: Substring, dictId: FileDict.ID) -> Word {

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -43,19 +43,18 @@ struct MemoryDict: DictProtocol {
                 return
             }
             if let entry = Entry(line: line, dictId: dictId) {
-                if entry.candidates.isEmpty {
-                    // "<よみ> //" のような変換候補を持たないエントリは無視する
-                    return
-                }
-                if let candidates = dict[entry.yomi] {
-                    dict[entry.yomi] = candidates + entry.candidates
-                } else {
-                    dict[entry.yomi] = entry.candidates
-                }
-                if entry.yomi.isOkuriAri {
-                    okuriAriYomis.append(entry.yomi)
-                } else {
-                    okuriNashiYomis.append(entry.yomi)
+                // 空文字列への変換候補をもつ場合、entry.candidatesは空になっているのでスキップする
+                if !entry.candidates.isEmpty {
+                    if let candidates = dict[entry.yomi] {
+                        dict[entry.yomi] = candidates + entry.candidates
+                    } else {
+                        dict[entry.yomi] = entry.candidates
+                    }
+                    if entry.yomi.isOkuriAri {
+                        okuriAriYomis.append(entry.yomi)
+                    } else {
+                        okuriNashiYomis.append(entry.yomi)
+                    }
                 }
             } else {
                 failedEntryCount += 1

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -43,6 +43,10 @@ struct MemoryDict: DictProtocol {
                 return
             }
             if let entry = Entry(line: line, dictId: dictId) {
+                if entry.candidates.isEmpty {
+                    // "<よみ> //" のような変換候補を持たないエントリは無視する
+                    return
+                }
                 if let candidates = dict[entry.yomi] {
                     dict[entry.yomi] = candidates + entry.candidates
                 } else {

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -33,10 +33,18 @@ final class EntryTests: XCTestCase {
     }
 
     func testSpecialCase() {
-        // TODO: いまは空の変換候補をスキップしているが扱えるようにしたい
-        XCTAssertNil(Entry(line: "から //", dictId: ""))
-        XCTAssertNil(Entry(line: "から /;/", dictId: ""))
-        XCTAssertNil(Entry(line: "から /;注釈/", dictId: ""))
+        var entry = Entry(line: "から //", dictId: "")
+        XCTAssertEqual(entry?.yomi, "から")
+        XCTAssertEqual(entry?.candidates, [])
+        entry = Entry(line: "から /空//殻/", dictId: "")
+        XCTAssertEqual(entry?.yomi, "から")
+        XCTAssertEqual(entry?.candidates, [Word("空"), Word("殻")])
+        entry = Entry(line: "から /;/", dictId: "")
+        XCTAssertEqual(entry?.yomi, "から")
+        XCTAssertEqual(entry?.candidates, [])
+        entry = Entry(line: "から /;注釈/", dictId: "")
+        XCTAssertEqual(entry?.yomi, "から")
+        XCTAssertEqual(entry?.candidates, [])
     }
 
     func testInvalidLine() {
@@ -45,11 +53,12 @@ final class EntryTests: XCTestCase {
         XCTAssertNil(Entry(line: "い/胃/", dictId: ""), "読みと変換候補の間にスペースがない")
         XCTAssertNil(Entry(line: "い  /胃/", dictId: ""), "読みと変換候補の間にスペースが2つある")
         XCTAssertNil(Entry(line: "い /胃/意", dictId: ""), "末尾がスラッシュで終わらない")
-        XCTAssertNil(Entry(line: "い //", dictId: ""), "変換候補が空")
-        XCTAssertNil(Entry(line: "い /胃//意/", dictId: ""), "変換候補が空")
-        XCTAssertNil(Entry(line: "い /胃/意//", dictId: ""), "変換候補が空")
+        // FIXME: 空文字列への変換候補をもつ行はエラーではない
+        //XCTAssertNil(Entry(line: "い //", dictId: ""), "変換候補が空")
+        //XCTAssertNil(Entry(line: "い /胃//意/", dictId: ""), "変換候補が空")
+        //XCTAssertNil(Entry(line: "い /胃/意//", dictId: ""), "変換候補が空")
+        //XCTAssertNil(Entry(line: "いt /[った//]/", dictId: ""), "送り仮名ブロックの変換候補が空")
         XCTAssertNil(Entry(line: "いt /[った/行]/", dictId: ""), "送り仮名ブロックの変換候補の末尾にスラッシュがない")
-        XCTAssertNil(Entry(line: "いt /[った//]/", dictId: ""), "変換候補が空")
         XCTAssertNil(Entry(line: "いt /[った/行/", dictId: ""), "送り仮名ブロックが閉じていない")
     }
 

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -45,6 +45,9 @@ final class EntryTests: XCTestCase {
         entry = Entry(line: "から /;注釈/", dictId: "")
         XCTAssertEqual(entry?.yomi, "から")
         XCTAssertEqual(entry?.candidates, [])
+        entry = Entry(line: "かっこ /[/", dictId: "")
+        XCTAssertEqual(entry?.yomi, "かっこ")
+        XCTAssertEqual(entry?.candidates, [Word("[")])
     }
 
     func testInvalidLine() {

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -32,6 +32,13 @@ final class EntryTests: XCTestCase {
         XCTAssertEqual(Entry(line: "ぶろっく /[ぶろっく]/", dictId: "")?.candidates.map { $0.word }, ["[ぶろっく]"])
     }
 
+    func testSpecialCase() {
+        // TODO: いまは空の変換候補をスキップしているが扱えるようにしたい
+        XCTAssertNil(Entry(line: "から //", dictId: ""))
+        XCTAssertNil(Entry(line: "から /;/", dictId: ""))
+        XCTAssertNil(Entry(line: "から /;注釈/", dictId: ""))
+    }
+
     func testInvalidLine() {
         XCTAssertNil(Entry(line: "", dictId: ""))
         XCTAssertNil(Entry(line: ";こめんと /コメント/", dictId: ""))

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -79,6 +79,16 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.entries["いぬ"]?.first?.annotation, Annotation(dictId: "testDict", text: "かわいい"))
     }
 
+    func testParseEmptyCandidate() throws {
+        // TODO: いまは空の変換候補をスキップしているが扱えるようにしたい
+        let source = """
+            から //
+
+            """
+        let dict = MemoryDict(dictId: "testDict", source: source, readonly: false)
+        XCTAssertNil(dict.entries["から"])
+    }
+
     func testAdd() throws {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertEqual(dict.entryCount, 0)


### PR DESCRIPTION
#233 次のようなSKK辞書のエントリで、ddskkと異なる挙動をしています。
またバグによりクラッシュするようなエントリがあることもわかりました。

エントリ | ddskk | macSKK
------- | ----- | ------
`よみ //` | 空文字列に漢字変換できる | 不正なエントリとして警告する
`よみ /;/` | 空文字列に漢字変換できる | クラッシュする
`よみ /;注釈/` | 空文字列に漢字変換できる | クラッシュする

ddskkに合わせて空文字列に変換できるかどうかは確認が必要なため、このPRでは次のように修正します。

エントリ | macSKK (v1.3.1現在) | このPR
------- | ----- | ------
`よみ //` | 不正なエントリとして警告する | 存在しないものと扱う
`よみ /;/` | クラッシュする | 存在しないものと扱う
`よみ /;注釈/` | クラッシュする | 存在しないものと扱う

上記以外、例えばスラッシュで終わらない行などはこれまでと同様に不正な行として扱います。