### PR TITLE
selecting時のqもtoggleKanaとして扱う

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -79,6 +79,10 @@ struct KeyBinding: Identifiable, Hashable {
             case .toggleKana:
                 if case .normal = inputMethodState {
                     return true
+                } else if case .selecting(_) = inputMethodState {
+                    // selecting時にはqキーはtoggleKanaとして扱うことで、選択中の変換要素で確定し
+                    // さらにNormalモード時にtoggleKanaしたとして扱わせたい
+                    return true
                 } else {
                     return false
                 }


### PR DESCRIPTION
#304 `▼漢字` の状態 (変換候補選択時) で `q` キーを押したときに `漢字` が確定したあとに `q` が入力されてしまうのを修正します。
#296 で「未入力時のかなカナ切り替え」と「入力した読みをかなカナ切り替えして確定」のキーバインドを分けたときの実装ミスで変換候補の選択中の `q` 入力がどちらのキーバインドでもないと扱われていました。
これを修正します。