### PR TITLE
ひらがなモードで文字未入力時はPageDnなどの特殊キーを無視する

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -350,11 +350,11 @@ final class StateMachine {
         guard let input = event.charactersIgnoringModifiers else {
             return false
         }
-        if !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.command) {
-            return handleNormalPrintable(input: input, action: action, specialState: specialState)
-        } else {
+        if event.modifierFlags.contains(.control) || event.modifierFlags.contains(.command) || event.modifierFlags.contains(.function) {
             // 単語登録中や登録解除中はtrueを返してなにもしない
             return state.specialState != nil
+        } else {
+            return handleNormalPrintable(input: input, action: action, specialState: specialState)
         }
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -323,10 +323,11 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    @MainActor func testHandleNormalUpDown() {
+    @MainActor func testHandleNormalUpDownPagedown() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         XCTAssertFalse(stateMachine.handle(upKeyAction))
         XCTAssertFalse(stateMachine.handle(downKeyAction))
+        XCTAssertFalse(stateMachine.handle(pagedownKeyAction))
     }
 
     @MainActor func testHandleNormalPrintableDirect() {
@@ -3304,7 +3305,7 @@ final class StateMachineTests: XCTestCase {
     }
     // Deleteを押した
     var deleteAction: Action {
-        Action(keyBind: .delete, event: generateNSEvent(character: "\u{63272}", characterIgnoringModifiers: "\u{63272}", modifierFlags: .function), cursorPosition: .zero)
+        Action(keyBind: .delete, event: generateNSEvent(character: "\u{f728}", characterIgnoringModifiers: "\u{f728}", modifierFlags: .function), cursorPosition: .zero)
     }
     // 英数キーを押した
     var eisuKeyAction: Action {
@@ -3313,6 +3314,10 @@ final class StateMachineTests: XCTestCase {
     // かなキーを押した
     var kanaKeyAction: Action {
         Action(keyBind: .kana, event: generateNSEvent(character: "\u{10}", characterIgnoringModifiers: "\u{10}"), cursorPosition: .zero)
+    }
+    // PageDownキーを押した
+    var pagedownKeyAction: Action {
+        Action(keyBind: nil, event: generateNSEvent(character: "\u{f72d}", characterIgnoringModifiers: "\u{f72d}", modifierFlags: .function), cursorPosition: .zero)
     }
 
     // NormalモードまたはSelectingモードでqキーを押した


### PR DESCRIPTION
#301 ひらがなモードでPageDnキーなどの特殊なキーをmacSKKで処理しないようにします。
これによりSafariのテキスト入力でPageDnが非印字文字として入力されてしまう不具合も解消されます。

キーイベントについて修飾キーにFunctionが押されている扱いになっているものだけ追加したので、もしかするとこれだけではまだ足りないかもしれません…。