### PR TITLE
補完候補をSKKServから取得するテスト機能を設定画面に追加

### DIFF
--- a/SKKServClient/Network/SKKServRequest.swift
+++ b/SKKServClient/Network/SKKServRequest.swift
@@ -3,13 +3,16 @@
 
 import Foundation
 
-// 以下の資料を参考にしています
+// end, request, version, hostは以下の資料を参考にしています
 // https://github.com/jj1bdx/dbskkd-cdb/blob/master/skk-server-protocol.md
+// midashiは以下の資料を参考にしています
+// https://ja.osdn.net/projects/pysocialskkserv/wiki/SKKServ
 enum SKKServRequest {
     case end
     case request(Data) // 見出し語をエンコードしたもの
     case version
     case host
+    case completion(Data) // 読みをエンコードしたもの
 
     var data: Data {
         let lf: UInt8 = 0x0a
@@ -27,12 +30,17 @@ enum SKKServRequest {
             return Data([0x32, space, lf]) // '2' + space + LF
         case .host:
             return Data([0x33, space, lf]) // '3' + space + LF
+        case .completion(let key):
+            var data = Data([0x34]) // '4' + key + space + LF
+            data.append(key)
+            data.append(contentsOf: [space, lf])
+            return data
         }
     }
 
     var terminateCharacter: UInt8 {
         switch self {
-        case .request:
+        case .request, .completion:
             return 0x0a
         case .version, .host:
             return 0x20

--- a/SKKServClient/SKKServClientProtocol.swift
+++ b/SKKServClient/SKKServClientProtocol.swift
@@ -63,5 +63,6 @@ public enum SKKServClientError: Error, CaseIterable {
 @objc protocol SKKServClientProtocol {
     func serverVersion(destination: SKKServDestination, with reply: @escaping (String?, (any Error)?) -> Void)
     func refer(destination: SKKServDestination, yomi: String, with reply: @escaping (String?, (any Error)?) -> Void)
+    func completion(destination: SKKServDestination, yomi: String, with reply: @escaping (String?, (any Error)?) -> Void)
     func disconnect()
 }

--- a/macSKK/Settings/SKKServDictView.swift
+++ b/macSKK/Settings/SKKServDictView.swift
@@ -39,6 +39,27 @@ struct SKKServDictView: View {
                                                                  encoding: setting.encoding)
                             testing = true
                             let result = Result {
+                                try skkservService.completion(yomi: yomi, destination: destination, timeout: 1.0)
+                            }
+                            switch result {
+                            case .success(let response):
+                                logger.log("skkservの応答: \(response, privacy: .public)")
+                                information = response
+                            case .failure(let error):
+                                showError(error)
+                            }
+                            testing = false
+                        } label: {
+                            Text("Find Completions")
+                        }.disabled(yomi.isEmpty || testing)
+                        Button {
+                            let skkservService = SKKServService()
+                            let setting = settingsViewModel.skkservDictSetting
+                            let destination = SKKServDestination(host: setting.address,
+                                                                 port: setting.port,
+                                                                 encoding: setting.encoding)
+                            testing = true
+                            let result = Result {
                                 try skkservService.refer(yomi: yomi, destination: destination, timeout: 1.0)
                             }
                             switch result {
@@ -50,7 +71,7 @@ struct SKKServDictView: View {
                             }
                             testing = false
                         } label: {
-                            Text("Refer")
+                            Text("Find Candidates")
                         }.disabled(yomi.isEmpty || testing)
                     }
                 } header: {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -85,7 +85,8 @@
 "TCP Port" = "TCP Port No.";
 "Response Encoding" = "Response Encoding";
 "Yomi" = "Yomi";
-"Refer" = "Refer";
+"Find Candidates" = "Find Candidates";
+"Find Completions" = "Find Completions";
 "Rename" = "Rename";
 "Duplicate" = "Duplicate";
 "Edit" = "Edit";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -85,7 +85,8 @@
 "TCP Port" = "TCPポート番号";
 "Response Encoding" = "応答エンコーディング";
 "Yomi" = "読み";
-"Refer" = "参照";
+"Find Candidates" = "変換候補を検索";
+"Find Completions" = "補完候補を検索";
 "Rename" = "リネーム";
 "Duplicate" = "複製";
 "Edit" = "編集";


### PR DESCRIPTION
#295 skkservから補完候補を検索するテスト機能をSKKServ辞書設定に追加します。
まだskkserv辞書から補完候補を検索することには対応していません。

<img width="640" alt="image" src="https://github.com/user-attachments/assets/c04954ba-f1dc-4297-b97f-65467236b8cc" />
