### PR TITLE
SKKServの設定画面に辞書の参照テストを追加

### DIFF
--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "LoadingStatusUnknown" = "Unknown";
 "SKKServDictTitle" = "SKKServ Dictionary Setting";
 "SKKServDictTesting" = "Testing to connect to skkserv…";
+"SKKServDictReferTestTitle" = "SKKServ Dictionary Referring Test";
 "SKKServClientConnected" = "Succeeded to connect to skkserv.";
 "SKKServClientUnknownError" = "Unknown error occurred while connecting to skkserv.";
 "SKKServClientConnectionRefused" = "Failed to connect to skkserv.";
@@ -74,10 +75,12 @@
 "Add…" = "Add…";
 "Cancel" = "Cancel";
 "Add" = "Add";
-"Test" = "Test";
+"Connection Test" = "Connection Test";
 "Address" = "Address";
 "TCP Port" = "TCP Port No.";
 "Response Encoding" = "Response Encoding";
+"Yomi" = "Yomi";
+"Refer" = "Refer";
 "Rename" = "Rename";
 "Duplicate" = "Duplicate";
 "Edit" = "Edit";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "LoadingStatusUnknown" = "不明";
 "SKKServDictTitle" = "SKKServ辞書の設定";
 "SKKServDictTesting" = "SKKServへの接続テスト中…";
+"SKKServDictReferTestTitle" = "SKKServ辞書の参照テスト";
 "SKKServClientConnected" = "skkservへの接続に成功しました";
 "SKKServClientUnknownError" = "skkservへの接続中に不明なエラーが発生しました";
 "SKKServClientConnectionRefused" = "skkservに接続できませんでした";
@@ -74,10 +75,12 @@
 "Add…" = "追加…";
 "Cancel" = "キャンセル";
 "Add" = "追加";
-"Test" = "テスト";
+"Connection Test" = "接続テスト";
 "Address" = "アドレス";
 "TCP Port" = "TCPポート番号";
 "Response Encoding" = "応答エンコーディング";
+"Yomi" = "読み";
+"Refer" = "参照";
 "Rename" = "リネーム";
 "Duplicate" = "複製";
 "Edit" = "編集";


### PR DESCRIPTION
環境設定の「辞書」→「SKKServ」内に、SKKServ辞書を引いたときのテストができる機能を追加します。

<img width="640" alt="skkserv-setting-refer" src="https://github.com/user-attachments/assets/28ecfc5d-61ff-4556-ba6d-89f0a897ada8">
