### PR TITLE
directモード時に単語登録・登録解除でないときは何もせずfalseを返す

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -342,6 +342,10 @@ final class StateMachine {
             break
         }
 
+        // 直接入力時かつ下線が引かれた未確定文字列がないときはなにもしない
+        if state.inputMode == .direct && state.specialState == nil {
+            return false
+        }
         let event = action.event
         guard let input = event.charactersIgnoringModifiers else {
             return false


### PR DESCRIPTION
半角英数モードでの入力時にこれまでは `IMKTextInput.insertText(_:replacementRange:)` で入力していました。

これを単語登録中・登録解除中を除き `IMKInputController.handle(_:client:)` でfalseを返すようにし、macSKKでinsertTextするのを止めます。

この修正に至った背景として、変換候補の表示や補完候補の検索もしない半角英数入力時にもmacSKKのCPU使用率が数パーセントあるのを見て、そもそも半角英数の入力をmacSKKからするのが無駄ではないかと考えていました。
私の環境で問題を再現できてないので効果があるのかはわからないのですが、 #112 がもしかしてなにか改善しないかな… とちょっとだけ考えています。