### PR TITLE
Spaceにスペースキー以外を割り当てているときnormalモードでは入力されたキーの入力を優先する

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -229,18 +229,9 @@ final class StateMachine {
                 state.specialState = specialState.dropLast()
                 updateMarkedText()
                 return true
-
             } else {
                 return false
             }
-        case .space:
-            switch state.inputMode {
-            case .eisu:
-                addFixedText("　")
-            default:
-                addFixedText(" ")
-            }
-            return true
         case .tab:
             return false
         case .stickyShift:
@@ -338,7 +329,7 @@ final class StateMachine {
         case .eisu:
             // 何もしない (OSがIMEの切り替えはしてくれる)
             return true
-        case .unregister, .backwardCandidate, .toggleAndFixKana, nil:
+        case .space, .unregister, .backwardCandidate, .toggleAndFixKana, nil:
             break
         }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -21,6 +21,7 @@ final class StateMachineTests: XCTestCase {
         Global.enterNewLine = false
         Global.selectingBackspace = SelectingBackspace.default
         Global.candidateListDirection.send(.vertical)
+        Global.keyBinding = KeyBindingSet.defaultKeyBindingSet
     }
 
     @MainActor func testHandleNormalSimple() {
@@ -201,6 +202,24 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "s")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor func testHandleNormalSpaceCustomized() {
+        Global.keyBinding = KeyBindingSet(id: "spaceCustomized", values: [
+            KeyBinding(.space, [
+                KeyBinding.Input(key: .character("."), modifierFlags: []),
+                KeyBinding.Input(key: .character("n"), modifierFlags: [.control])
+            ])
+        ])
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(1).sink { events in
+            XCTAssertEqual(events[0], .fixedText("1")) // 変換開始や変換中じゃないので入力キーがそのまま入力される
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "1")))
+        XCTAssertFalse(stateMachine.handle(ctrlNAction)) // Ctrlを含むキー入力は無視して本来の挙動を優先する
         wait(for: [expectation], timeout: 1.0)
     }
 
@@ -3289,6 +3308,10 @@ final class StateMachineTests: XCTestCase {
     // 矢印の下キーを押した
     var downKeyAction: Action {
         Action(keyBind: .down, event: generateNSEvent(character: "\u{63233}", characterIgnoringModifiers: "\u{63233}", modifierFlags: [.function, .numericPad]), cursorPosition: .zero)
+    }
+    // Ctrl-nキーを押した
+    var ctrlNAction: Action {
+        Action(keyBind: .endOfLine, event: generateNSEvent(character: "n", characterIgnoringModifiers: "n", modifierFlags: .control), cursorPosition: .zero)
     }
     // 矢印の左キーを押した
     var leftKeyAction: Action {


### PR DESCRIPTION
キーバインド設定で `C-n` をSpaceに割り当てているとき、変換中じゃないときにもスペースを入力したとして扱っていました。
これを読みがまだ入力されてないときは入力したキーとして扱うことにします。

- `C-n` を `Space` に割り当てていた場合
  - 変換中は次候補移動として扱い、読みが入力されてないときはmacSKKではなにもしない (入力しているエディタの挙動にまかせる)
- `a` を `Space` に割り当てていた場合
  - 変換中は次候補移動として扱い、ひらがなモードのときは `a` が入力されたとしてローマ字変換して `あ` を入力する。