### PR TITLE
プライベートモードの設定をUserDefaultsに永続化

### DIFF
--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -35,4 +35,5 @@ struct UserDefaultsKeys {
     static let selectingBackspace = "selectingBackspace"
     // カンマ、ピリオド入力時の句読点
     static let punctuation = "punctuation"
+    static let privateMode = "privateMode"
 }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -86,6 +86,7 @@ class UserDict: NSObject, DictProtocol {
                 logger.log("プライベートモードが解除されました")
                 self?.privateUserDict = MemoryDict(entries: [:], readonly: true)
             }
+            UserDefaults.standard.set(privateMode, forKey: UserDefaultsKeys.privateMode)
         }
         .store(in: &cancellables)
     }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -57,7 +57,8 @@ struct macSKKApp: App {
             ).appendingPathComponent("Dictionaries")
             let settingsViewModel = try SettingsViewModel(dictionariesDirectoryUrl: dictionariesDirectoryUrl)
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
-            
+            Global.privateMode.send(UserDefaults.standard.bool(forKey: UserDefaultsKeys.privateMode))
+
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
             Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode, findCompletionFromAllDicts: Global.findCompletionFromAllDicts)
             settingsWindowController = NSWindowController(window: settingsWindow)
@@ -195,7 +196,8 @@ struct macSKKApp: App {
             UserDefaultsKeys.enterNewLine: false,
             UserDefaultsKeys.systemDict: SystemDict.Kind.daijirin.rawValue,
             UserDefaultsKeys.selectingBackspace: SelectingBackspace.default.rawValue,
-            UserDefaultsKeys.punctuation: Punctuation.default.rawValue
+            UserDefaultsKeys.punctuation: Punctuation.default.rawValue,
+            UserDefaultsKeys.privateMode: false,
         ])
     }
 


### PR DESCRIPTION
#251 プライベートモードにした状態でOSの再起動などによりmacSKKが再起動された場合にはプライベートモードの状態はリセットされていました。
UserDefaultsに保存することでこれを永続化します。