### PR TITLE
テストが落ちたときにGitHub Workflowとしても失敗となるようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,12 @@ name: test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '*.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
 
 # bashを使うようにしてpipefailを有効にする
 # https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# bashを使うようにしてpipefailを有効にする
+# https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: macos-14


### PR DESCRIPTION
現在、GitHub Workflowでのテスト実行コマンドは `xcodebuild -target macSKKTests -scheme macSKK DEVELOPMENT_TEAM= test | xcpretty` としており、出力をきれいにするためにxcprettyにパイプでつないでいました。
そのためxcodebuild test自体が失敗しても終了コードが成功になってしまっていました。

shellにbashを指定することでpipefailを有効にします。
https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

ついでにpaths-ignoreを指定して、Markdownだけの修正時はCIを実行しないようにします。