### PR TITLE
新規ファイルテンプレからSPDX-FileCopyrightTextを削除

### DIFF
--- a/macSKK.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/macSKK.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -3,7 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>FILEHEADER</key>
-	<string> SPDX-FileCopyrightText: ___YEAR___ mtgto &lt;hogerappa@gmail.com&gt;
-// SPDX-License-Identifier: GPL-3.0-or-later</string>
+	<string> SPDX-License-Identifier: GPL-3.0-or-later</string>
 </dict>
 </plist>


### PR DESCRIPTION
新規ファイルにはテンプレでSPDXヘッダーを2つ入れていました。

- `// SPDX-FileCopyrightText: ___YEAR___ mtgto &lt;hogerappa@gmail.com&gt;`
- `// SPDX-License-Identifier: GPL-3.0-or-later`

そのうちSPDX-FileCopyrightTextは自分以外が作成したファイルに付くのも変なので削除します。
作成年はgitで辿れるはず。

既存のコードはgitのリビジョンを増やすほどではないかなと思ってたぶんそのままにします。
そのうち例えば「コントリビューター含めた表記にしよう」とか思い立って直すかもしれません。