### PR TITLE
読みの末尾がnのとき接頭辞検索で"ん"に変換してなかったのを修正

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -230,7 +230,10 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
         return ComposingState(isShift: isShift, text: text, okuri: okuri, romaji: "", cursor: cursor, prevMode: prevMode)
     }
 
-    /// カーソルより左のtext部分を返す。``trim(kanaRule:)`` と違い、未確定のローマ字部分は含まない。
+    /**
+     * カーソルより左のtext部分を返す。
+     * ``trim(kanaRule:)`` と違い、未確定のローマ字部分の変換 ("n" を "ん" にするなど) は行わない。
+     */
     func subText() -> [String] {
         if let cursor {
             return Array(text[0..<cursor])

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -798,7 +798,7 @@ final class StateMachine {
 
         if input == "." && action.shiftIsPressed() && state.inputMode != .direct && !composing.text.isEmpty { // ">"
             // 接頭辞が入力されたものとして ">" より前で変換を開始する
-            let newComposing = composing.appendText(Romaji.Moji(firstRomaji: "", kana: ">"))
+            let newComposing = composing.trim(kanaRule: Global.kanaRule).appendText(Romaji.Moji(firstRomaji: "", kana: ">"))
             return handleComposingStartConvert(action, composing: newComposing, specialState: specialState)
         }
         switch state.inputMode {


### PR DESCRIPTION
#297 たとえば `Shift-a` + `n` + `>` のように末尾が "n" の状態で接頭辞変換をすると `あ>ん` のようになってしまうバグを修正します。
`あん>` として `あん` で始まる接頭辞を検索するのが正しいです。