### PR TITLE
独自のローマ字かな変換ルールファイルが空の場合デフォルトルールを使用する

### DIFF
--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -72,6 +72,8 @@ struct Romaji: Equatable, Sendable {
     enum RomajiError: Error {
         /// 不正な設定
         case invalid
+        /// 1行も有効な設定がない
+        case empty
     }
 
     /// ローマ字かな変換テーブル
@@ -148,6 +150,8 @@ struct Romaji: Equatable, Sendable {
         }
         if let error {
             throw error
+        } else if table.isEmpty && lowercaseMap.isEmpty {
+            throw RomajiError.empty
         }
         self.table = table
         self.undecidedInputs = undecidedInputs

--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -72,8 +72,6 @@ struct Romaji: Equatable, Sendable {
     enum RomajiError: Error {
         /// 不正な設定
         case invalid
-        /// 1行も有効な設定がない
-        case empty
     }
 
     /// ローマ字かな変換テーブル
@@ -94,6 +92,11 @@ struct Romaji: Equatable, Sendable {
      * 現在入力中の未確定文字列がこの集合にないときは最後の未確定文字列だけを残すために利用する。
      */
     let undecidedInputs: Set<String>
+
+    /// 設定がまったくないか
+    var isEmpty: Bool {
+        table.isEmpty && lowercaseMap.isEmpty
+    }
 
     init(contentsOf url: URL) throws {
         try self.init(source: try String(contentsOf: url, encoding: .utf8))
@@ -150,8 +153,6 @@ struct Romaji: Equatable, Sendable {
         }
         if let error {
             throw error
-        } else if table.isEmpty && lowercaseMap.isEmpty {
-            throw RomajiError.empty
         }
         self.table = table
         self.undecidedInputs = undecidedInputs

--- a/macSKK/SettingsWatcher.swift
+++ b/macSKK/SettingsWatcher.swift
@@ -40,14 +40,17 @@ final class SettingsWatcher: NSObject, Sendable {
     @MainActor func loadKanaRule(contentsOf url: URL) {
         do {
             if try url.isReadable() {
-                Global.kanaRule = try Romaji(contentsOf: url)
-                logger.log("独自のローマ字かな変換ルールを適用しました")
+                let kanaRule = try Romaji(contentsOf: url)
+                if kanaRule.isEmpty {
+                    Global.kanaRule = Global.defaultKanaRule
+                    logger.log("ローマ字かな変換ルールファイルが空のためデフォルトのルールを使用します")
+                } else {
+                    Global.kanaRule = kanaRule
+                    logger.log("独自のローマ字かな変換ルールを適用しました")
+                }
             } else {
                 logger.log("ローマ字かな変換ルールファイルとして不適合なファイルであるため読み込みできませんでした")
             }
-        } catch Romaji.RomajiError.empty {
-            Global.kanaRule = Global.defaultKanaRule
-            logger.log("ローマ字かな変換ルールファイルが空のためデフォルトのルールを使用します")
         } catch {
             logger.error("ローマ字かな変換ルールの読み込みでエラーが発生しました: \(error)")
         }

--- a/macSKK/SettingsWatcher.swift
+++ b/macSKK/SettingsWatcher.swift
@@ -43,8 +43,11 @@ final class SettingsWatcher: NSObject, Sendable {
                 Global.kanaRule = try Romaji(contentsOf: url)
                 logger.log("独自のローマ字かな変換ルールを適用しました")
             } else {
-                logger.log("ローマ字かなルールファイルとして不適合なファイルであるため読み込みできませんでした")
+                logger.log("ローマ字かな変換ルールファイルとして不適合なファイルであるため読み込みできませんでした")
             }
+        } catch Romaji.RomajiError.empty {
+            Global.kanaRule = Global.defaultKanaRule
+            logger.log("ローマ字かな変換ルールファイルが空のためデフォルトのルールを使用します")
         } catch {
             logger.error("ローマ字かな変換ルールの読み込みでエラーが発生しました: \(error)")
         }

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -7,12 +7,7 @@ import XCTest
 
 class RomajiTests: XCTestCase {
     func testInit() {
-        XCTAssertThrowsError(try Romaji(source: "")) { error in
-            XCTAssertEqual(error as? Romaji.RomajiError, Romaji.RomajiError.empty)
-        }
-        XCTAssertThrowsError(try Romaji(source: "# hoge"), "#で始まる行はコメント") { error in
-            XCTAssertEqual(error as? Romaji.RomajiError, Romaji.RomajiError.empty)
-        }
+        XCTAssertNoThrow(try Romaji(source: "# hoge"), "#で始まる行はコメント")
         XCTAssertNoThrow(try Romaji(source: "&sharp;,あ"), "シャープを使いたい場合は &sharp; と書く")
         XCTAssertThrowsError(try Romaji(source: ",あ"), "1要素目が空")
         XCTAssertThrowsError(try Romaji(source: "a,"), "2要素目が空")

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -7,7 +7,12 @@ import XCTest
 
 class RomajiTests: XCTestCase {
     func testInit() {
-        XCTAssertNoThrow(try Romaji(source: "# hoge"), "#で始まる行はコメント")
+        XCTAssertThrowsError(try Romaji(source: "")) { error in
+            XCTAssertEqual(error as? Romaji.RomajiError, Romaji.RomajiError.empty)
+        }
+        XCTAssertThrowsError(try Romaji(source: "# hoge"), "#で始まる行はコメント") { error in
+            XCTAssertEqual(error as? Romaji.RomajiError, Romaji.RomajiError.empty)
+        }
         XCTAssertNoThrow(try Romaji(source: "&sharp;,あ"), "シャープを使いたい場合は &sharp; と書く")
         XCTAssertThrowsError(try Romaji(source: ",あ"), "1要素目が空")
         XCTAssertThrowsError(try Romaji(source: "a,"), "2要素目が空")


### PR DESCRIPTION
有効なルールが一つもない独自のローマ字かな変換ルールファイルの場合はデフォルトのルールにフェイルバックします。
開発で一時的にローマ字かな変換ルールを書き換えたいときにちょっと不便だったので入れたのが主目的です。