### PR TITLE
送り仮名ブロックを含む複数の変換候補をもつ場合にパースできないバグを修正

### DIFF
--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -120,6 +120,7 @@ struct Entry: Sendable {
                         result.append(parseWord(wordsText.dropLast(), dictId: dictId))
                         wordsText = array[1].dropFirst()
                     }
+                    continue
                 }
             }
             let array = wordsText.split(separator: "/", maxSplits: 1)

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -48,6 +48,17 @@ final class EntryTests: XCTestCase {
         entry = Entry(line: "かっこ /[/", dictId: "")
         XCTAssertEqual(entry?.yomi, "かっこ")
         XCTAssertEqual(entry?.candidates, [Word("[")])
+        // 空の変換候補だけスキップ
+        entry = Entry(line: "い /胃//意/", dictId: "")
+        XCTAssertEqual(entry?.candidates, [Word("胃"), Word("意")])
+        entry = Entry(line: "い /胃/意//", dictId: "")
+        XCTAssertEqual(entry?.candidates, [Word("胃"), Word("意")])
+        // 送り仮名ブロックの変換候補が空
+        entry = Entry(line: "いt /[った//]/", dictId: "")
+        XCTAssertEqual(entry?.candidates, [])
+        // 送り仮名ブロックが閉じていない
+        entry = Entry(line: "いt /[った/行/", dictId: "")
+        XCTAssertEqual(entry?.candidates, [Word("[った"), Word("行")])
     }
 
     func testInvalidLine() {
@@ -56,13 +67,7 @@ final class EntryTests: XCTestCase {
         XCTAssertNil(Entry(line: "い/胃/", dictId: ""), "読みと変換候補の間にスペースがない")
         XCTAssertNil(Entry(line: "い  /胃/", dictId: ""), "読みと変換候補の間にスペースが2つある")
         XCTAssertNil(Entry(line: "い /胃/意", dictId: ""), "末尾がスラッシュで終わらない")
-        // FIXME: 空文字列への変換候補をもつ行はエラーではない
-        //XCTAssertNil(Entry(line: "い //", dictId: ""), "変換候補が空")
-        //XCTAssertNil(Entry(line: "い /胃//意/", dictId: ""), "変換候補が空")
-        //XCTAssertNil(Entry(line: "い /胃/意//", dictId: ""), "変換候補が空")
-        //XCTAssertNil(Entry(line: "いt /[った//]/", dictId: ""), "送り仮名ブロックの変換候補が空")
         XCTAssertNil(Entry(line: "いt /[った/行]/", dictId: ""), "送り仮名ブロックの変換候補の末尾にスラッシュがない")
-        XCTAssertNil(Entry(line: "いt /[った/行/", dictId: ""), "送り仮名ブロックが閉じていない")
     }
 
     func testSerialize() {


### PR DESCRIPTION
#236 の処理に問題があり、 `あt /[た/当]/[て/当]/` のような送り仮名ブロックのエントリが処理されずに「閉じてない送り仮名ブロック」と処理されていました。
#236 の時点でユニットテストで落ちていたのですが、CIが成功となるバグで気付いていませんでした (#237で修正)
このバグを修正します。