### PR TITLE
LSBackgroundOnlyを設定する

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ ${CONFIGURATION} = \"Release\" ]; then\n    /usr/libexec/PlistBuddy -c \"Add LSUIElement BOOL YES\" \"${TEMP_DIR}/Preprocessed-Info.plist\"\nfi\n";
+			shellScript = "if [ ${CONFIGURATION} = \"Release\" ]; then\n    /usr/libexec/PlistBuddy -c \"Add LSUIElement BOOL YES\" \"${TEMP_DIR}/Preprocessed-Info.plist\"\n    /usr/libexec/PlistBuddy -c \"Add LSBackgroundOnly BOOL YES\" \"${TEMP_DIR}/Preprocessed-Info.plist\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
#112 の時々入力メニューで無効になってしまう対策になるかどうかはわからないけど他のアプリを見ていて気になったところをいじってみます。
Info.plistでLSBackgroundOnlyをYESに設定します。
↓のドキュメントを読む限り「UIもたないアプリ用」ぽく見えるのですが、mozcやAquaSKKなども設定しているのでまあいいのかなと。

https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-109268