### PR TITLE
マルチスクリーン対応

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -161,9 +161,7 @@ class InputController: IMKInputController {
                 if let completion = Global.dictionary.findCompletion(prefix: yomi) {
                     self.stateMachine.completion = (yomi, completion)
                     Global.completionPanel.viewModel.completion = completion
-                    // 下線分1ピクセル下に余白を設ける
-                    let cursorPosition = self.cursorPosition.offsetBy(dx: 0, dy: -1)
-                    Global.completionPanel.show(at: cursorPosition.origin, windowLevel: self.windowLevel)
+                    Global.completionPanel.show(at: self.cursorPosition, windowLevel: self.windowLevel)
                 } else {
                     self.stateMachine.completion = nil
                     Global.completionPanel.orderOut(nil)

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -95,17 +95,15 @@ final class CandidatesPanel: NSPanel {
         }
         setContentSize(NSSize(width: width, height: height))
         if let mainScreen = NSScreen.main {
-            // スクリーン右にはみ出す場合はスクリーン右端に接するように表示する
-            if origin.x + width > mainScreen.visibleFrame.size.width {
-                origin.x = mainScreen.frame.size.width - width
+            let visibleFrame = mainScreen.visibleFrame
+            if origin.x + width > visibleFrame.minX + visibleFrame.width {
+                origin.x = visibleFrame.minX + visibleFrame.width - width
+            }
+            if origin.y - height < visibleFrame.minY {
+                origin.y = cursorPosition.maxY + height
             }
         }
-        if origin.y > height {
-            setFrameTopLeftPoint(origin)
-        } else {
-            // スクリーン下にはみ出す場合はテキスト入力位置の上に表示する
-            setFrameOrigin(CGPoint(x: origin.x, y: origin.y + cursorPosition.size.height))
-        }
+        setFrameTopLeftPoint(origin)
         level = windowLevel
         orderFrontRegardless()
     }

--- a/macSKK/View/CandidatesPanel.swift
+++ b/macSKK/View/CandidatesPanel.swift
@@ -44,7 +44,7 @@ final class CandidatesPanel: NSPanel {
     func setCursorPosition(_ cursorPosition: NSRect) {
         self.cursorPosition = cursorPosition
         if let mainScreen = NSScreen.main {
-            viewModel.maxWidth = mainScreen.visibleFrame.size.width - cursorPosition.origin.x
+            viewModel.maxWidth = mainScreen.visibleFrame.minX + mainScreen.visibleFrame.size.width - cursorPosition.origin.x
         }
     }
 

--- a/macSKK/View/CompletionPanel.swift
+++ b/macSKK/View/CompletionPanel.swift
@@ -15,9 +15,23 @@ class CompletionPanel: NSPanel {
         contentViewController = viewController
     }
 
-    func show(at point: NSPoint, windowLevel: NSWindow.Level) {
+    func show(at cursorPoint: NSRect, windowLevel: NSWindow.Level) {
         level = windowLevel
-        setFrameTopLeftPoint(point)
+        var origin = cursorPoint.origin
+        
+        if let size = contentViewController?.view.frame.size, let mainScreen = NSScreen.main {
+            let visibleFrame = mainScreen.visibleFrame
+            if origin.x + size.width > visibleFrame.minX + visibleFrame.width {
+                origin.x = visibleFrame.minX + visibleFrame.width - size.width
+            }
+            // 1ピクセルの余白を設ける
+            if origin.y - size.height < visibleFrame.minY {
+                origin.y = origin.y + size.height + cursorPoint.height + 1
+            } else {
+                origin.y -= 1
+            }
+        }
+        setFrameTopLeftPoint(origin)
         orderFrontRegardless()
     }
 }


### PR DESCRIPTION
マルチスクリーンを使ったときに、入力カーソルがスクリーンの境目のあたりにあると候補一覧や tab completion の表示が切れてしまう場合があるので軽くに修正しました。

いろんなケースはありますが、secondary screen が左にあった場合の位置関係は以下の感じです。

```
      ------------------------------------------------
      |                        |                     |
      |    secondary screen    |      main screen    |
      |             入力カーソル_ |                     |
      | -----------------------|----------------------
(-1024, 0)                   (0, 0)
```

候補一覧 ↓ ページカウントの位置計算はもともとあった問題、且ついい方法をまだみつかってないので一旦候補一覧 view を基ついての計算にしてます。
<img width="372" alt="Screenshot 2025-01-07 at 16 39 10" src="https://github.com/user-attachments/assets/12a77f27-683b-45be-afc4-f4dec1a7547c" />

tab completion ↓
<img width="221" alt="Screenshot 2025-01-07 at 16 40 07" src="https://github.com/user-attachments/assets/81a620db-f905-4b0e-8c55-bee249514dde" />

