### PR TITLE
ローマ字かな変換ルールで"<shift>" + key形式でkeyがアルファベット以外のときに読み入力が開始されないバグを修正

### DIFF
--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -9,6 +9,15 @@ struct Action {
     let event: NSEvent
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect
+    /// `Romaji.convertKeyEvent` によって変換されたNSEventから生成されたアクションかどうか.
+    let treatedAsAlphabet: Bool
+
+    init(keyBind: KeyBinding.Action?, event: NSEvent, cursorPosition: NSRect, treatedAsAlphabet: Bool = false) {
+        self.keyBind = keyBind
+        self.event = event
+        self.cursorPosition = cursorPosition
+        self.treatedAsAlphabet = treatedAsAlphabet
+    }
 
     func shiftIsPressed() -> Bool {
         return event.modifierFlags.contains(.shift)

--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -9,14 +9,14 @@ struct Action {
     let event: NSEvent
     /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
     let cursorPosition: NSRect
-    /// `Romaji.convertKeyEvent` によって変換されたNSEventから生成されたアクションかどうか.
-    let treatedAsAlphabet: Bool
+    /// ``Romaji/convertKeyEvent(_:)`` によって変換されたNSEventから生成されたアクションかどうか.
+    let treatAsAlphabet: Bool
 
-    init(keyBind: KeyBinding.Action?, event: NSEvent, cursorPosition: NSRect, treatedAsAlphabet: Bool = false) {
+    init(keyBind: KeyBinding.Action?, event: NSEvent, cursorPosition: NSRect, treatAsAlphabet: Bool = false) {
         self.keyBind = keyBind
         self.event = event
         self.cursorPosition = cursorPosition
-        self.treatedAsAlphabet = treatedAsAlphabet
+        self.treatAsAlphabet = treatAsAlphabet
     }
 
     func shiftIsPressed() -> Bool {

--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -309,6 +309,11 @@ struct Romaji: Equatable, Sendable {
      *
      * 今はシフトキーが押されているときのみに対応する
      * https://github.com/mtgto/macSKK/issues/225
+     *
+     * > Note: charactersIgnoringModifiersは本来のIMKInputController#handleではシフトキーで変わる記号の場合
+     *         `characters = "<"`, `charactersIgnoringModifiers = ","` のように異なります。
+     *         しかしcharactersが記号の場合のcharactersIgnoringModifiersをシフトキーなしのときの文字として
+     *         記述する設定方法を用意してないので、暫定としてcharactersと同様の値を設定します。
      */
     func convertKeyEvent(_ event: NSEvent) -> NSEvent? {
         // シフトキーが押されてなければ無視する
@@ -316,9 +321,6 @@ struct Romaji: Equatable, Sendable {
             return nil
         }
         guard let characters = event.characters else {
-            return nil
-        }
-        guard let charactersIgnoringCharacters = event.charactersIgnoringModifiers else {
             return nil
         }
         if let mapped = lowercaseMap[characters] {
@@ -329,7 +331,7 @@ struct Romaji: Equatable, Sendable {
                                     windowNumber: event.windowNumber,
                                     context: nil,
                                     characters: mapped,
-                                    charactersIgnoringModifiers: charactersIgnoringCharacters,
+                                    charactersIgnoringModifiers: mapped,
                                     isARepeat: event.isARepeat,
                                     keyCode: event.keyCode)
         }

--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -346,7 +346,7 @@ struct Romaji: Equatable, Sendable {
      *
      * デフォルトのローマ字かな変換ルールでの例:
      *
-     * input | modifierFlags | treatedAsAlphabet | 結果 | 補足
+     * input | modifierFlags | treatAsAlphabet | 結果 | 補足
      * ----- | ------------- | ----------------- | ---- | ----
      * "a" | `[]` | false | true | "a" の全体なので
      * "a" | `[.shift]` | false | true | アルファベットの場合シフトキーが押されていてもよい
@@ -361,13 +361,13 @@ struct Romaji: Equatable, Sendable {
      * - Parameters
      *   - input: IMKInputController.handle の引数NSEventのcharacterIgnoringModifiers
      *   - modifierFlags: 修飾キー
-     *   - treatedAsAlphabet: 実質アルファベットとして見做すかどうか。Romaji.convertedKeyEventで変換された場合。
+     *   - treatAsAlphabet: 実質アルファベットとして見做すかどうか。Romaji.convertedKeyEventで変換された場合。
      */
-    func isPrefix(_ input: String, modifierFlags: NSEvent.ModifierFlags, treatedAsAlphabet: Bool) -> Bool {
+    func isPrefix(_ input: String, modifierFlags: NSEvent.ModifierFlags, treatAsAlphabet: Bool) -> Bool {
         if !modifierFlags.isDisjoint(with: [.option, .command, .control]) {
             return false
         } else if undecidedInputs.contains(input) || table[input] != nil {
-            return input.isAlphabet || !modifierFlags.contains(.shift) || treatedAsAlphabet
+            return input.isAlphabet || !modifierFlags.contains(.shift) || treatAsAlphabet
         }
         return false
     }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -364,7 +364,7 @@ final class StateMachine {
     @MainActor func handleNormalPrintable(input: String, action: Action, specialState: SpecialState?) -> Bool {
         switch state.inputMode {
         case .hiragana, .katakana, .hankaku:
-            if Global.kanaRule.isPrefix(input, modifierFlags: action.event.modifierFlags, treatedAsAlphabet: action.treatedAsAlphabet) {
+            if Global.kanaRule.isPrefix(input, modifierFlags: action.event.modifierFlags, treatAsAlphabet: action.treatAsAlphabet) {
                 let result = Global.kanaRule.convert(input, punctuation: Global.punctuation)
                 if let moji = result.kakutei {
                     if action.shiftIsPressed() {
@@ -388,7 +388,7 @@ final class StateMachine {
                             Action(keyBind: Global.keyBinding.action(event: mappedEvent),
                                    event: mappedEvent,
                                    cursorPosition: action.cursorPosition,
-                                   treatedAsAlphabet: true),
+                                   treatAsAlphabet: true),
                             specialState: specialState)
                     }
                     let result = Global.kanaRule.convert(characters, punctuation: Global.punctuation)
@@ -806,7 +806,7 @@ final class StateMachine {
                     Action(keyBind: Global.keyBinding.action(event: mappedEvent),
                            event: mappedEvent,
                            cursorPosition: action.cursorPosition,
-                           treatedAsAlphabet: true),
+                           treatAsAlphabet: true),
                     composing: composing,
                     specialState: specialState
                 )
@@ -870,7 +870,7 @@ final class StateMachine {
                     }
                 }
                 updateMarkedText()
-            } else if Global.kanaRule.isPrefix(input, modifierFlags: action.event.modifierFlags, treatedAsAlphabet: action.treatedAsAlphabet) {
+            } else if Global.kanaRule.isPrefix(input, modifierFlags: action.event.modifierFlags, treatAsAlphabet: action.treatAsAlphabet) {
                 // ローマ字の一部が入力された場合
                 // シフトが押されているかどうかで送り仮名入力かそうでないかに分岐
                 if !text.isEmpty && okuri == nil && action.shiftIsPressed() {

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -66,20 +66,20 @@ class RomajiTests: XCTestCase {
 
     func testIsPrefix() throws {
         let kanaRule = Romaji.defaultKanaRule
-        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [.shift], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.option], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.shift, .option], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.command], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.control], treatedAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix("k", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix("ky", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix("kya", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix("kyi", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix("q", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [], treatedAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix(",", modifierFlags: [.shift], treatedAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [.shift], treatedAsAlphabet: true))
+        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [.shift], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.option], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.shift, .option], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.command], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.control], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("k", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("ky", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("kya", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("kyi", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("q", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix(",", modifierFlags: [.shift], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [.shift], treatAsAlphabet: true))
     }
 }
 

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -66,19 +66,20 @@ class RomajiTests: XCTestCase {
 
     func testIsPrefix() throws {
         let kanaRule = Romaji.defaultKanaRule
-        XCTAssertTrue(kanaRule.isPrefix(input: "a", modifierFlags: []))
-        XCTAssertTrue(kanaRule.isPrefix(input: "a", modifierFlags: [.shift]))
-        XCTAssertFalse(kanaRule.isPrefix(input: "a", modifierFlags: [.option]))
-        XCTAssertFalse(kanaRule.isPrefix(input: "a", modifierFlags: [.shift, .option]))
-        XCTAssertFalse(kanaRule.isPrefix(input: "a", modifierFlags: [.command]))
-        XCTAssertFalse(kanaRule.isPrefix(input: "a", modifierFlags: [.control]))
-        XCTAssertTrue(kanaRule.isPrefix(input: "k", modifierFlags: []))
-        XCTAssertTrue(kanaRule.isPrefix(input: "ky", modifierFlags: []))
-        XCTAssertTrue(kanaRule.isPrefix(input: "kya", modifierFlags: []))
-        XCTAssertFalse(kanaRule.isPrefix(input: "kyi", modifierFlags: []))
-        XCTAssertFalse(kanaRule.isPrefix(input: "q", modifierFlags: []))
-        XCTAssertTrue(kanaRule.isPrefix(input: ",", modifierFlags: []))
-        XCTAssertFalse(kanaRule.isPrefix(input: ",", modifierFlags: [.shift]))
+        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [.shift], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.option], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.shift, .option], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.command], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("a", modifierFlags: [.control], treatedAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("k", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("ky", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("kya", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("kyi", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix("q", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [], treatedAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix(",", modifierFlags: [.shift], treatedAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [.shift], treatedAsAlphabet: true))
     }
 }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1469,6 +1469,20 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleComposingRomajiKanaRuleKigou() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.kanaRule = try! Romaji(source: ["ka,か", "<,<shift>k"].joined(separator: "\n"))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("k")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("か")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "<", characterIgnoringModifier: ",", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleComposingPrintableAndL() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1483,6 +1483,20 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleComposingRomajiKanaRuleRomaji() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.kanaRule = try! Romaji(source: ["ka,か", ">,<shift>k"].joined(separator: "\n"))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("k")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("か")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ">", characterIgnoringModifier: ".", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleComposingPrintableAndL() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1471,14 +1471,14 @@ final class StateMachineTests: XCTestCase {
 
     @MainActor func testHandleComposingRomajiKanaRuleKigou() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
-        Global.kanaRule = try! Romaji(source: ["ka,か", "<,<shift>k"].joined(separator: "\n"))
+        Global.kanaRule = try! Romaji(source: [".a,か", ">,<shift>."].joined(separator: "\n"))
         let expectation = XCTestExpectation()
         stateMachine.inputMethodEvent.collect(2).sink { events in
-            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("k")])))
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain(".")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("か")])))
             expectation.fulfill()
         }.store(in: &cancellables)
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "<", characterIgnoringModifier: ",", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ">", characterIgnoringModifier: ".", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a")))
         wait(for: [expectation], timeout: 1.0)
     }


### PR DESCRIPTION
#285 ローマ字かな変換ルールで第二引数で `>,<shift>.` のように第二引数が `<shift>` + 非アルファベットのときにローマ字入力の開始として扱われなかったバグを修正します。

以下のようなローマ字かな変換ルールで `>` を入力した場合

```
.g,く
.t,か
>,<shift>.
```

- 正: `▽.` のようにシフトを押しながらローマ字の一文字目として `.` をかな入力開始の一文字目を入力したとして扱われる
- 誤: `.` が確定されて入力される