### PR TITLE
読み入力中ではないとき "n " と入力すると "ん" が確定しないバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -601,7 +601,9 @@ final class StateMachine {
                 )
             }
             if text.isEmpty {
-                addFixedText(" ")
+                // 未確定ローマ字はn以外は入力されずに削除される. nだけは"ん"として変換する
+                let fixedText = composing.string(for: state.inputMode, kanaRule: Global.kanaRule)
+                addFixedText(fixedText + " ")
                 state.inputMethod = .normal
                 updateModeIfPrevModeExists()
                 return true

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -29,6 +29,7 @@ class RomajiTests: XCTestCase {
         XCTAssertEqual(kanaRule.convert("nn", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "n", kana: "ん")))
         XCTAssertEqual(kanaRule.convert("nk", punctuation: .default), Romaji.ConvertedMoji(input: "k", kakutei: Romaji.Moji(firstRomaji: "n", kana: "ん")))
         XCTAssertEqual(kanaRule.convert("n!", punctuation: .default), Romaji.ConvertedMoji(input: "!", kakutei: Romaji.Moji(firstRomaji: "n", kana: "ん")))
+        XCTAssertEqual(kanaRule.convert("n ", punctuation: .default), Romaji.ConvertedMoji(input: " ", kakutei: Romaji.Moji(firstRomaji: "n", kana: "ん")))
         XCTAssertEqual(kanaRule.convert("kn", punctuation: .default), Romaji.ConvertedMoji(input: "n", kakutei: nil))
         XCTAssertEqual(kanaRule.convert("ny", punctuation: .default), Romaji.ConvertedMoji(input: "ny", kakutei: nil))
         XCTAssertEqual(kanaRule.convert("nya", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "n", kana: "にゃ")))

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -36,19 +36,6 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    @MainActor func testHandleNormalRomajiN() {
-        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
-        let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(2).sink { events in
-            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("n")])))
-            XCTAssertEqual(events[1], .fixedText("ん"))
-            expectation.fulfill()
-        }.store(in: &cancellables)
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
-        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
-        wait(for: [expectation], timeout: 1.0)
-    }
-
     @MainActor func testHandleNormalRomaji() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -78,6 +65,20 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleNormalRomajiN() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(3).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("n")])))
+            XCTAssertEqual(events[1], .fixedText("ん"))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.plain("t")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "t")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleNormalNAndHyphen() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -99,6 +100,19 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "1")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "!", characterIgnoringModifier: "1", withShift: true)))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor func testHandleNormalRomajiNAndSpace() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("n")])))
+            XCTAssertEqual(events[1], .fixedText("ん "))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         wait(for: [expectation], timeout: 1.0)
     }
 


### PR DESCRIPTION
#297 ひらがな入力モードで "n " と入力すると "ん" が入力されず、半角スペースだけが入力されてしまうバグを修正します。