### PR TITLE
キーバインド設定画面のローカライズ漏れを修正

### DIFF
--- a/macSKK/Settings/KeyBinding/KeyBindingView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingView.swift
@@ -14,7 +14,7 @@ struct KeyBindingView: View {
 
     var body: some View {
         HStack {
-            Picker("設定", selection: $settingsViewModel.selectedKeyBindingSet) {
+            Picker("Settings", selection: $settingsViewModel.selectedKeyBindingSet) {
                 ForEach(settingsViewModel.keyBindingSets) { keyBindingSet in
                     Text(keyBindingSet.id)
                         .tag(keyBindingSet)

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 "Reset" = "Reset";
 "Vertical" = "Vertical";
 "Horizontal" = "Horizontal";
+"Settings" = "Settings";
 
 "KeyBindingActionHiragana" = "Hiragana Mode";
 "KeyBindingActionTogglekana" = "Toggle Kana Mode";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 "Reset" = "リセット";
 "Vertical" = "縦方向";
 "Horizontal" = "横方向";
+"Settings" = "設定";
 
 "KeyBindingActionHiragana" = "ひらがなモード";
 "KeyBindingActionTogglekana" = "かなカナモード切り替え";


### PR DESCRIPTION
#315 キーバインド設定画面で「設定」という文字列をローカライズし忘れていたので修正します。