### PR TITLE
abbrevモードでTab補完すると前のモードに戻れなくなるバグを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -649,7 +649,8 @@ final class StateMachine {
                                                               text: newText,
                                                               okuri: nil,
                                                               romaji: "",
-                                                              cursor: nil))
+                                                              cursor: nil,
+                                                              prevMode: composing.prevMode))
                 self.completion = nil
                 updateMarkedText()
             }


### PR DESCRIPTION
#311 AbbrevモードでTabで補完して確定しても前のモードに戻れないバグを修正します。
Tabで補完したときに前の入力モードをComposingState.prevModeにもつのを忘れていました。