### PR TITLE
複数の変換候補があるエントリから削除したときにシリアライズ候補から削除されていた

### DIFF
--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -108,6 +108,7 @@ final class FileDictTests: XCTestCase {
             "いr /射/",
             FileDict.okuriNashiHeader,
             "い /伊/",
+            "あ /阿;阿の注釈/",
             "",
         ].joined(separator: "\n")
         XCTAssertEqual(dict.serialize(), expected)


### PR DESCRIPTION
#231 でユニットテストが実は落ちていたことで発覚。
複数の変換候補があるエントリから1つの候補を削除したときに、誤って読みのリストから削除してしまっていました。
そのバグは #231 で修正したのですが、FileDictTests#testSerializeにあったユニットテスト自体に複数候補をもつものから1つの変換候補を消したあとのシリアライズした結果の成功判定に問題があり、ここでもエントリ自体が消えることを期待してしまっていました。