### PR TITLE
TISGetInputSourcePropertyで取得したInputSource配列をretainする

### DIFF
--- a/macSKK/InputSource.swift
+++ b/macSKK/InputSource.swift
@@ -26,9 +26,8 @@ struct InputSource: Hashable, Identifiable {
             guard let id = getStringProperty(inputSource, key: kTISPropertyInputSourceID) else { return nil }
             guard let localizedName = getStringProperty(inputSource, key: kTISPropertyLocalizedName) else { return nil }
             // 第一言語が英語じゃないものは弾く。
-            // APIドキュメントには特に書いてないけどCFGetRetainCountで見るとretainedな値を返してそうなのでtakeRetainedValueで変換
             if let languagesPointer = TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceLanguages),
-               let languages = Unmanaged<CFArray>.fromOpaque(languagesPointer).takeRetainedValue() as? Array<String> {
+               let languages = Unmanaged<CFArray>.fromOpaque(languagesPointer).takeUnretainedValue() as? Array<String> {
                 if let first = languages.first {
                     if first != "en" {
                         return nil
@@ -41,6 +40,6 @@ struct InputSource: Hashable, Identifiable {
 
     static func getStringProperty(_ tisInputSource: TISInputSource, key: NSString) -> String? {
         guard let pointer = TISGetInputSourceProperty(tisInputSource, key) else { return nil }
-        return unsafeBitCast(pointer, to: CFString.self) as String
+        return String(Unmanaged<CFString>.fromOpaque(pointer).takeUnretainedValue())
     }
 }


### PR DESCRIPTION
#258 を入れた結果、macOS 15.2でmacSKK v1.6.1の設定画面を開き一般とそれ以外を何度か切り換えると画面が変わらなくなる問題がありました。
デバッグモードで起動してみたところ、以下のような警告とエラーが出ていたのでmacSKK側でretainするように修正します。

```
-[__NSCFString count]: unrecognized selector sent to instance 0x60000085d080
(
	0   CoreFoundation                      0x000000019c49ae80 __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x000000019bf82cd8 objc_exception_throw + 88
	2   CoreFoundation                      0x000000019c5501d8 -[NSObject(NSObject) __retain_OA] + 0
	3   CoreFoundation                      0x000000019c407820 ___forwarding___ + 1568
	4   CoreFoundation                      0x000000019c407140 _CF_forwarding_prep_0 + 96
	5   Foundation                          0x000000019d8162a0 $ss21_arrayConditionalCastySayq_GSgSayxGr0_lFSayyXlGACyXlRszr0_lIetgo_Tp5 + 960
	6   Foundation                          0x000000019d893474 $sSa10FoundationE34_conditionallyBridgeFromObjectiveC_6resultSbSo7NSArrayC_SayxGSgztFZ + 100
	7   libswiftCore.dylib                  0x00000001ad10ad6c $ss45_conditionallyBridgeFromObjectiveC_bridgeableyxSg01_D5CTypeQz_xmts01_D11CBridgeableRzlF + 128
	8   macSKK.debug.dylib                  0x000000010197afe8 $s6macSKK11InputSourceV5fetchSayACGSgyFZACSgSo08TISInputD3RefaXEfU_ + 828
	9   macSKK.debug.dylib                  0x000000010197b204 $s6macSKK11InputSourceV5fetchSayACGSgyFZACSgSo08TISInputD3RefaXEfU_TA + 16
	10  libswiftCore.dylib                  0x00000001ad347abc $sSTsE10compactMapySayqd__Gqd__Sg7ElementQzKXEKlFTm + 1292
	11  libswiftCore.dylib                  0x00000001ad2b32d0 $sSTsE10compactMapySayqd__Gqd__Sg7ElementQzKXEKlF + 16
	12  macSKK.debug.dylib                  0x000000010197aabc $s6macSKK11InputSourceV5fetchSayACGSgyFZ + 1196
	13  macSKK.debug.dylib                  0x00000001019486ec $s6macSKK17SettingsViewModelC16loadInputSourcesyyF + 60
	14  macSKK.debug.dylib                  0x0000000101a1fe4c $s6macSKK11GeneralViewV4bodyQrvgyycfU0_ + 68
	15  SwiftUICore                         0x000000023b9fcb00 $s7SwiftUI25_AppearanceActionModifierV9MergedBox33_3EDE22C3B37C9BBEF12EC9D1A4B340F3LLC6updateyyFyycfU_ + 96
	16  SwiftUICore                         0x000000023b849118 $sIg_Ieg_TR + 28
	17  SwiftUICore                         0x000000023b849f6c $s7SwiftUI6UpdateO15dispatchActionsyyFZ + 1236
	18  SwiftUICore                         0x000000023b849450 $s7SwiftUI6UpdateO3endyyFZ + 212
	19  SwiftUICore                         0x000000023bd736e0 $sSo9NSRunLoopC7SwiftUIE11addObserveryyyycFZySo05CFRunbF3RefaSg_So0gB8ActivityVSvSgtcfU_Tf4ddd_n + 176
	20  CoreFoundation                      0x000000019c427bd8 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 36
	21  CoreFoundation                      0x000000019c427ac4 __CFRunLoopDoObservers + 552
	22  CoreFoundation                      0x000000019c426770 CFRunLoopRunSpecific + 664
	23  HIToolbox                           0x00000001a797e530 RunCurrentEventLoopInMode + 292
	24  HIToolbox                           0x00000001a798417c ReceiveNextEventCommon + 216
	25  HIToolbox                           0x00000001a7984508 _BlockUntilNextEventMatchingListInModeWithFilter + 76
	26  AppKit                              0x000000019ff91034 _DPSNextEvent + 660
	27  AppKit                              0x00000001a08f52d4 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 688
	28  AppKit                              0x000000019ff84060 -[NSApplication run] + 480
	29  AppKit                              0x000000019ff5a854 NSApplicationMain + 888
	30  SwiftUI                             0x00000001cb077a6c $s7SwiftUI6runAppys5NeverOSo21NSApplicationDelegate_So11NSResponderCXcFTf4e_nAA07TestingdG0C_Tg5Tm + 160
	31  SwiftUI                             0x00000001cb4eb3f8 $s7SwiftUI6runAppys5NeverOxAA0D0RzlF + 140
	32  SwiftUI                             0x00000001cb866f38 $s7SwiftUI3AppPAAE4mainyyFZ + 224
	33  macSKK.debug.dylib                  0x00000001019dc7c8 $s6macSKK0A6SKKAppV5$mainyyFZ + 40
	34  macSKK.debug.dylib                  0x00000001019dc808 __debug_main_executable_dylib_entry_point + 12
	35  dyld                                0x000000019bfc0274 start + 2840
)
FAULT: NSInvalidArgumentException: -[__NSCFString count]: unrecognized selector sent to instance 0x60000085d080; (user info absent)
```