### PR TITLE
IMKInputController#activateServerではoverrideKeyboardしない

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -262,11 +262,7 @@ class InputController: IMKInputController {
 
     // MARK: - IMKStateSetting
     @MainActor override func activateServer(_ sender: Any!) {
-        if let textInput = sender as? any IMKTextInput {
-            setCustomInputSource(textInput: textInput)
-        } else {
-            logger.warning("activateServerの引数clientがIMKTextInputではありません")
-        }
+        super.activateServer(sender)
     }
 
     @MainActor override func deactivateServer(_ sender: Any!) {


### PR DESCRIPTION
AppleアプリであるSafari, Mail, メモで入力ソースをmacSKKに切り替えるとAppleアプリがクラッシュするという報告をvim-jp Slackで受けました (macSKKがクラッシュするのではなくメモアプリなどがクラッシュしてしまう)。
私の環境では再現せず原因は判明してないんですが、アプリを切り替えたときに実行される `IMKInputController#activateServer` で怪しいのはoverrideKeyboardなのでこれをやめてみます。

#71 でキー配列のカスタマイズを導入した際に `IMKInputController#activateServer` からもoverrideKeyboardした理由は覚えていないのですが、ビルドして簡単に試してみたかんじアプリを切り替えずともキー配列は変更されているようなのでとりあえず問題ないと思います。
AquaSKK v4.7.6でもactivateServerではキーボード設定してないので、自分はなんでこうしてたんだろう…。
https://github.com/codefirst/aquaskk/blob/e853fba8983a788d75b6d389f1d91be0449d5657/platform/mac/src/server/SKKInputController.mm#L115-L126