### PR TITLE
FileDictをSwift Concurrency対応

### DIFF
--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -29,7 +29,7 @@ struct DictLoadEvent {
     let status: DictLoadStatus
 }
 
-@MainActor protocol DictProtocol {
+protocol DictProtocol {
     /**
      * 辞書を引き変換候補順に返す
      *
@@ -39,7 +39,7 @@ struct DictLoadEvent {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - option: 辞書を引くときに接頭辞、接尾辞や送り仮名ブロックから検索するかどうか。nilなら通常のエントリから検索する
      */
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word]
+    @MainActor func refer(_ yomi: String, option: DictReferringOption?) -> [Word]
 
     /**
      * 辞書にエントリを追加する。
@@ -48,7 +48,7 @@ struct DictLoadEvent {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - word: SKK辞書の変換候補。
      */
-    mutating func add(yomi: String, word: Word)
+    @MainActor mutating func add(yomi: String, word: Word)
 
     /**
      * 辞書からエントリを削除する。
@@ -60,7 +60,7 @@ struct DictLoadEvent {
      *   - word: SKK辞書の変換候補。
      * - Returns: エントリを削除できたかどうか
      */
-    mutating func delete(yomi: String, word: Word.Word) -> Bool
+    @MainActor mutating func delete(yomi: String, word: Word.Word) -> Bool
 
     /**
      * 現在入力中のprefixに続く入力候補を1つ返す。見つからなければnilを返す。
@@ -73,5 +73,5 @@ struct DictLoadEvent {
      * - prefixと読みが完全に一致する場合は補完候補とはしない
      * - 数値変換用の読みは補完候補としない
      */
-    func findCompletion(prefix: String) -> String?
+    @MainActor func findCompletion(prefix: String) -> String?
 }

--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -29,7 +29,7 @@ struct DictLoadEvent {
     let status: DictLoadStatus
 }
 
-protocol DictProtocol {
+@MainActor protocol DictProtocol {
     /**
      * 辞書を引き変換候補順に返す
      *

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -238,11 +238,11 @@ enum FileDictType: Equatable {
     var failedEntryCount: Int { return dict.failedEntryCount }
 
     // MARK: DictProtocol
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
+    @MainActor func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
         return dict.refer(yomi, option: option)
     }
 
-    func add(yomi: String, word: Word) {
+    @MainActor func add(yomi: String, word: Word) {
         dict.add(yomi: yomi, word: word)
         NotificationCenter.default.post(name: notificationNameDictLoad,
                                         object: DictLoadEvent(id: self.id,
@@ -250,7 +250,7 @@ enum FileDictType: Equatable {
         hasUnsavedChanges = true
     }
 
-    func delete(yomi: String, word: Word.Word) -> Bool {
+    @MainActor func delete(yomi: String, word: Word.Word) -> Bool {
         if dict.delete(yomi: yomi, word: word) {
             hasUnsavedChanges = true
             NotificationCenter.default.post(name: notificationNameDictLoad,
@@ -261,7 +261,7 @@ enum FileDictType: Equatable {
         return false
     }
 
-    func findCompletion(prefix: String) -> String? {
+    @MainActor func findCompletion(prefix: String) -> String? {
         return dict.findCompletion(prefix: prefix)
     }
 
@@ -277,10 +277,6 @@ extension FileDict: NSFilePresenter {
     // どちらも同じ辞書ファイルを監視しているので、Aが保存してもAのpresentedItemDidChangeは呼び出されないが、
     // BのpresentedItemDidChangeは呼び出される。
     nonisolated func presentedItemDidChange() {
-        guard let version = NSFileVersion.currentVersionOfItem(at: fileURL) else {
-            logger.error("辞書 \(self.id, privacy: .public) のバージョンが存在しません")
-            return
-        }
         logger.log("辞書 \(self.id, privacy: .public) が変更されたので読み込みます")
         load(fileURL: self.fileURL)
     }

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// 実ファイルをもたないSKK辞書
-struct MemoryDict: DictProtocol {
+struct MemoryDict: DictProtocol, Sendable {
     /**
      * 読み込み専用で保存しないかどうか
      *

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -488,8 +488,10 @@ final class SettingsViewModel: ObservableObject {
                 if let userDict = Global.dictionary.userDict as? FileDict, userDict.id == loadEvent.id {
                     self.userDictLoadingStatus = loadEvent.status
                     if case .fail(let error) = loadEvent.status {
+                        logger.error("辞書 \(loadEvent.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")
                         UNNotifier.sendNotificationForUserDict(readError: error)
-                    } else if case .loaded(_, let failureCount) = loadEvent.status, failureCount > 0 {
+                    } else if case .loaded(let successCount, let failureCount) = loadEvent.status, failureCount > 0 {
+                        logger.log("辞書 \(loadEvent.id, privacy: .public) から \(successCount) エントリ読み込みました")
                         UNNotifier.sendNotificationForUserDict(failureEntryCount: failureCount)
                     }
                 } else {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -304,6 +304,9 @@ final class SettingsViewModel: ObservableObject {
                 return Future<[FileDict], Never>() { promise in
                     Task {
                         for dictSetting in dictSettings {
+                            if !dictSetting.enabled {
+                                continue
+                            }
                             let dict = Global.dictionary.fileDict(id: dictSetting.id)
                             // 無効だった辞書が有効化された、もしくは辞書のエンコーディング設定が変わったら読み込む
                             if dictSetting.type.encoding != dict?.type.encoding {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -298,34 +298,37 @@ final class SettingsViewModel: ObservableObject {
         Global.ignoreUserDictInPrivateMode.send(ignoreUserDictInPrivateMode)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
-        $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
-            let enabledDicts = dictSettings.compactMap { dictSetting -> FileDict? in
-                let dict = Global.dictionary.fileDict(id: dictSetting.id)
-                if dictSetting.enabled {
-                    // 無効だった辞書が有効化された、もしくは辞書のエンコーディング設定が変わったら読み込む
-                    if dictSetting.type.encoding != dict?.type.encoding {
-                        let fileURL = dictionariesDirectoryUrl.appendingPathComponent(dictSetting.filename)
-                        do {
-                            logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
-                            let fileDict = try FileDict(contentsOf: fileURL, type: dictSetting.type, readonly: true)
-                            logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
-                            return fileDict
-                        } catch {
-                            dictSetting.enabled = false
-                            logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の読み込みに失敗しました!: \(error)")
-                            return nil
+        $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).flatMap { dictSettings in
+            Deferred {
+                var fileDicts: [FileDict] = []
+                return Future<[FileDict], Never>() { promise in
+                    Task {
+                        for dictSetting in dictSettings {
+                            let dict = Global.dictionary.fileDict(id: dictSetting.id)
+                            // 無効だった辞書が有効化された、もしくは辞書のエンコーディング設定が変わったら読み込む
+                            if dictSetting.type.encoding != dict?.type.encoding {
+                                let fileURL = dictionariesDirectoryUrl.appendingPathComponent(dictSetting.filename)
+                                do {
+                                    logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
+                                    let fileDict = FileDict(contentsOf: fileURL, type: dictSetting.type, readonly: true)
+                                    try await fileDict.load(fileURL: fileURL)
+                                    logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
+                                    fileDicts.append(fileDict)
+                                } catch {
+                                    dictSetting.enabled = false
+                                    logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の読み込みに失敗しました!: \(error)")
+                                }
+                            } else if let dict {
+                                // 変更がないのでそのまま
+                                fileDicts.append(dict)
+                            }
                         }
-                    } else {
-                        return dict
+                        promise(.success(fileDicts))
                     }
-                } else {
-                    if dict != nil {
-                        logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を無効化します")
-                    }
-                    return nil
                 }
             }
-            Global.dictionary.dicts = enabledDicts
+        }.sink { fileDicts in
+            Global.dictionary.dicts = fileDicts
             UserDefaults.standard.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
         }
         .store(in: &cancellables)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -54,12 +54,8 @@ import Foundation
                 logger.log("ユーザー辞書ファイルがないため作成します")
                 try Data().write(to: userDictFileURL, options: .withoutOverwriting)
             }
-            do {
-                let userDict = try FileDict(contentsOf: userDictFileURL, type: .traditional(.utf8), readonly: false)
-                self.userDict = userDict
-            } catch {
-                self.userDict = nil
-            }
+            let userDict = FileDict(contentsOf: userDictFileURL, type: .traditional(.utf8), readonly: false)
+            self.userDict = userDict
         }
         super.init()
         NSFileCoordinator.addFilePresenter(self)
@@ -87,6 +83,12 @@ import Foundation
 
     deinit {
         NSFileCoordinator.removeFilePresenter(self)
+    }
+
+    func load() async throws {
+        if let userDict = userDict as? FileDict {
+            try await userDict.load(fileURL: userDictFileURL)
+        }
     }
 
     /**

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -105,7 +105,7 @@ import Foundation
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - option: 辞書を引くときに接頭辞や接尾辞から検索するかどうか。nilなら通常のエントリから検索する
      */
-    @MainActor func referDicts(_ yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
+    func referDicts(_ yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
         var result: [Candidate] = []
         var candidates = refer(yomi, option: option).map { word in
             let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -104,6 +104,9 @@ struct macSKKApp: App {
             setupDirectMode()
             setupSettingsNotification()
         }
+        Task {
+            try await Global.dictionary.load()
+        }
     }
 
     var body: some Scene {

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -10,13 +10,13 @@ final class FileDictTests: XCTestCase {
     let fileURL = Bundle(for: FileDictTests.self).url(forResource: "empty", withExtension: "txt")!
     var cancellables: Set<AnyCancellable> = []
 
-    func testLoadContainsBom() throws {
+    @MainActor func testLoadContainsBom() throws {
         let fileURL = Bundle(for: Self.self).url(forResource: "utf8-bom", withExtension: "txt")!
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
         XCTAssertEqual(dict.dict.entries, ["ゆにこーど": [Word("ユニコード")]])
     }
 
-    func testLoadJson() throws {
+    @MainActor func testLoadJson() throws {
         let expectation = XCTestExpectation()
         NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { notification in
             if let loadEvent = notification.object as? DictLoadEvent {
@@ -34,7 +34,7 @@ final class FileDictTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testLoadJsonBroken() throws {
+    @MainActor func testLoadJsonBroken() throws {
         let expectation = XCTestExpectation()
         NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { notification in
             if let loadEvent = notification.object as? DictLoadEvent {
@@ -48,7 +48,7 @@ final class FileDictTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testAdd() throws {
+    @MainActor func testAdd() throws {
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
         XCTAssertEqual(dict.entryCount, 0)
         let word = Word("井")
@@ -58,7 +58,7 @@ final class FileDictTests: XCTestCase {
         XCTAssertTrue(dict.hasUnsavedChanges)
     }
 
-    func testDelete() throws {
+    @MainActor func testDelete() throws {
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
         dict.setEntries(["あr": [Word("有"), Word("在")]], readonly: true)
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
@@ -67,7 +67,7 @@ final class FileDictTests: XCTestCase {
         XCTAssertTrue(dict.hasUnsavedChanges)
     }
 
-    func testSerialize() throws {
+    @MainActor func testSerialize() throws {
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: false)
         XCTAssertEqual(dict.serialize(),
                        [FileDict.headers[0], FileDict.okuriAriHeader, FileDict.okuriNashiHeader, ""].joined(separator: "\n"))

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -10,13 +10,14 @@ final class FileDictTests: XCTestCase {
     let fileURL = Bundle(for: FileDictTests.self).url(forResource: "empty", withExtension: "txt")!
     var cancellables: Set<AnyCancellable> = []
 
-    @MainActor func testLoadContainsBom() throws {
+    @MainActor func testLoadContainsBom() async throws {
         let fileURL = Bundle(for: Self.self).url(forResource: "utf8-bom", withExtension: "txt")!
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        let dict = FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        try await dict.load(fileURL: fileURL)
         XCTAssertEqual(dict.dict.entries, ["ゆにこーど": [Word("ユニコード")]])
     }
 
-    @MainActor func testLoadJson() throws {
+    @MainActor func testLoadJson() async throws {
         let expectation = XCTestExpectation()
         NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { notification in
             if let loadEvent = notification.object as? DictLoadEvent {
@@ -28,13 +29,13 @@ final class FileDictTests: XCTestCase {
             }
         }.store(in: &cancellables)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json")!
-        let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true)
+        let dict = FileDict(contentsOf: fileURL, type: .json, readonly: true)
+        try await dict.load(fileURL: fileURL)
         XCTAssertEqual(dict.dict.refer("い", option: nil).map({ $0.word }).sorted(), ["伊", "胃"])
         XCTAssertEqual(dict.dict.refer("あr", option: nil).map({ $0.word }).sorted(), ["在;注釈として解釈されない", "有"])
-        wait(for: [expectation], timeout: 1.0)
     }
 
-    @MainActor func testLoadJsonBroken() throws {
+    @MainActor func testLoadJsonBroken() async throws {
         let expectation = XCTestExpectation()
         NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { notification in
             if let loadEvent = notification.object as? DictLoadEvent {
@@ -44,12 +45,18 @@ final class FileDictTests: XCTestCase {
             }
         }.store(in: &cancellables)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.broken", withExtension: "json")!
-        _ = try FileDict(contentsOf: fileURL, type: .json, readonly: true)
-        wait(for: [expectation], timeout: 1.0)
+        let dict = FileDict(contentsOf: fileURL, type: .json, readonly: true)
+        do {
+            try await dict.load(fileURL: fileURL)
+            XCTFail("エラーが発生するはずなのに発生していない")
+        } catch {
+            // OK
+        }
     }
 
-    @MainActor func testAdd() throws {
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+    @MainActor func testAdd() async throws {
+        let dict = FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        try await dict.load(fileURL: fileURL)
         XCTAssertEqual(dict.entryCount, 0)
         let word = Word("井")
         XCTAssertFalse(dict.hasUnsavedChanges)
@@ -58,8 +65,9 @@ final class FileDictTests: XCTestCase {
         XCTAssertTrue(dict.hasUnsavedChanges)
     }
 
-    @MainActor func testDelete() throws {
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+    @MainActor func testDelete() async throws {
+        let dict = FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        try await dict.load(fileURL: fileURL)
         dict.setEntries(["あr": [Word("有"), Word("在")]], readonly: true)
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
         XCTAssertFalse(dict.hasUnsavedChanges)
@@ -67,8 +75,9 @@ final class FileDictTests: XCTestCase {
         XCTAssertTrue(dict.hasUnsavedChanges)
     }
 
-    @MainActor func testSerialize() throws {
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: false)
+    @MainActor func testSerialize() async throws {
+        let dict = FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: false)
+        try await dict.load(fileURL: fileURL)
         XCTAssertEqual(dict.serialize(),
                        [FileDict.headers[0], FileDict.okuriAriHeader, FileDict.okuriNashiHeader, ""].joined(separator: "\n"))
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -89,7 +89,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertNil(dict.entries["から"])
     }
 
-    func testAdd() throws {
+    @MainActor func testAdd() throws {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertEqual(dict.entryCount, 0)
         let word1 = Word("井")
@@ -120,7 +120,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.refer("いt", option: nil), [Word("行", okuri: "った"), Word("行")])
     }
 
-    func testDelete() throws {
+    @MainActor func testDelete() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")], "え": [Word("絵"), Word("柄")]], readonly: false)
         XCTAssertFalse(dict.entries.isEmpty)
         XCTAssertEqual(dict.okuriAriYomis, ["あr"])
@@ -145,14 +145,14 @@ class MemoryDictTests: XCTestCase {
         XCTAssertTrue(dict.entries.isEmpty)
     }
 
-    func testDeleteOkuriBlock() throws {
+    @MainActor func testDeleteOkuriBlock() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有", okuri: "る"), Word("有", okuri: "り"), Word("有")]], readonly: false)
         XCTAssertTrue(dict.delete(yomi: "あr", word: "有"))
         XCTAssertEqual(dict.refer("あr", option: nil), [], "あr を読みとして持つ変換候補が全て削除された")
         XCTAssertEqual(dict.okuriAriYomis, [])
     }
 
-    func testFindCompletion() throws {
+    @MainActor func testFindCompletion() throws {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertNil(dict.findCompletion(prefix: ""), "辞書が空だとnil")
         dict.add(yomi: "あいうえおか", word: Word("アイウエオカ"))
@@ -166,7 +166,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertNil(dict.findCompletion(prefix: "だい"), "数値変換の読みはnil")
     }
 
-    func testReferWithOption() {
+    @MainActor func testReferWithOption() {
         let dict = MemoryDict(entries: ["あき>": [Word("空き")],
                                         "あき": [Word("秋")],
                                         ">し": [Word("氏")],

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -7,7 +7,7 @@ import Combine
 @testable import macSKK
 
 final class UserDictTests: XCTestCase {
-    func testRefer() throws {
+    @MainActor func testRefer() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true)
         let userDict = try UserDict(dicts: [dict1, dict2],
@@ -32,7 +32,7 @@ final class UserDictTests: XCTestCase {
         XCTAssertEqual(userDict.referDicts("い").map({ $0.annotations.map({ $0.dictId }) }), [["dict1", "dict2"], [], []])
     }
 
-    func testReferWithOption() throws {
+    @MainActor func testReferWithOption() throws {
         let dict = MemoryDict(entries: ["あき>": [Word("空き")],
                                         "あき": [Word("秋")],
                                         ">し": [Word("氏")],
@@ -54,7 +54,7 @@ final class UserDictTests: XCTestCase {
         XCTAssertEqual(userDict.refer("し", option: .prefix), [])
     }
 
-    func testPrivateMode() throws {
+    @MainActor func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let userDict = try UserDict(dicts: [],
                                     userDictEntries: ["い": [Word("位")]],
@@ -72,7 +72,7 @@ final class UserDictTests: XCTestCase {
         XCTAssertTrue(userDict.delete(yomi: "い", word: "井"))
     }
 
-    func testFindCompletionPrivateMode() throws {
+    @MainActor func testFindCompletionPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(true)
         let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
@@ -92,7 +92,7 @@ final class UserDictTests: XCTestCase {
         XCTAssertEqual(userDict.findCompletion(prefix: "に"), "にふ")
     }
 
-    func testFindCompletionFromAllDicts() throws {
+    @MainActor func testFindCompletionFromAllDicts() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let findCompletionFromAllDicts = CurrentValueSubject<Bool, Never>(false)


### PR DESCRIPTION
UserDictやFileDictでSwift Concurrency対応してSwift 6でコンパイルエラーになるという警告が出ないように修正します。

辞書の参照や単語の追加削除は基本的には `@MainActor` にしていくだけなのですが、読み込みだけは時間がかかるため別スレッドでの実行を可能にする必要があります。
そのためnonisolatedなメソッド `FileDict#load` を生やし、読み込み処理はそちらにもっていきます。
nonisolatedなメソッド内でメンバ変数dictを設定する必要があり、そのためにasyncメソッドにしています。