### PR TITLE
Romaji.undecidedInputsにローマ字のプレフィクスの全パターンを登録する

### DIFF
--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -143,7 +143,9 @@ struct Romaji: Equatable, Sendable {
                                       hankaku: hankaku,
                                       remain: remain)
             if elements[0].count > 1 {
-                undecidedInputs.insert(String(elements[0].dropLast()))
+                for n in 1..<elements[0].count {
+                    undecidedInputs.insert(String(elements[0].prefix(n)))
+                }
             }
         }
         if let error {

--- a/macSKK/Romaji.swift
+++ b/macSKK/Romaji.swift
@@ -143,8 +143,12 @@ struct Romaji: Equatable, Sendable {
                                       hankaku: hankaku,
                                       remain: remain)
             if elements[0].count > 1 {
-                for n in 1..<elements[0].count {
-                    undecidedInputs.insert(String(elements[0].prefix(n)))
+                for n in stride(from: elements[0].count - 1, to: 0, by: -1) {
+                    let prefix = String(elements[0].prefix(n))
+                    if undecidedInputs.contains(prefix) {
+                        break
+                    }
+                    undecidedInputs.insert(prefix)
                 }
             }
         }

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -64,6 +64,14 @@ class RomajiTests: XCTestCase {
         XCTAssertEqual(kanaRule.convert("vu", punctuation: .default).kakutei?.kana, "ゔ")
     }
 
+    func testIsPrefixLongRule() throws {
+        let kanaRule = try Romaji(source: "abcdefghijklmnopqrstuvwxyz,あ")
+        XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("ab", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("abcdefghijkl", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix("abcdefghijklmnopqrstuvwxy", modifierFlags: [], treatAsAlphabet: false))
+    }
+
     func testIsPrefix() throws {
         let kanaRule = Romaji.defaultKanaRule
         XCTAssertTrue(kanaRule.isPrefix("a", modifierFlags: [], treatAsAlphabet: false))


### PR DESCRIPTION
#266 ローマ字かな変換ルールの読み込みの際に、 "abcd,あ" のように2文字以上のローマ字からなるルールがあり、かつ "a" + 任意のキー、もしくは "ab" + 任意のキーのどちらかのローマ字のルールがないときに変換できない問題を解消します。
ローマ字かな変換ルールを読み込む際のRomaji.undecidedInputsに、ローマ字のプレフィクスの全パターンを登録するように修正します。

例: "abcd,あ" というルールの場合

- before: "abc" だけをプレフィクスとして登録していたので、"a" が入力されたときにローマ字の途中だと判定できてなかった
- after: "a", "ab", "abc" をすべて登録する