### PR TITLE
CIでxcbeautifyを使う

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths-ignore:
       - '*.md'
+      - '.github/workflows/update.yml'
 
 # bashを使うようにしてpipefailを有効にする
 # https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
@@ -20,8 +21,6 @@ defaults:
 jobs:
   test:
     runs-on: macos-15
-    permissions:
-      checks: write
     steps:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode
     - name: Select Xcode version
@@ -29,4 +28,4 @@ jobs:
     - uses: actions/checkout@v4
     - name: test
       run: |
-        xcodebuild -target macSKKTests -scheme macSKK DEVELOPMENT_TEAM= test | xcpretty
+        xcodebuild -target macSKKTests -scheme macSKK DEVELOPMENT_TEAM= test | xcbeautify


### PR DESCRIPTION
GitHub ActionsのmacOS Runnerにxcprettyだけでなくxcbeautifyが入っていたのでそっちを使うようにします。
https://github.com/actions/runner-images/issues/8827

xcprettyはRunnerのツールリストから消えてた。
https://github.com/erik-bershel/runner-images/blob/004bb48b9e2748205d91182a2ff8a2e0b04e65ad/images/macos/toolsets/toolset-15.json#L83