### PR TITLE
デフォルトのローマ字かな変換ルールに "n,ん" を追加

### DIFF
--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -266,6 +266,8 @@ struct Romaji: Equatable, Sendable {
      *
      * - "ka" が入力されたら確定文字 "か" と残りのローマ字文字列 "" を返す
      * - "k" が入力されたら確定文字はnil, 残りのローマ字文字列 "k" を返す
+     * - "n" が入力されたらこのあとに子音が続くまでは「ん」とならないので確定文字はnil
+     * - "nk" のようにn + 子音が入力されたら確定文字 "ん" と残りのローマ字文字列 "k" を返す
      * - "kt" のように連続できない子音が連続したinputの場合は"k"を捨てて"t"をinput引数としたときのconvertの結果を返す
      * - "kya" のように確定した文字が複数の場合がありえる
      * - "aiueo" のように複数の確定が可能な場合は最初に確定できた文字だけを確定文字として返し、残りは(確定可能だが)inputとして返す
@@ -289,10 +291,10 @@ struct Romaji: Equatable, Sendable {
             } else {
                 fatalError()
             }
-        } else if let moji = table[input] {
-            return ConvertedMoji(input: moji.remain ?? "", kakutei: moji)
         } else if undecidedInputs.contains(input) {
             return ConvertedMoji(input: input, kakutei: nil)
+        } else if let moji = table[input] {
+            return ConvertedMoji(input: moji.remain ?? "", kakutei: moji)
         } else if input.hasPrefix("n") && input.count == 2 {
             return ConvertedMoji(input: String(input.dropFirst()), kakutei: Romaji.n)
         } else if input.count > 1, let c = input.last {

--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -268,6 +268,7 @@ struct Romaji: Equatable, Sendable {
      * - "k" が入力されたら確定文字はnil, 残りのローマ字文字列 "k" を返す
      * - "n" が入力されたらこのあとに子音が続くまでは「ん」とならないので確定文字はnil
      * - "nk" のようにn + 子音が入力されたら確定文字 "ん" と残りのローマ字文字列 "k" を返す
+     * - "nyk" のようにny + 子音が入力されたら"ny"を捨てて残りのローマ字文字列 "k" をinput引数としたときのconvertの結果を返す
      * - "kt" のように連続できない子音が連続したinputの場合は"k"を捨てて"t"をinput引数としたときのconvertの結果を返す
      * - "kya" のように確定した文字が複数の場合がありえる
      * - "aiueo" のように複数の確定が可能な場合は最初に確定できた文字だけを確定文字として返し、残りは(確定可能だが)inputとして返す
@@ -295,10 +296,10 @@ struct Romaji: Equatable, Sendable {
             return ConvertedMoji(input: input, kakutei: nil)
         } else if let moji = table[input] {
             return ConvertedMoji(input: moji.remain ?? "", kakutei: moji)
-        } else if input.hasPrefix("n") && input.count == 2 {
-            return ConvertedMoji(input: String(input.dropFirst()), kakutei: Romaji.n)
-        } else if input.count > 1, let c = input.last {
-            return convert(String(c), punctuation: punctuation)
+        } else if input.count == 2, let first = input.first, let converted = table[String(first)] {
+            return ConvertedMoji(input: String(input.dropFirst()), kakutei: converted)
+        } else if input.count > 1, let last = input.last {
+            return convert(String(last), punctuation: punctuation)
         }
         return ConvertedMoji(input: input, kakutei: nil)
     }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -606,7 +606,7 @@ final class StateMachine {
                 return true
             } else {
                 if state.inputMode != .direct {
-                    return handleComposingStartConvert(action, composing: composing.trim(), specialState: specialState)
+                    return handleComposingStartConvert(action, composing: composing.trim(kanaRule: Global.kanaRule), specialState: specialState)
                 } else {
                     return handleComposingStartConvert(action, composing: composing, specialState: specialState)
                 }
@@ -928,7 +928,7 @@ final class StateMachine {
         // skkservから引く場合もあるのでTaskで実行する
         // 未確定ローマ字はn以外は入力されずに削除される. nだけは"ん"として変換する
         // 変換候補がないときは辞書登録へ
-        let trimmedComposing = composing.trim()
+        let trimmedComposing = composing.trim(kanaRule: Global.kanaRule)
         var yomiText = trimmedComposing.yomi(for: self.state.inputMode)
         let candidateWords: [Candidate]
         // FIXME: Abbrevモードでも接頭辞、接尾辞を検索するべきか再検討する。

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -467,7 +467,7 @@ final class StateMachine {
             }
             // 入力中文字列を確定させてひらがなモードにする
             state.inputMethod = .normal
-            addFixedText(composing.string(for: state.inputMode, convertHatsuon: true))
+            addFixedText(composing.string(for: state.inputMode, kanaRule: Global.kanaRule))
             state.inputMode = .hiragana
             inputMethodEventSubject.send(.modeChanged(.hiragana, action.cursorPosition))
             return true
@@ -478,10 +478,10 @@ final class StateMachine {
                 state.inputMethod = .normal
                 switch state.inputMode {
                 case .hiragana, .hankaku:
-                    addFixedText(composing.string(for: .katakana, convertHatsuon: true))
+                    addFixedText(composing.string(for: .katakana, kanaRule: Global.kanaRule))
                     return true
                 case .katakana:
-                    addFixedText(composing.string(for: .hiragana, convertHatsuon: true))
+                    addFixedText(composing.string(for: .hiragana, kanaRule: Global.kanaRule))
                     return true
                 case .direct:
                     // 普通に入力させる
@@ -507,7 +507,7 @@ final class StateMachine {
                 } else {
                     // 半角カタカナで確定する。
                     state.inputMethod = .normal
-                    addFixedText(composing.string(for: .hankaku, convertHatsuon: false))
+                    addFixedText(composing.string(for: .hankaku, kanaRule: nil))
                 }
                 return true
             } else {
@@ -520,7 +520,7 @@ final class StateMachine {
                 switch state.inputMode {
                 case .hiragana, .katakana, .hankaku:
                     state.inputMethod = .normal
-                    addFixedText(composing.string(for: state.inputMode, convertHatsuon: true))
+                    addFixedText(composing.string(for: state.inputMode, kanaRule: Global.kanaRule))
                     return handleNormal(action, specialState: specialState)
                 case .direct:
                     // 普通にlを入力させる
@@ -568,7 +568,7 @@ final class StateMachine {
             break
         case .enter:
             // 未確定ローマ字はn以外は入力されずに削除される. nだけは"ん"として変換する
-            let fixedText = composing.string(for: state.inputMode, convertHatsuon: true)
+            let fixedText = composing.string(for: state.inputMode, kanaRule: Global.kanaRule)
             state.inputMethod = .normal
             addFixedText(fixedText)
             updateModeIfPrevModeExists()
@@ -1234,7 +1234,7 @@ final class StateMachine {
             case .normal:
                 return
             case .composing(let composing):
-                let fixedText = composing.string(for: state.inputMode, convertHatsuon: false)
+                let fixedText = composing.string(for: state.inputMode, kanaRule: nil)
                 state.inputMethod = .normal
                 addFixedText(fixedText)
             case .selecting(let selecting):

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -929,7 +929,7 @@ final class StateMachine {
         // 未確定ローマ字はn以外は入力されずに削除される. nだけは"ん"として変換する
         // 変換候補がないときは辞書登録へ
         let trimmedComposing = composing.trim(kanaRule: Global.kanaRule)
-        var yomiText = trimmedComposing.yomi(for: self.state.inputMode)
+        var yomiText = trimmedComposing.yomi(for: self.state.inputMode, kanaRule: Global.kanaRule)
         let candidateWords: [Candidate]
         // FIXME: Abbrevモードでも接頭辞、接尾辞を検索するべきか再検討する。
         // いまは ">"で終わる・始まる場合は、Abbrevモードであっても接頭辞・接尾辞を探しているものとして検索する

--- a/macSKK/kana-rule.conf
+++ b/macSKK/kana-rule.conf
@@ -77,6 +77,7 @@ wa,わ
 wyi,ゐ
 wye,ゑ
 wo,を
+n,ん
 nn,ん
 ga,が
 gi,ぎ

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -37,7 +37,7 @@ class RomajiTests: XCTestCase {
         XCTAssertEqual(kanaRule.convert("z,", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "z", kana: "‥")))
         XCTAssertEqual(kanaRule.convert("x,,", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "d", kana: "だぶるかんま")), "firstRomajiはかなの一文字目から決定される")
         XCTAssertEqual(kanaRule.convert("@", punctuation: .default), Romaji.ConvertedMoji(input: "@", kakutei: nil), "ルールにない文字は変換されない")
-        XCTAssertEqual(kanaRule.convert("a;", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "a", kana:"あせみころん")), "システム用の文字を含むことができる")
+        XCTAssertEqual(kanaRule.convert("b;", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "b", kana:"びーせみころん")), "システム用の文字を含むことができる")
         XCTAssertEqual(kanaRule.convert("ca", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "k", kana:"か")), "実際に入力した一文字目(c)ではなく「か」からローマ字(k)に変換する")
         // 読点
         XCTAssertEqual(kanaRule.convert(",", punctuation: Punctuation(comma: .ten, period: .default)), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: ",", kana: "、")))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -124,6 +124,20 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleNormalRomajiKanaRuleN() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.kanaRule = try! Romaji(source: ["nn,ん", "a,あ"].joined(separator: "\n"))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("n")])))
+            XCTAssertEqual(events[1], .fixedText("あ"))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleNormalSpace() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -36,6 +36,19 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleNormalRomajiN() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("n")])))
+            XCTAssertEqual(events[1], .fixedText("ん"))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleNormalRomaji() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -14,14 +14,21 @@ final class StateTests: XCTestCase {
         var state = ComposingState(
             isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: nil)
         state = state.appendText(Romaji.Moji(firstRomaji: "u", kana: "う"))
-        XCTAssertEqual(state.string(for: .hiragana, convertHatsuon: false), "あいう")
+        XCTAssertEqual(state.string(for: .hiragana, kanaRule: nil), "あいう")
         state = state.moveCursorLeft()
         XCTAssertEqual(state.cursor, 2)
         state = state.appendText(Romaji.Moji(firstRomaji: "e", kana: "え"))
-        XCTAssertEqual(state.string(for: .hiragana, convertHatsuon: false), "あいえう")
+        XCTAssertEqual(state.string(for: .hiragana, kanaRule: nil), "あいえう")
         XCTAssertEqual(state.cursor, 3)
         state = state.moveCursorRight()
         XCTAssertNil(state.cursor, "末尾まで移動したらカーソルはnilになる")
+    }
+
+    func testComposingStateString() {
+        let state = ComposingState(
+            isShift: true, text: ["あ", "い"], okuri: nil, romaji: "n", cursor: nil)
+        XCTAssertEqual(state.string(for: .hiragana, kanaRule: Romaji.defaultKanaRule), "あいん")
+        XCTAssertEqual(state.string(for: .hiragana, kanaRule: nil), "あい")
     }
 
     func testComposingStateDropLast() {

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -6,6 +6,10 @@ import XCTest
 @testable import macSKK
 
 final class StateTests: XCTestCase {
+    @MainActor override func setUp() {
+        Global.kanaRule = Romaji.defaultKanaRule
+    }
+
     func testComposingStateAppendText() throws {
         var state = ComposingState(
             isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: nil)
@@ -86,18 +90,22 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(state.subText(), ["あ"], "未確定のローマ字部分は含まない")
     }
 
-    func testComposingStateTrim() {
+    @MainActor func testComposingStateTrim() {
         let state = ComposingState(
-            isShift: true, text: ["あ"], okuri: nil, romaji: "n", cursor: nil).trim()
+            isShift: true,
+            text: ["あ"],
+            okuri: nil,
+            romaji: "n",
+            cursor: nil).trim(kanaRule: Global.kanaRule)
         XCTAssertEqual(state.text, ["あ", "ん"])
         XCTAssertNil(state.okuri)
     }
 
-    func testComposingStateTrimOkuriN() {
+    @MainActor func testComposingStateTrimOkuriN() {
         let state = ComposingState(
-            isShift: true, text: ["く", "や"], okuri: [], romaji: "n", cursor: nil).trim()
-        XCTAssertEqual(state.trim().text, ["く", "や"])
-        XCTAssertEqual(state.trim().okuri, [Romaji.n])
+            isShift: true, text: ["く", "や"], okuri: [], romaji: "n", cursor: nil).trim(kanaRule: Global.kanaRule)
+        XCTAssertEqual(state.trim(kanaRule: Global.kanaRule).text, ["く", "や"])
+        XCTAssertEqual(state.trim(kanaRule: Global.kanaRule).okuri, [Romaji.n])
     }
 
     func testComposingStateYomi() {

--- a/macSKKTests/fixture/kana-rule-for-test.conf
+++ b/macSKKTests/fixture/kana-rule-for-test.conf
@@ -10,11 +10,12 @@ zi,じ
 ji,じ
 na,な
 nya,にゃ
+n,ん
 nn,ん
 &comma;,、
 z&comma;,‥
 x&comma;&comma;,だぶるかんま
-a;,あせみころん
+b;,びーせみころん
 ca,か
 +,<shift>;
 :,<shift>;


### PR DESCRIPTION
#263 デフォルトのローマ字かな変換ルールに "n,ん" を追加し、暗黙的に "n" から "ん" に変換していた処理をローマ字かな変換ルールに従うようにします。
nを含むカスタムしたローマ字かな変換ルールに使いたいとき向けの修正です。

デフォルトのローマ字かな変換ルールのときは挙動に変更はありません。

- "nk", "ns" のように n + 子音を入力 → "ん"を確定し、残りの子音を入力中にする
- "nyk", "nys" のように ny + 子音を入力 → nyを取り消し、残りの子音を入力中にする。"ん"も確定させない。
- あn のような状態で変換する → "あん" として変換開始する

仮にデフォルトのローマ字かな変換ルールに "n,ん" がない場合は、次のように変わります。

- "nk", "ns" のように n + 子音を入力 → nを取り消し、残りの子音を入力中にする。"ん"も確定させない。
- あn のような状態で変換する → "あ" として変換開始する