### PR TITLE
fix: enable slach in composing mode

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -746,9 +746,9 @@ final class StateMachine {
                 updateMarkedText()
             }
             return true
-        case .abbrev, .up, .down, .registerPaste, .eisu, .kana:
+        case .up, .down, .registerPaste, .eisu, .kana:
             return true
-        case .unregister, .backwardCandidate, .none:
+        case .abbrev, .unregister, .backwardCandidate, .none:
             break
         }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -906,7 +906,7 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
     
-    @MainActor func testHandleAbbrevSlash() {
+    @MainActor func testHandleComposingAbbrevSlash() {
         Global.dictionary.setEntries(["/": [Word("／")]])
 
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))


### PR DESCRIPTION
https://github.com/mtgto/macSKK/issues/280 を修正してみました。StateMachine 完全理解はできてませんのでやりかた間違ってるかもしれません。