### PR TITLE
CI環境をmacOS 15に変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       checks: write
     steps:


### PR DESCRIPTION
CIで使っているmacos-14イメージにはXcode 15しか置かれなくなったそうです。
Xcode 16が入っているmacos-15に変更します。まだベータ扱いですが、古いXcode使うよりはましと思われます。