### PR TITLE
`KeyBinding.accepts`の入力の`NSEvent`をやめて前処理用の`CurrentInput`を導入

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4B8E87D42CE05C40004E7461 /* CurrentInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8E87D32CE05C3F004E7461 /* CurrentInput.swift */; };
+		4B8E87D62CE05D0C004E7461 /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8E87D52CE05D0A004E7461 /* Key.swift */; };
+		4B8E87D82CE068A0004E7461 /* CurrentInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8E87D72CE0689D004E7461 /* CurrentInputTests.swift */; };
 		CE0326A02C5D1DD6000FF691 /* SKK-JISYO.test.json in Resources */ = {isa = PBXBuildFile; fileRef = CE03269F2C5D1DD6000FF691 /* SKK-JISYO.test.json */; };
 		CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA292AAC171B00E80E5E /* FileDictTests.swift */; };
 		CE06CA2D2AAC172F00E80E5E /* empty.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE06CA2C2AAC172F00E80E5E /* empty.txt */; };
@@ -168,6 +171,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4B8E87D32CE05C3F004E7461 /* CurrentInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentInput.swift; sourceTree = "<group>"; };
+		4B8E87D52CE05D0A004E7461 /* Key.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Key.swift; sourceTree = "<group>"; };
+		4B8E87D72CE0689D004E7461 /* CurrentInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentInputTests.swift; sourceTree = "<group>"; };
 		CE03269F2C5D1DD6000FF691 /* SKK-JISYO.test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "SKK-JISYO.test.json"; sourceTree = "<group>"; };
 		CE06CA292AAC171B00E80E5E /* FileDictTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDictTests.swift; sourceTree = "<group>"; };
 		CE06CA2C2AAC172F00E80E5E /* empty.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
@@ -406,6 +412,8 @@
 				CEADA44A2B025A0F0026E2BD /* Entry.swift */,
 				CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */,
 				CE84A3E6295DA4DA009394C4 /* Romaji.swift */,
+				4B8E87D32CE05C3F004E7461 /* CurrentInput.swift */,
+				4B8E87D52CE05D0A004E7461 /* Key.swift */,
 				CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */,
 				CE39FA962BF0813E00E293F0 /* KeyBindingSet.swift */,
 				CE3E44AC2B5391DB00105798 /* SettingsWatcher.swift */,
@@ -467,6 +475,7 @@
 				CED1CA1D2BAFBE0600C32AE3 /* SKKServDictTests.swift */,
 				CEADA44C2B025A8A0026E2BD /* EntryTests.swift */,
 				CE84A3E8295DA504009394C4 /* RomajiTests.swift */,
+				4B8E87D72CE0689D004E7461 /* CurrentInputTests.swift */,
 				CE2F3B122C030C9A00CE342B /* KeyBindingTests.swift */,
 				CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */,
 				CED7CA3D2A8397E4004EF988 /* UpdateCheckerTests.swift */,
@@ -789,6 +798,7 @@
 				CE1B006D2BA54DE400C830FD /* SKKServClientProtocol.swift in Sources */,
 				CE1B006A2BA5490E00C830FD /* SKKServDictView.swift in Sources */,
 				CED0984D2B779E4700F2E844 /* UNNotifier.swift in Sources */,
+				4B8E87D42CE05C40004E7461 /* CurrentInput.swift in Sources */,
 				CE7F9AD92AADEBF9001B1877 /* AppDelegate.swift in Sources */,
 				CEF0825B296D8FF000646366 /* CandidatesView.swift in Sources */,
 				CED098512B95F32600F2E844 /* WorkaroundView.swift in Sources */,
@@ -800,6 +810,7 @@
 				CEF3D86C2B9C022900BD1D3A /* WorkaroundApplicationView.swift in Sources */,
 				CE11C7B52BDD461C00A35F3D /* Global.swift in Sources */,
 				CE84A3DE29571797009394C4 /* Action.swift in Sources */,
+				4B8E87D62CE05D0C004E7461 /* Key.swift in Sources */,
 				CED987412BB953E7001B40F9 /* Data+EucJis2004.swift in Sources */,
 				CE485A882A8FA195008271EF /* Release+UNNotification.swift in Sources */,
 				CED7CA3A2A839505004EF988 /* FetchUpdateServiceProtocol.swift in Sources */,
@@ -837,6 +848,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B8E87D82CE068A0004E7461 /* CurrentInputTests.swift in Sources */,
 				CE84A3ED295DA818009394C4 /* MemoryDictTests.swift in Sources */,
 				CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */,
 				CE84A3E9295DA504009394C4 /* RomajiTests.swift in Sources */,

--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA292AAC171B00E80E5E /* FileDictTests.swift */; };
 		CE06CA2D2AAC172F00E80E5E /* empty.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE06CA2C2AAC172F00E80E5E /* empty.txt */; };
 		CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */; };
+		CE118EE52CE0B4DE00A7C300 /* KeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE118EE42CE0B4DB00A7C300 /* KeyTests.swift */; };
 		CE11C7B52BDD461C00A35F3D /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7B42BDD461C00A35F3D /* Global.swift */; };
 		CE11C7BD2BE47D5D00A35F3D /* KeyBindingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7BC2BE47D5D00A35F3D /* KeyBindingView.swift */; };
 		CE11C7BF2BE47D9800A35F3D /* KeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */; };
@@ -178,6 +179,7 @@
 		CE06CA292AAC171B00E80E5E /* FileDictTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDictTests.swift; sourceTree = "<group>"; };
 		CE06CA2C2AAC172F00E80E5E /* empty.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
 		CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDict+Utilities.swift"; sourceTree = "<group>"; };
+		CE118EE42CE0B4DB00A7C300 /* KeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyTests.swift; sourceTree = "<group>"; };
 		CE11C7B42BDD461C00A35F3D /* Global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Global.swift; sourceTree = "<group>"; };
 		CE11C7BC2BE47D5D00A35F3D /* KeyBindingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingView.swift; sourceTree = "<group>"; };
 		CE11C7BE2BE47D9800A35F3D /* KeyBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBinding.swift; sourceTree = "<group>"; };
@@ -476,6 +478,7 @@
 				CEADA44C2B025A8A0026E2BD /* EntryTests.swift */,
 				CE84A3E8295DA504009394C4 /* RomajiTests.swift */,
 				4B8E87D72CE0689D004E7461 /* CurrentInputTests.swift */,
+				CE118EE42CE0B4DB00A7C300 /* KeyTests.swift */,
 				CE2F3B122C030C9A00CE342B /* KeyBindingTests.swift */,
 				CE49A2772C19E07800D53CFE /* KeyBindingSetTests.swift */,
 				CED7CA3D2A8397E4004EF988 /* UpdateCheckerTests.swift */,
@@ -848,6 +851,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE118EE52CE0B4DE00A7C300 /* KeyTests.swift in Sources */,
 				4B8E87D82CE068A0004E7461 /* CurrentInputTests.swift in Sources */,
 				CE84A3ED295DA818009394C4 /* MemoryDictTests.swift in Sources */,
 				CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */,

--- a/macSKK/CurrentInput.swift
+++ b/macSKK/CurrentInput.swift
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+
+/**
+ * 修飾キーついて整理されたキー入力情報。
+ */
+struct CurrentInput: Equatable {
+    let key: Key
+    let modifierFlags: NSEvent.ModifierFlags
+
+    init(key: Key, modifierFlags: NSEvent.ModifierFlags) {
+        self.key = key
+        self.modifierFlags = modifierFlags
+    }
+
+    init(event: NSEvent) {
+        if event.modifierFlags.contains(.shift), let character = event.characters?.lowercased().first, Key.characters.contains(character) {
+            // Shiftを押しながら入力されたキーはキーバインド設定から登録した場合は (NSEvent#charactersIgnoringModifiersが記号のほうを返すため)
+            // .character("!") のように記号のほうをもっているが、IMKInputController#handleに渡されるNSEventの
+            // charactersIgnoringModifiersは記号のほうではない ("!"なら"1"になっている) ため、charactersのほうを見る
+            key = .character(character)
+        } else if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
+            key = .character(character)
+        } else {
+            key = .code(event.keyCode)
+        }
+
+        // 使用する可能性があるものだけを抽出する。じゃないとrawValueで256が入ってしまうっぽい?
+        modifierFlags = event.modifierFlags.intersection(Key.allowedModifierFlags)
+    }
+}

--- a/macSKK/CurrentInput.swift
+++ b/macSKK/CurrentInput.swift
@@ -4,7 +4,9 @@
 import AppKit
 
 /**
- * 修飾キーついて整理されたキー入力情報。
+ * 整理されたキー入力情報。
+ *
+ * NSEventからキーと修飾キーについてIMEの入力として必要な情報だけを取り出して所持しておく。
  */
 struct CurrentInput: Equatable {
     let key: Key

--- a/macSKK/Key.swift
+++ b/macSKK/Key.swift
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+
+/**
+ * macSKKのキー情報。
+ */
+enum Key: Hashable, Equatable {
+    /// jやqやlなど、キーに印字されているテキスト。
+    /// シフトを押しながら入力する場合は英字は小文字、!や#など記号はそのまま。
+    case character(Character)
+    /// keyCode形式。矢印キーなど表記できないキーを表現するために使用する。
+    /// 設定でDvorak配列を選んでいる場合などもkeyCodeはQwerty配列の位置のままなので基本的にはcharacterで設定すること。
+    /// 例えば設定でDvorak配列を選んだ状態でoを入力してもkeyCodeはQwerty配列のsのキーと同じになる。
+    case code(UInt16)
+    /// macSKKでkeyCodeベースでなく印字されている文字で取り扱うキーの集合。
+    /// キーバインド設定画面で使用しているNSEvent#charactersIngoringModifiersはIMKInputControllerへ入力されるNSEventと違い
+    /// Shiftを押しながら入力する記号の場合 (!とか) は記号の方が渡ってくる
+    /// (IMKInputControllerのNSEvent#charactersIgnoringModifiersは1)
+    /// Shiftを押しながら入力する記号も含まれている。
+    static let characters: [Character] = "abcdefghijklmnopqrstuvwxyz1234567890,./;-=`'\\!@#$%^&*()|:<>?\"~".map { $0 }
+
+    /// Inputで管理する修飾キーの集合。ここに含まれてない修飾キーは無視する
+    static let allowedModifierFlags: NSEvent.ModifierFlags = [.shift, .control, .function, .option, .command]
+
+    // UserDefaultsからのデコード用
+    init?(rawValue: Any) {
+        if let character = rawValue as? String, Self.characters.contains(character) {
+            self = .character(Character(character))
+        } else if let keyCode = rawValue as? UInt16 {
+            self = .code(keyCode)
+        } else {
+            return nil
+        }
+    }
+
+    // UserDefaultsへのエンコード用
+    func encode() -> Any {
+        switch self {
+        case .character(let character):
+            return String(character)
+        case .code(let keyCode):
+            return keyCode
+        }
+    }
+
+    var displayString: String {
+        switch self {
+        case .character(let character):
+            if character.isAlphabet {
+                return character.uppercased()
+            } else {
+                return String(character)
+            }
+        case .code(let keyCode):
+            switch keyCode {
+            case 0x24:
+                return "Enter"
+            case 0x30:
+                return "Tab"
+            case 0x31:
+                return "Space"
+            case 0x33:
+                return "Backspace"
+            case 0x35:
+                return "ESC"
+            case 0x66:
+                return String(localized: "KeyEisu")
+            case 0x68:
+                return String(localized: "KeyKana")
+            case 0x73:
+                return "Home"
+            case 0x74:
+                return "PageUp"
+            case 0x75:
+                return "Delete"
+            case 0x77:
+                return "End"
+            case 0x79:
+                return "PageDown"
+            case 0x7b:
+                return "←"
+            case 0x7c:
+                return "→"
+            case 0x7d:
+                return "↓"
+            case 0x7e:
+                return "↑"
+            default:
+                return "\(keyCode)"
+            }
+        }
+    }
+}

--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -86,7 +86,9 @@ struct KeyBindingSet: Identifiable, Hashable {
     /// 現在のキーバインドに割り当てられているアクションを返す。
     /// 入力はIMKInputController#handleの引数のNSEventなので、charactersIgnoreingModifiersがシフトキーの影響を受けない。
     func action(event: NSEvent) -> KeyBinding.Action? {
-        sorted.first(where: { $0.0.accepts(event: event) })?.1
+        let currentInput = CurrentInput(event: event)
+
+        return sorted.first(where: { $0.0.accepts(currentInput: currentInput) })?.1
     }
 
     var canDelete: Bool {

--- a/macSKK/Settings/KeyBinding/KeyBindingInputsView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingInputsView.swift
@@ -4,16 +4,16 @@
 import SwiftUI
 
 struct KeyWithModifierFlags: Hashable {
-    let key: KeyBinding.Key
+    let key: Key
     let modifierFlags: NSEvent.ModifierFlags
 
     var displayString: String {
         KeyBinding.Input(key: key, modifierFlags: modifierFlags).localized
     }
 
-    init(_ key: KeyBinding.Key, _ modifierFlags: NSEvent.ModifierFlags) {
+    init(_ key: Key, _ modifierFlags: NSEvent.ModifierFlags) {
         self.key = key
-        self.modifierFlags = modifierFlags.intersection(KeyBinding.Input.allowedModifierFlags)
+        self.modifierFlags = modifierFlags.intersection(Key.allowedModifierFlags)
     }
 
     // Equatable
@@ -35,7 +35,7 @@ final class KeyBindingInput: ObservableObject, Identifiable, Hashable {
     @Published var displayString: String
     var optionalModifierFlags: NSEvent.ModifierFlags
 
-    init(key: KeyBinding.Key, modifierFlags: NSEvent.ModifierFlags, optionalModifierFlags: NSEvent.ModifierFlags = []) {
+    init(key: Key, modifierFlags: NSEvent.ModifierFlags, optionalModifierFlags: NSEvent.ModifierFlags = []) {
         let keyWithModifierFlags = KeyWithModifierFlags(key, modifierFlags)
         self.keyWithModifierFlags = keyWithModifierFlags
         self.optionalModifierFlags = optionalModifierFlags
@@ -149,8 +149,8 @@ struct KeyBindingInputsView: View {
                 .onChange(of: editingInput) { newEditingInput in
                     if let newEditingInput {
                         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
-                            let key: KeyBinding.Key
-                            if let character = event.charactersIgnoringModifiers?.lowercased().first, KeyBinding.Key.characters.contains(character) {
+                            let key: Key
+                            if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
                                 key = .character(character)
                             } else {
                                 key = .code(event.keyCode)

--- a/macSKKTests/CurrentInputTests.swift
+++ b/macSKKTests/CurrentInputTests.swift
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-
 import XCTest
 
 @testable import macSKK

--- a/macSKKTests/CurrentInputTests.swift
+++ b/macSKKTests/CurrentInputTests.swift
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+import XCTest
+
+@testable import macSKK
+
+final class CurrentInputTests: XCTestCase {
+    func generateKeyEvent(modifierFlags: NSEvent.ModifierFlags, characters: String, charactersIgnoringModifiers: String? = nil, keyCode: UInt16 = 0) -> NSEvent {
+        NSEvent.keyEvent(with: .keyDown,
+                         location: .zero,
+                         modifierFlags: modifierFlags,
+                         timestamp: 0,
+                         windowNumber: 0,
+                         context: nil,
+                         characters: characters,
+                         charactersIgnoringModifiers: charactersIgnoringModifiers ?? characters,
+                         isARepeat: false,
+                         keyCode: keyCode)!
+    }
+
+    func testCurrentInputCharacterWithShift() {
+        let inputQ = CurrentInput(key: .character("q"), modifierFlags: [])
+        let inputShiftQ = CurrentInput(key: .character("q"), modifierFlags: .shift)
+        let eventQ = generateKeyEvent(modifierFlags: [], characters: "q")
+        let eventShiftQ = generateKeyEvent(modifierFlags: .shift, characters: "q")
+        
+        XCTAssertEqual(inputQ, CurrentInput(event: eventQ))
+        XCTAssertEqual(inputShiftQ, CurrentInput(event: eventShiftQ))
+        XCTAssertNotEqual(inputQ, CurrentInput(event: eventShiftQ))
+        XCTAssertNotEqual(inputShiftQ, CurrentInput(event: eventQ))
+    }
+
+    func testCurrentInputKeyCodeWithShift() {
+        let inputLeft = CurrentInput(key: .code(0x7b), modifierFlags: .function)
+        let inputShiftLeft = CurrentInput(key: .code(0x7b), modifierFlags: [.function, .shift])
+        let eventLeft = generateKeyEvent(modifierFlags: [.function], characters: "\u{63234}", keyCode: 0x7b)
+        let eventShiftLeft = generateKeyEvent(modifierFlags: [.function, .shift], characters: "\u{63234}", keyCode: 0x7b)
+        
+        XCTAssertEqual(inputLeft, CurrentInput(event: eventLeft))
+        XCTAssertEqual(inputShiftLeft, CurrentInput(event: eventShiftLeft))
+        XCTAssertNotEqual(inputLeft, CurrentInput(event: eventShiftLeft))
+        XCTAssertNotEqual(inputShiftLeft, CurrentInput(event: eventLeft))
+    }
+
+    func testCurrentInputKeyCode() {
+        let inputEnter = CurrentInput(key: .code(0x24), modifierFlags: [])
+        let eventEnter = generateKeyEvent(modifierFlags: [], characters: "\r", keyCode: 0x24)
+        let eventOptionEnter = generateKeyEvent(modifierFlags: .option, characters: "\r", keyCode: 0x24)
+        
+        XCTAssertEqual(inputEnter, CurrentInput(event: eventEnter))
+        XCTAssertNotEqual(inputEnter, CurrentInput(event: eventOptionEnter))
+    }
+}

--- a/macSKKTests/KeyBindingTests.swift
+++ b/macSKKTests/KeyBindingTests.swift
@@ -22,12 +22,12 @@ final class KeyBindingTests: XCTestCase {
     }
 
     func testKeyEncodeAndDecode() {
-        let key1: KeyBinding.Key = .character("q")
-        XCTAssertEqual(key1, KeyBinding.Key(rawValue: key1.encode()))
-        let key2: KeyBinding.Key = .code(0x66)
-        XCTAssertEqual(key2, KeyBinding.Key(rawValue: key2.encode()))
-        let key3: KeyBinding.Key = .character("Q")
-        XCTAssertNil(KeyBinding.Key(rawValue: key3.encode()))
+        let key1: Key = .character("q")
+        XCTAssertEqual(key1, Key(rawValue: key1.encode()))
+        let key2: Key = .code(0x66)
+        XCTAssertEqual(key2, Key(rawValue: key2.encode()))
+        let key3: Key = .character("Q")
+        XCTAssertNil(Key(rawValue: key3.encode()))
     }
 
     func testInputEncodeAndDecode() {
@@ -57,38 +57,26 @@ final class KeyBindingTests: XCTestCase {
     }
 
     func testInputAccepts() {
-        func generateKeyEvent(modifierFlags: NSEvent.ModifierFlags, characters: String, charactersIgnoringModifiers: String? = nil, keyCode: UInt16 = 0) -> NSEvent {
-            NSEvent.keyEvent(with: .keyDown,
-                             location: .zero,
-                             modifierFlags: modifierFlags,
-                             timestamp: 0,
-                             windowNumber: 0,
-                             context: nil,
-                             characters: characters,
-                             charactersIgnoringModifiers: charactersIgnoringModifiers ?? characters,
-                             isARepeat: false,
-                             keyCode: keyCode)!
-        }
         let inputQ = KeyBinding.Input(key: .character("q"), modifierFlags: [])
         let inputShiftQ = KeyBinding.Input(key: .character("q"), modifierFlags: .shift)
-        let eventQ = generateKeyEvent(modifierFlags: [], characters: "q")
-        let eventShiftQ = generateKeyEvent(modifierFlags: .shift, characters: "q")
-        XCTAssertTrue(inputQ.accepts(event: eventQ))
-        XCTAssertFalse(inputShiftQ.accepts(event: eventQ))
-        XCTAssertFalse(inputQ.accepts(event: eventShiftQ))
-        XCTAssertTrue(inputShiftQ.accepts(event: eventShiftQ))
+        let currentInputQ = CurrentInput(key: .character("q"), modifierFlags: [])
+        let currentInputShiftQ = CurrentInput(key: .character("q"), modifierFlags: .shift)
+        XCTAssertTrue(inputQ.accepts(currentInput: currentInputQ))
+        XCTAssertFalse(inputShiftQ.accepts(currentInput: currentInputQ))
+        XCTAssertFalse(inputQ.accepts(currentInput: currentInputShiftQ))
+        XCTAssertTrue(inputShiftQ.accepts(currentInput: currentInputShiftQ))
         let inputLeft = KeyBinding.Input(key: .code(0x7b), modifierFlags: .function, optionalModifierFlags: .shift)
-        let eventLeft = generateKeyEvent(modifierFlags: [.function], characters: "\u{63234}", keyCode: 0x7b)
-        let eventShiftLeft = generateKeyEvent(modifierFlags: [.function, .shift], characters: "\u{63234}", keyCode: 0x7b)
-        XCTAssertTrue(inputLeft.accepts(event: eventLeft))
-        XCTAssertTrue(inputLeft.accepts(event: eventShiftLeft))
-        XCTAssertFalse(inputLeft.accepts(event: eventQ))
+        let currentInputLeft = CurrentInput(key: .code(0x7b), modifierFlags: [.function])
+        let currentInputShiftLeft = CurrentInput(key: .code(0x7b), modifierFlags: [.function, .shift])
+        XCTAssertTrue(inputLeft.accepts(currentInput: currentInputLeft))
+        XCTAssertTrue(inputLeft.accepts(currentInput: currentInputShiftLeft))
+        XCTAssertFalse(inputLeft.accepts(currentInput: currentInputQ))
         let inputEnter = KeyBinding.Input(key: .code(0x24), modifierFlags: [], optionalModifierFlags: .option)
-        let eventEnter = generateKeyEvent(modifierFlags: [], characters: "\r", keyCode: 0x24)
-        let eventOptionEnter = generateKeyEvent(modifierFlags: .option, characters: "\r", keyCode: 0x24)
-        XCTAssertTrue(inputEnter.accepts(event: eventEnter))
-        XCTAssertTrue(inputEnter.accepts(event: eventOptionEnter))
-        XCTAssertFalse(inputEnter.accepts(event: eventLeft))
+        let currentInputEnter = CurrentInput(key: .code(0x24), modifierFlags: [])
+        let currentInputOptionEnter = CurrentInput(key: .code(0x24), modifierFlags: .option)
+        XCTAssertTrue(inputEnter.accepts(currentInput: currentInputEnter))
+        XCTAssertTrue(inputEnter.accepts(currentInput: currentInputOptionEnter))
+        XCTAssertFalse(inputEnter.accepts(currentInput: currentInputLeft))
     }
 
     func testIsDefault() {

--- a/macSKKTests/KeyBindingTests.swift
+++ b/macSKKTests/KeyBindingTests.swift
@@ -21,15 +21,6 @@ final class KeyBindingTests: XCTestCase {
         XCTAssertNotEqual(shiftRight, shiftCtrlRight)
     }
 
-    func testKeyEncodeAndDecode() {
-        let key1: Key = .character("q")
-        XCTAssertEqual(key1, Key(rawValue: key1.encode()))
-        let key2: Key = .code(0x66)
-        XCTAssertEqual(key2, Key(rawValue: key2.encode()))
-        let key3: Key = .character("Q")
-        XCTAssertNil(Key(rawValue: key3.encode()))
-    }
-
     func testInputEncodeAndDecode() {
         let input1 = KeyBinding.Input(key: .character("l"), modifierFlags: [])
         XCTAssertEqual(input1, KeyBinding.Input(dict: input1.encode()))

--- a/macSKKTests/KeyTests.swift
+++ b/macSKKTests/KeyTests.swift
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 mtgto <hogerappa@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+
+@testable import macSKK
+
+final class KeyTests: XCTestCase {
+    func testEncodeAndDecode() {
+        let key1: Key = .character("q")
+        XCTAssertEqual(key1, Key(rawValue: key1.encode()))
+        let key2: Key = .code(0x66)
+        XCTAssertEqual(key2, Key(rawValue: key2.encode()))
+        let key3: Key = .character("Q")
+        XCTAssertNil(Key(rawValue: key3.encode()))
+    }
+}


### PR DESCRIPTION
### 背景

- https://github.com/mtgto/macSKK/pull/173#discussion_r1641021314 で議論したとおり、従来の`KeyBinding.accepts`はmacSKKに入力される`NSEvent`について、下記のような入力キー情報や修飾キー情報などの整理といった前処理が必要となる
    - https://github.com/mtgto/macSKK/blob/4f8aa7e6a64edcbbd273e5ebc6d728c970dd62b6/macSKK/KeyBinding.swift#L228-L241
- 一方で`KeyBinding.accepts`は`KeyBindingSet.action`で繰り返し呼び出されるため、この`NSEvent`に対する前処理は事前にやってから`KeyBinding.accepts`の判定処理を行うほうがよいとなっていた
    - https://github.com/mtgto/macSKK/blob/4f8aa7e6a64edcbbd273e5ebc6d728c970dd62b6/macSKK/KeyBindingSet.swift#L88-L90

### やったこと

- `NSEvent`からキー入力情報を整理しておくためのデータ構造`CurrentInput`を与えた
    - 副作用として`KeyBinding.Input`の役割は完全にキーバインディングのアクションとのキーペアに限定された
- `KeyBinding`に定義されていた`Key`を共通で使うために`Key.swift`へ引っ越した
    - `allowedModifierFlags`もここに設置した