### PR TITLE
左右移動でOptionキーを任意修飾キーに追加

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -229,10 +229,10 @@ struct KeyBinding: Identifiable, Hashable {
                 return KeyBinding(action, [Input(key: .code(0x35), modifierFlags: []),
                                            Input(key: .character("g"), modifierFlags: .control)])
             case .left:
-                return KeyBinding(action, [Input(key: .code(0x7b), modifierFlags: .function, optionalModifierFlags: [.shift]),
+                return KeyBinding(action, [Input(key: .code(0x7b), modifierFlags: .function, optionalModifierFlags: [.shift, .option]),
                                            Input(key: .character("b"), modifierFlags: .control)])
             case .right:
-                return KeyBinding(action, [Input(key: .code(0x7c), modifierFlags: .function, optionalModifierFlags: [.shift]),
+                return KeyBinding(action, [Input(key: .code(0x7c), modifierFlags: .function, optionalModifierFlags: [.shift, .option]),
                                            Input(key: .character("f"), modifierFlags: .control)])
             case .down:
                 return KeyBinding(action, [Input(key: .code(0x7d), modifierFlags: .function, optionalModifierFlags: [.shift]),


### PR DESCRIPTION
#272 `Option + ←` と `Option + →` をデフォルトで左右移動として扱うようにします。
入力中じゃないときにこれまではmacSKKが吸ってたんですが、これで吸われなくなります。