### PR TITLE
`n ESC` で "ん" を確定させる

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -717,6 +717,9 @@ final class StateMachine {
                 state.inputMethod = .normal
                 if let reconvertText = composing.reconvertText {
                     addFixedText(reconvertText)
+                } else if !isShift {
+                    // `n` だけ入力した状態でESC押したときは `ん` を確定させる。Shiftが押されているときは確定させない
+                    addFixedText(composing.string(for: state.inputMode, kanaRule: Global.kanaRule))
                 }
                 updateModeIfPrevModeExists()
             } else {

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -542,18 +542,27 @@ final class StateMachineTests: XCTestCase {
     @MainActor func testHandleNormalCancel() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(5).sink { events in
+        stateMachine.inputMethodEvent.collect(10).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("え")])))
             XCTAssertEqual(events[1], .modeChanged(.hiragana, .zero))
             XCTAssertEqual(events[2], .markedText(MarkedText([.plain("[登録：え]")])))
             XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("え")])))
             XCTAssertEqual(events[4], .markedText(MarkedText([])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([.plain("n")])))
+            XCTAssertEqual(events[6], .fixedText("ん"))
+            XCTAssertEqual(events[7], .markedText(MarkedText([])))
+            XCTAssertEqual(events[8], .markedText(MarkedText([.markerCompose, .plain("n")])))
+            XCTAssertEqual(events[9], .markedText(MarkedText([])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertFalse(stateMachine.handle(cancelAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n")))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n", withShift: true)))
         XCTAssertTrue(stateMachine.handle(cancelAction))
         wait(for: [expectation], timeout: 1.0)
     }


### PR DESCRIPTION
#320 ddskk、AquaSKKのように `n` + 取り消し (ESCやC-g) で「ん」が確定させるようにします。

- Shift-n + 取り消し → 何も入力されない状態に戻る
- n + 取り消し → んが確定される