### PR TITLE
プライベートモード時にユーザー辞書を参照しない設定を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -40,7 +40,7 @@ import Combine
     /// カンマかピリオドを入力したときに入力する句読点の設定
     static var punctuation: Punctuation = .default
     /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
-    static var privateModeIgnoreUserDict: Bool = false
+    static var ignoreUserDictInPrivateMode: Bool = false
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -39,6 +39,8 @@ import Combine
     static var selectingBackspace: SelectingBackspace = .default
     /// カンマかピリオドを入力したときに入力する句読点の設定
     static var punctuation: Punctuation = .default
+    /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
+    static var privateModeIgnoreUserDict: Bool = false
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -14,6 +14,8 @@ import Combine
     /// skkserv辞書
     static var skkservDict: SKKServDict? = nil
     static let privateMode = CurrentValueSubject<Bool, Never>(false)
+    /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
+    static var ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
     // 直接入力するアプリケーションのBundleIdentifierの集合のコピー。
     // マスターはSettingsViewModelがもっているが、InputControllerからAppが参照できないのでグローバル変数にコピーしている。
     // FIXME: NotificationCenter経由で設定画面で変更したことを各InputControllerに通知するようにしてこの変数は消すかも。
@@ -39,8 +41,6 @@ import Combine
     static var selectingBackspace: SelectingBackspace = .default
     /// カンマかピリオドを入力したときに入力する句読点の設定
     static var punctuation: Punctuation = .default
-    /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
-    static var ignoreUserDictInPrivateMode: Bool = false
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -67,6 +67,9 @@ struct GeneralView: View {
                     Toggle(isOn: $settingsViewModel.findCompletionFromAllDicts, label: {
                         Text("Find completion from all dictionaries")
                     })
+                    Toggle(isOn: $settingsViewModel.privateModeIgnoreUserDict, label: {
+                        Text("Ignore User Dict in Private Mode")
+                    })
                 }
             }
             .formStyle(.grouped)

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -67,7 +67,7 @@ struct GeneralView: View {
                     Toggle(isOn: $settingsViewModel.findCompletionFromAllDicts, label: {
                         Text("Find completion from all dictionaries")
                     })
-                    Toggle(isOn: $settingsViewModel.privateModeIgnoreUserDict, label: {
+                    Toggle(isOn: $settingsViewModel.ignoreUserDictInPrivateMode, label: {
                         Text("Ignore User Dict in Private Mode")
                     })
                 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -233,6 +233,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var selectingBackspace: SelectingBackspace
     @Published var period: Punctuation.Period
     @Published var comma: Punctuation.Comma
+    // プライベートモード時に変換候補にユーザー辞書を無視するかどうか
+    @Published var privateModeIgnoreUserDict: Bool
 
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
@@ -288,10 +290,12 @@ final class SettingsViewModel: ObservableObject {
         selectingBackspace = SelectingBackspace(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.selectingBackspace)) ?? SelectingBackspace.default
         comma = Punctuation.Comma(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
         period = Punctuation.Period(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
+        privateModeIgnoreUserDict = UserDefaults.standard.bool(forKey: UserDefaultsKeys.privateModeIgnoreUserDict)
         Global.selectCandidateKeys = selectCandidateKeys.lowercased().map { $0 }
         Global.systemDict = systemDict
         Global.selectingBackspace = selectingBackspace
         Global.punctuation = Punctuation(comma: comma, period: period)
+        Global.privateModeIgnoreUserDict = privateModeIgnoreUserDict
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -514,6 +518,7 @@ final class SettingsViewModel: ObservableObject {
         selectingBackspace = SelectingBackspace.default
         comma = Punctuation.default.comma
         period = Punctuation.default.period
+        privateModeIgnoreUserDict = false
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -234,7 +234,7 @@ final class SettingsViewModel: ObservableObject {
     @Published var period: Punctuation.Period
     @Published var comma: Punctuation.Comma
     // プライベートモード時に変換候補にユーザー辞書を無視するかどうか
-    @Published var privateModeIgnoreUserDict: Bool
+    @Published var ignoreUserDictInPrivateMode: Bool
 
     // 辞書ディレクトリ
     let dictionariesDirectoryUrl: URL
@@ -290,12 +290,12 @@ final class SettingsViewModel: ObservableObject {
         selectingBackspace = SelectingBackspace(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.selectingBackspace)) ?? SelectingBackspace.default
         comma = Punctuation.Comma(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
         period = Punctuation.Period(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
-        privateModeIgnoreUserDict = UserDefaults.standard.bool(forKey: UserDefaultsKeys.privateModeIgnoreUserDict)
+        ignoreUserDictInPrivateMode = UserDefaults.standard.bool(forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
         Global.selectCandidateKeys = selectCandidateKeys.lowercased().map { $0 }
         Global.systemDict = systemDict
         Global.selectingBackspace = selectingBackspace
         Global.punctuation = Punctuation(comma: comma, period: period)
-        Global.privateModeIgnoreUserDict = privateModeIgnoreUserDict
+        Global.ignoreUserDictInPrivateMode = ignoreUserDictInPrivateMode
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -518,7 +518,7 @@ final class SettingsViewModel: ObservableObject {
         selectingBackspace = SelectingBackspace.default
         comma = Punctuation.default.comma
         period = Punctuation.default.period
-        privateModeIgnoreUserDict = false
+        ignoreUserDictInPrivateMode = false
     }
 
     // DictionaryViewのPreviewProvider用

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -295,7 +295,7 @@ final class SettingsViewModel: ObservableObject {
         Global.systemDict = systemDict
         Global.selectingBackspace = selectingBackspace
         Global.punctuation = Punctuation(comma: comma, period: period)
-        Global.ignoreUserDictInPrivateMode = ignoreUserDictInPrivateMode
+        Global.ignoreUserDictInPrivateMode.send(ignoreUserDictInPrivateMode)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -475,6 +475,12 @@ final class SettingsViewModel: ObservableObject {
             let punctuation = Punctuation(comma: comma, period: period)
             Global.punctuation = punctuation
             UserDefaults.standard.set(punctuation.rawValue, forKey: UserDefaultsKeys.punctuation)
+        }.store(in: &cancellables)
+
+        $ignoreUserDictInPrivateMode.dropFirst().sink { ignoreUserDictInPrivateMode in
+            logger.log("プライベートモードでユーザー辞書を \(ignoreUserDictInPrivateMode ? "参照しない" : "参照する", privacy: .public) に変更しました")
+            Global.ignoreUserDictInPrivateMode.send(ignoreUserDictInPrivateMode)
+            UserDefaults.standard.set(ignoreUserDictInPrivateMode, forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
         }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameDictLoad).receive(on: RunLoop.main).sink { [weak self] notification in

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -37,5 +37,5 @@ struct UserDefaultsKeys {
     static let punctuation = "punctuation"
     static let privateMode = "privateMode"
     // プライベートモード時に変換候補にユーザー辞書を無視するかどうか
-    static let privateModeIgnoreUserDict = "privateModeIgnoreUserDict"
+    static let ignoreUserDictInPrivateMode = "ignoreUserDictInPrivateMode"
 }

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -36,4 +36,6 @@ struct UserDefaultsKeys {
     // カンマ、ピリオド入力時の句読点
     static let punctuation = "punctuation"
     static let privateMode = "privateMode"
+    // プライベートモード時に変換候補にユーザー辞書を無視するかどうか
+    static let privateModeIgnoreUserDict = "privateModeIgnoreUserDict"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1306,7 +1306,9 @@ final class StateMachine {
     /// 見出し語で辞書を引く。同じ文字列である変換候補が複数の辞書にある場合は最初の1つにまとめる。
     /// 「う゛」は「ゔ」にしてから引く
     @MainActor func candidates(for yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
-        return Global.dictionary.referDicts(yomi.replacing("う゛", with: "ゔ"), option: option)
+        return Global.dictionary.referDicts(yomi.replacing("う゛", with: "ゔ"),
+                                            referUserDict: !Global.privateMode.value || !Global.privateModeIgnoreUserDict,
+                                            option: option)
     }
 
     /**

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1307,7 +1307,7 @@ final class StateMachine {
     /// 「う゛」は「ゔ」にしてから引く
     @MainActor func candidates(for yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
         return Global.dictionary.referDicts(yomi.replacing("う゛", with: "ゔ"),
-                                            referUserDict: !Global.privateMode.value || !Global.privateModeIgnoreUserDict,
+                                            referUserDict: !Global.privateMode.value || !Global.ignoreUserDictInPrivateMode,
                                             option: option)
     }
 

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1306,9 +1306,7 @@ final class StateMachine {
     /// 見出し語で辞書を引く。同じ文字列である変換候補が複数の辞書にある場合は最初の1つにまとめる。
     /// 「う゛」は「ゔ」にしてから引く
     @MainActor func candidates(for yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
-        return Global.dictionary.referDicts(yomi.replacing("う゛", with: "ゔ"),
-                                            referUserDict: !Global.privateMode.value || !Global.ignoreUserDictInPrivateMode,
-                                            option: option)
+        return Global.dictionary.referDicts(yomi.replacing("う゛", with: "ゔ"), option: option)
     }
 
     /**

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -78,7 +78,6 @@ class UserDict: NSObject, DictProtocol {
             if privateMode {
                 logger.log("プライベートモードが設定されました")
             } else {
-                // プライベートモードを解除したときにそれまでのエントリを削除する
                 logger.log("プライベートモードが解除されました")
             }
             UserDefaults.standard.set(privateMode, forKey: UserDefaultsKeys.privateMode)
@@ -202,7 +201,7 @@ class UserDict: NSObject, DictProtocol {
      *  - Parameters:
      *    - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *    - word: SKK辞書の変換候補。
-     *  - Returns: エントリを削除できたかどうか。プライベートモード時は常にtrue。
+     *  - Returns: エントリを削除できたかどうか。プライベートモード時はなにも削除せずに常にtrueを返す。
      */
     func delete(yomi: String, word: Word.Word) -> Bool {
         if privateMode.value {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -21,13 +21,6 @@ class UserDict: NSObject, DictProtocol {
     var userDict: (any DictProtocol)?
     /// 有効になっている辞書。優先度が高い順。
     var dicts: [any DictProtocol]
-    /**
-     * プライベートモードのユーザー辞書。プライベートモードが有効な時に変換や単語登録するとユーザー辞書とは別に更新されます。
-     *
-     * マイ辞書ファイルには永続化されません。
-     * プライベートモード時に変換・登録された単語だけ登録されるので、このあと非プライベートモードに遷移するとリセットされます。
-     */
-    private(set) var privateUserDict = MemoryDict(entries: [:], readonly: true)
     private let savePublisher = PassthroughSubject<Void, Never>()
     private let privateMode: CurrentValueSubject<Bool, Never>
     private var cancellables: Set<AnyCancellable> = []
@@ -78,13 +71,12 @@ class UserDict: NSObject, DictProtocol {
                 }
             }
             .store(in: &cancellables)
-        self.privateMode.drop(while: { !$0 }).removeDuplicates().sink { [weak self] privateMode in
+        self.privateMode.drop(while: { !$0 }).removeDuplicates().sink { privateMode in
             if privateMode {
                 logger.log("プライベートモードが設定されました")
             } else {
                 // プライベートモードを解除したときにそれまでのエントリを削除する
                 logger.log("プライベートモードが解除されました")
-                self?.privateUserDict = MemoryDict(entries: [:], readonly: true)
             }
             UserDefaults.standard.set(privateMode, forKey: UserDefaultsKeys.privateMode)
         }
@@ -150,17 +142,14 @@ class UserDict: NSObject, DictProtocol {
         return result
     }
 
+    /**
+     * 非プライベートモード時はユーザー辞書、それ以外の辞書の順に参照する。
+     * プライベートモードで入力したエントリは参照しない。
+     */
     // MARK: DictProtocol
     func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {
         if let userDict = userDict {
             var result = userDict.refer(yomi, option: option)
-            if privateMode.value {
-                privateUserDict.refer(yomi, option: option).forEach { found in
-                    if !result.contains(found) {
-                        result.append(found)
-                    }
-                }
-            }
             dicts.forEach { dict in
                 dict.refer(yomi, option: option).forEach { found in
                     if !result.contains(found) {
@@ -177,17 +166,14 @@ class UserDict: NSObject, DictProtocol {
     /**
      * ユーザー辞書にエントリを追加する。
      *
-     * プライベートモード時にはメモリ上に記録はされるが、通常モード時とは分けて記録しているため
-     * プライベートモード時に追加されたエントリはマイ辞書に永続化されないといった違いがある。
+     * プライベートモード時には追加を行わない。
      *
      * - Parameters:
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - word: SKK辞書の変換候補。
      */
     func add(yomi: String, word: Word) {
-        if privateMode.value {
-            privateUserDict.add(yomi: yomi, word: word)
-        } else if let dict = userDict as? FileDict {
+        if !privateMode.value, let dict = userDict as? FileDict {
             dict.add(yomi: yomi, word: word)
             savePublisher.send(())
         }
@@ -199,24 +185,20 @@ class UserDict: NSObject, DictProtocol {
      *  ユーザー辞書にないエントリ (ファイル辞書) の削除は無視されます。
      *  (ユーザー辞書に入力履歴があれば削除されるが、元のファイル辞書は更新されない)
      *
-     *  プライベートモードが有効なときの仕様はあんまり自信がないが、ひとまず次のように定義します。
      *  - 非プライベート時
-     *    - 非プライベートモード用の辞書からのみエントリを削除する
-     *    - もしプライベートモード用の辞書にエントリがあっても削除しない
+     *    - 非プライベートモード用のユーザー辞書からのみエントリを削除する
      *    - ファイル形式の辞書にだけエントリがあった場合はなにもしない
      *  - プライベートモード時
-     *    - プライベートモード用の辞書からのみエントリを削除する
-     *    - もし非プライベートモード用の辞書にエントリがあっても削除しない
-     *    - ファイル形式の辞書にだけエントリがあった場合はなにもしない
+     *    - なにもしない
      *
      *  - Parameters:
      *    - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *    - word: SKK辞書の変換候補。
-     *  - Returns: エントリを削除できたかどうか
+     *  - Returns: エントリを削除できたかどうか。プライベートモード時は常にtrue。
      */
     func delete(yomi: String, word: Word.Word) -> Bool {
         if privateMode.value {
-            return privateUserDict.delete(yomi: yomi, word: word)
+            return true
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 savePublisher.send(())
@@ -239,11 +221,6 @@ class UserDict: NSObject, DictProtocol {
      * - 数値変換用の読みは補完候補としない
      */
     func findCompletion(prefix: String) -> String? {
-        if privateMode.value {
-            if let completion = privateUserDict.findCompletion(prefix: prefix) {
-                return completion
-            }
-        }
         if let userDict {
             if let completion = userDict.findCompletion(prefix: prefix) {
                 return completion

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -70,6 +70,7 @@
 "Candidates font size" = "Candidates font size";
 "Annotation font size" = "Annotation font size";
 "Find completion from all dictionaries" = "Find completion from all dictionaries";
+"Ignore User Dict in Private Mode" = "Ignore User Dict in Private Mode";
 "Enter Key confirms a candidate and sends a newline" = "Enter Key confirms a candidate and sends a newline";
 "Insert Blank String" = "Insert Blank String";
 "Enabled" = "Enabled";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -70,6 +70,7 @@
 "Candidates font size" = "変換候補のフォントサイズ";
 "Annotation font size" = "注釈のフォントサイズ";
 "Find completion from all dictionaries" = "ユーザー辞書だけでなくすべての辞書から補完を探す";
+"Ignore User Dict in Private Mode" = "プライベートモードではユーザー辞書を参照しない";
 "Enter Key confirms a candidate and sends a newline" = "Enterキーで変換候補確定後に改行を入力";
 "Insert Blank String" = "空文字挿入";
 "Enabled" = "有効";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -60,7 +60,10 @@ struct macSKKApp: App {
             Global.privateMode.send(UserDefaults.standard.bool(forKey: UserDefaultsKeys.privateMode))
 
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
-            Global.dictionary = try UserDict(dicts: [], privateMode: Global.privateMode, findCompletionFromAllDicts: Global.findCompletionFromAllDicts)
+            Global.dictionary = try UserDict(dicts: [],
+                                             privateMode: Global.privateMode,
+                                             ignoreUserDictInPrivateMode: Global.ignoreUserDictInPrivateMode,
+                                             findCompletionFromAllDicts: Global.findCompletionFromAllDicts)
             settingsWindowController = NSWindowController(window: settingsWindow)
             self.settingsViewModel = settingsViewModel
             settingsWindowController.windowFrameAutosaveName = "Settings"

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -198,6 +198,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.selectingBackspace: SelectingBackspace.default.rawValue,
             UserDefaultsKeys.punctuation: Punctuation.default.rawValue,
             UserDefaultsKeys.privateMode: false,
+            UserDefaultsKeys.privateModeIgnoreUserDict: false,
         ])
     }
 

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -198,7 +198,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.selectingBackspace: SelectingBackspace.default.rawValue,
             UserDefaultsKeys.punctuation: Punctuation.default.rawValue,
             UserDefaultsKeys.privateMode: false,
-            UserDefaultsKeys.privateModeIgnoreUserDict: false,
+            UserDefaultsKeys.ignoreUserDictInPrivateMode: false,
         ])
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -16,6 +16,7 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor override func setUpWithError() throws {
         Global.dictionary.setEntries([:])
+        Global.privateMode.send(false)
         Global.skkservDict = nil
         cancellables = []
         // テストごとにローマ字かな変換ルールをデフォルトに戻す
@@ -2819,13 +2820,11 @@ final class StateMachineTests: XCTestCase {
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertNil(Global.dictionary.entries())
-        XCTAssertTrue(Global.dictionary.privateUserDict.entries.isEmpty)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "o")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(enterAction))
         XCTAssertNil(Global.dictionary.entries())
-        XCTAssertFalse(Global.dictionary.privateUserDict.entries.isEmpty)
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2371,6 +2371,7 @@ final class StateMachineTests: XCTestCase {
         let dict = MemoryDict(entries: ["あu": [Word("会"), Word("合")]], readonly: true)
         Global.dictionary = try UserDict(dicts: [dict],
                                          privateMode: CurrentValueSubject<Bool, Never>(false),
+                                         ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
                                          findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
         Global.dictionary.setEntries([:])
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
@@ -2394,6 +2395,7 @@ final class StateMachineTests: XCTestCase {
         let dict = MemoryDict(entries: ["あu": [Word("会"), Word("合")]], readonly: true)
         Global.dictionary = try UserDict(dicts: [dict],
                                          privateMode: CurrentValueSubject<Bool, Never>(false),
+                                         ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
                                          findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
         Global.dictionary.setEntries([:])
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
@@ -2420,6 +2422,7 @@ final class StateMachineTests: XCTestCase {
         let dict = MemoryDict(entries: ["あu": [Word("会"), Word("合")]], readonly: true)
         Global.dictionary = try UserDict(dicts: [dict],
                                          privateMode: CurrentValueSubject<Bool, Never>(false),
+                                         ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
                                          findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
         Global.dictionary.setEntries([:])
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
@@ -2807,7 +2810,11 @@ final class StateMachineTests: XCTestCase {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         // プライベートモードが有効ならユーザー辞書を参照はするが保存はしない
         let dict = MemoryDict(entries: ["と": [Word("都")]], readonly: true)
-        Global.dictionary = try UserDict(dicts: [dict], userDictEntries: [:], privateMode: privateMode, findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
+        Global.dictionary = try UserDict(dicts: [dict],
+                                         userDictEntries: [:],
+                                         privateMode: privateMode,
+                                         ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                         findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -9,17 +9,27 @@ import Combine
 final class UserDictTests: XCTestCase {
     func testRefer() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true)
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["い": [Word("井"), Word("伊")]], privateMode: privateMode, findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
+        let userDict = try UserDict(dicts: [dict1, dict2],
+                                    userDictEntries: ["い": [Word("井"), Word("伊")]],
+                                    privateMode: privateMode,
+                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+                                    findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊", "胃", "意"])
     }
 
     @MainActor func testReferMergeAnnotation() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: [:], privateMode: privateMode, findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
+        let userDict = try UserDict(dicts: [dict1, dict2],
+                                    userDictEntries: [:],
+                                    privateMode: privateMode,
+                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+                                    findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
         XCTAssertEqual(userDict.refer("い").map({ $0.word }), ["胃", "伊", "胃", "意"], "dict1, dict2に胃が1つずつある")
         XCTAssertEqual(userDict.refer("い").compactMap({ $0.annotation?.dictId }), ["dict1", "dict2"])
         XCTAssertEqual(userDict.referDicts("い").map({ $0.word }), ["胃", "伊", "意"])
@@ -28,6 +38,7 @@ final class UserDictTests: XCTestCase {
 
     func testReferWithOption() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let dict = MemoryDict(entries: ["あき>": [Word("空き")],
                                         "あき": [Word("秋")],
                                         ">し": [Word("氏")],
@@ -39,6 +50,7 @@ final class UserDictTests: XCTestCase {
                                                       ">し": [Word("詞")],
                                                       "し": [Word("士")]],
                                     privateMode: privateMode,
+                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
                                     findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false))
         XCTAssertEqual(userDict.refer("あき", option: nil), [Word("安芸"), Word("秋")])
         XCTAssertEqual(userDict.refer("あき", option: .prefix), [Word("飽き"), Word("空き")])
@@ -50,8 +62,13 @@ final class UserDictTests: XCTestCase {
 
     func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)
-        let userDict = try UserDict(dicts: [], userDictEntries: ["い": [Word("位")]], privateMode: privateMode, findCompletionFromAllDicts: findCompletionFromAllDicts)
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: ["い": [Word("位")]],
+                                    privateMode: privateMode,
+                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+                                    findCompletionFromAllDicts: findCompletionFromAllDicts)
         let word = Word("井")
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["位"])
         privateMode.send(true)
@@ -65,10 +82,15 @@ final class UserDictTests: XCTestCase {
 
     func testFindCompletionFromAllDicts() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
         let dict2 = MemoryDict(entries: ["にほんご": [Word("日本語")]], readonly: false)
-        let userDict = try UserDict(dicts: [dict1, dict2], userDictEntries: ["にふ": [Word("二歩")]], privateMode: privateMode, findCompletionFromAllDicts: findCompletionFromAllDicts)
+        let userDict = try UserDict(dicts: [dict1, dict2],
+                                    userDictEntries: ["にふ": [Word("二歩")]],
+                                    privateMode: privateMode,
+                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+                                    findCompletionFromAllDicts: findCompletionFromAllDicts)
         XCTAssertEqual(userDict.findCompletion(prefix: "に"), "にふ")
         XCTAssertNil(userDict.findCompletion(prefix: "にほ"))
         XCTAssertNil(userDict.findCompletion(prefix: "にほん"))

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -49,27 +49,20 @@ final class UserDictTests: XCTestCase {
     }
 
     func testPrivateMode() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(true)
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
         let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)
-        let userDict = try UserDict(dicts: [], userDictEntries: [:], privateMode: privateMode, findCompletionFromAllDicts: findCompletionFromAllDicts)
-        let word1 = Word("井")
-        let word2 = Word("伊")
+        let userDict = try UserDict(dicts: [], userDictEntries: ["い": [Word("位")]], privateMode: privateMode, findCompletionFromAllDicts: findCompletionFromAllDicts)
+        let word = Word("井")
+        XCTAssertEqual(userDict.refer("い").map { $0.word }, ["位"])
+        privateMode.send(true)
         // addのテスト
-        userDict.add(yomi: "い", word: word1)
-        XCTAssertEqual(userDict.privateUserDict.entries, ["い": [word1]])
-        userDict.add(yomi: "い", word: word2)
-        XCTAssertEqual(userDict.privateUserDict.entries, ["い": [word2, word1]])
-        userDict.add(yomi: "い", word: word1)
-        XCTAssertEqual(userDict.privateUserDict.entries, ["い": [word1, word2]])
-        // referのテスト
-        XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊"])
+        userDict.add(yomi: "い", word: word)
+        // referは変化しない
+        XCTAssertEqual(userDict.refer("い").map { $0.word }, ["位"])
         // deleteのテスト
         XCTAssertTrue(userDict.delete(yomi: "い", word: "井"))
-        XCTAssertEqual(userDict.refer("い").map { $0.word }, ["伊"])
-        // プライベートモードが解除されるとプライベートモードでのエントリがリセットされる
-        privateMode.send(false)
-        XCTAssertTrue(userDict.privateUserDict.entries.isEmpty)
     }
+
     func testFindCompletionFromAllDicts() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)


### PR DESCRIPTION
#250 プライベートモードでのユーザー辞書の参照・補完候補検索の仕様を変更します。
また、プライベートモードでユーザー辞書を参照しない設定を追加します (デフォルトOFF)

<img width="640" alt="image" src="https://github.com/user-attachments/assets/93eae67c-c1bc-4975-9d45-83c3219d0c7e" />

- 変換候補の参照順 (変換順や入力候補の検索順)
  - 現行
    - 通常時 ユーザー辞書→他の辞書の順で検索
    - プライベートモード: ユーザー辞書→プライベートモードで変換した候補→他の辞書の順で検索
  - このPR
    - 通常時 ユーザー辞書→他の辞書の順で検索 (変更なし)
    - プライベートモード: ユーザー辞書→他の辞書の順で検索 (通常時と同じ)
    - プライベートモード + ユーザー辞書を参照しない設定: 他の辞書を検索