### PR TITLE
BackspaceでOptionキーを任意修飾キーに追加

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -220,7 +220,7 @@ struct KeyBinding: Identifiable, Hashable {
             case .tab:
                 return KeyBinding(action, [Input(key: .code(0x30), modifierFlags: [], optionalModifierFlags: .shift)])
             case .backspace:
-                return KeyBinding(action, [Input(key: .code(0x33), modifierFlags: [], optionalModifierFlags: .shift),
+                return KeyBinding(action, [Input(key: .code(0x33), modifierFlags: [], optionalModifierFlags: [.shift, .option]),
                                            Input(key: .character("h"), modifierFlags: .control)])
             case .delete:
                 return KeyBinding(action, [Input(key: .code(0x75), modifierFlags: .function),


### PR DESCRIPTION
#272 SafariのテキストフィールドでOption + Backspaceを打つと単語削除ではなく `0x08` が入力されてしまいます (ASCII CODEのBS)。
#274 と同様にBackspaceのデフォルト設定でOptionキーを任意修飾キーに追加します。