### PR TITLE
SKK辞書のファイル名にutf8が含まれたらUTF-8をデフォルトで指定する

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -563,7 +563,11 @@ final class SettingsViewModel: ObservableObject {
                         let type: FileDictType = if url.pathExtension == "json" {
                             .json
                         } else {
-                            .traditional(.japaneseEUC)
+                            if url.lastPathComponent.contains("utf8") {
+                                .traditional(.utf8)
+                            } else {
+                                .traditional(.japaneseEUC)
+                            }
                         }
                         self.dictSettings.append(DictSetting(filename: url.lastPathComponent,
                                                              enabled: false,


### PR DESCRIPTION
#235 SKK辞書ファイル名に `utf8` が含まれるときはエンコーディングをUTF-8をデフォルトで選択します。
慣習として拡張子がわりに `.utf8` になっていることが多そう?

- https://github.com/uasi/skk-emoji-jisyo `SKK-JISYO.emoji.utf8`
- https://github.com/tani/skk-jisyo-latex `SKK-JISYO.latex.utf8`