### PR TITLE
Composing モードで abbrev を入力するときに backspace で最初の文字を消した時に ascii モードになるのを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -581,6 +581,7 @@ final class StateMachine {
                 state.inputMethod = .composing(newComposingState)
             } else {
                 state.inputMethod = .normal
+                updateModeIfPrevModeExists()
             }
             updateMarkedText()
             return true


### PR DESCRIPTION
`/` で abbrev の composing モードに入って、その後に backspace で `▽` を消した時に ascii モードにはいります。
`updateModeIfPrevModeExists()` って便利なメソッドがあったので修正してみました。