### PR TITLE
送り仮名ありで変換開始して読み入力に戻るときに読みに送り仮名を統合する

### DIFF
--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -273,6 +273,25 @@ struct ComposingState: Equatable, MarkedTextProtocol, CursorProtocol {
         }
     }
 
+    /**
+     * 送り仮名を読みに統合して返す。送り仮名は未入力状態に戻す
+     * 例えば yomiが "おく", okuriが ["り"] の場合、yomiが"おくり"、okuriがnilの状態のComposingStateを返す
+     */
+    func uniteOkuri() -> Self {
+        if let okuri {
+            let newState = okuri.reduce(self, { composing, moji in composing.appendText(moji) })
+            let newCursor = cursor.map { $0 + okuri.count }
+            return ComposingState(isShift: newState.isShift,
+                                  text: newState.text,
+                                  okuri: nil,
+                                  romaji: "",
+                                  cursor: newCursor,
+                                  prevMode: newState.prevMode)
+        } else {
+            return self
+        }
+    }
+
     // MARK: - CursorProtocol
     func moveCursorLeft() -> Self {
         let newCursor: Int

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -248,7 +248,9 @@ final class StateMachine {
                 switch specialState {
                 case .register(let registerState, let prevRegisterStates):
                     state.inputMode = registerState.prev.mode
-                    state.inputMethod = .composing(registerState.prev.composing)
+                    // 送り仮名がある場合は読みに結合する。例えば `Na I` という入力("な*い")をしてからキャンセルするときは
+                    // `Nai` という入力をしたときの状態に戻す。
+                    state.inputMethod = .composing(registerState.prev.composing.uniteOkuri())
                     if let prevRegisterState = prevRegisterStates.last {
                         state.specialState = .register(prevRegisterState, prev: prevRegisterStates.dropLast())
                     } else {
@@ -972,7 +974,6 @@ final class StateMachine {
     }
 
     @MainActor func handleComposingStartConvert(_ action: Action, composing: ComposingState, specialState: SpecialState?) -> Bool {
-        // skkservから引く場合もあるのでTaskで実行する
         // 未確定ローマ字はn以外は入力されずに削除される. nだけは"ん"として変換する
         // 変換候補がないときは辞書登録へ
         let trimmedComposing = composing.trim(kanaRule: Global.kanaRule)
@@ -1113,7 +1114,9 @@ final class StateMachine {
             fixCurrentSelect()
             return handle(action)
         case .cancel:
-            state.inputMethod = .composing(selecting.prev.composing)
+            // 送り仮名がある場合は読みに結合する。例えば `Na I` という入力("な*い")をしてからキャンセルするときは
+            // `Nai` という入力をしたときの状態に戻す。
+            state.inputMethod = .composing(selecting.prev.composing.uniteOkuri())
             state.inputMode = selecting.prev.mode
             updateCandidates(selecting: nil)
             updateMarkedText()
@@ -1213,7 +1216,9 @@ final class StateMachine {
             state.inputMethod = .selecting(newSelectingState)
         } else {
             updateCandidates(selecting: nil)
-            state.inputMethod = .composing(selecting.prev.composing)
+            // 送り仮名がある場合は読みに結合する。例えば `Na I` という入力("な*い")をしてからキャンセルするときは
+            // `Nai` という入力をしたときの状態に戻す。
+            state.inputMethod = .composing(selecting.prev.composing.uniteOkuri())
             state.inputMode = selecting.prev.mode
         }
         updateMarkedText()

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -204,6 +204,25 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(composingState.remain(), ["い"])
     }
 
+    func testComposingUniteOkuri() {
+        var state = ComposingState(isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: nil).uniteOkuri()
+        XCTAssertEqual(state.text, ["あ", "い"])
+        XCTAssertNil(state.okuri)
+        XCTAssertNil(state.cursor)
+        state = ComposingState(isShift: true, text: ["あ", "い"], okuri: [], romaji: "", cursor: nil).uniteOkuri()
+        XCTAssertEqual(state.text, ["あ", "い"])
+        XCTAssertNil(state.okuri)
+        XCTAssertNil(state.cursor)
+        state = ComposingState(isShift: true, text: ["あ", "い"], okuri: [Romaji.Moji(firstRomaji: "r", kana: "る")], romaji: "", cursor: nil).uniteOkuri()
+        XCTAssertEqual(state.text, ["あ", "い", "る"])
+        XCTAssertNil(state.okuri)
+        XCTAssertNil(state.cursor)
+        state = ComposingState(isShift: true, text: ["あ", "い"], okuri: [Romaji.Moji(firstRomaji: "r", kana: "る")], romaji: "", cursor: 1).uniteOkuri()
+        XCTAssertEqual(state.text, ["あ", "る", "い"]) // カーソルの位置に挿入される
+        XCTAssertNil(state.okuri)
+        XCTAssertEqual(state.cursor, 2) // 送り仮名の分加算される
+    }
+
     func testSelectingStateFixedText() throws {
         let selectingState = SelectingState(
             prev: SelectingState.PrevState(
@@ -428,7 +447,7 @@ final class StateTests: XCTestCase {
     }
 
     func testIMEStateDisplayTextRegister() {
-        let prevComposingState = ComposingState(isShift: true, text: ["あいうえお"], romaji: "")
+        let prevComposingState = ComposingState(isShift: true, text: ["あ", "い", "う", "え", "お"], romaji: "")
         let registerState = RegisterState(prev: RegisterState.PrevState(mode: .hiragana, composing: prevComposingState),
                                           yomi: "あいうえお",
                                           text: "愛上")
@@ -448,7 +467,7 @@ final class StateTests: XCTestCase {
     }
 
     func testIMEStateDisplayTextRegisterCursor() {
-        let prevComposingState = ComposingState(isShift: true, text: ["あいうえお"], romaji: "")
+        let prevComposingState = ComposingState(isShift: true, text: ["あ", "い", "う", "え", "お"], romaji: "")
         let registerState = RegisterState(prev: RegisterState.PrevState(mode: .hiragana, composing: prevComposingState),
                                           yomi: "あいうえお",
                                           text: "愛上",
@@ -469,12 +488,12 @@ final class StateTests: XCTestCase {
     }
 
     func testIMEStateDisplayTextRegisterRecursive() {
-        let firstComposingState = ComposingState(isShift: true, text: ["あいうえお"], romaji: "")
+        let firstComposingState = ComposingState(isShift: true, text: ["あ", "い", "う", "え", "お"], romaji: "")
         let prevRegisterState = RegisterState(prev: RegisterState.PrevState(mode: .hiragana, composing: firstComposingState),
                                               yomi: "あいうえお",
                                               text: "",
                                               cursor: nil)
-        let prevComposingState = ComposingState(isShift: true, text: ["あいうえ"], romaji: "")
+        let prevComposingState = ComposingState(isShift: true, text: ["あ", "い", "う", "え"], romaji: "")
         let registerState = RegisterState(prev: RegisterState.PrevState(mode: .hiragana, composing: prevComposingState),
                                           yomi: "あいうえ",
                                           text: "愛上",
@@ -526,7 +545,7 @@ final class StateTests: XCTestCase {
                 mode: .hiragana,
                 composing: ComposingState(
                     isShift: true,
-                    text: ["だい2"],
+                    text: ["だ", "い", "2"],
                     okuri: nil,
                     romaji: ""
                 )


### PR DESCRIPTION
#319 送り仮名ありで変換開始してからキャンセルして読み入力に戻るときに読みに送り仮名を統合します。

例えば `OKu` という入力で変換を開始すると、読みが「お」、送り仮名が「く」("お*く") となります。
この状態でCtrl-gやESCなどで読み入力に戻るときに、これまでは送り仮名がある状態 (読みが「お」、送り仮名が「く」) に戻していました。
それをこのPRでは送り仮名を読みにくっつけて `Oku` と入力したような状態 (読みが「おく」、送り仮名はなし) にします。

ddskkのデフォルトの挙動もそうなっているようでした。
AquaSKKは送り仮名が消失するようでした。

この挙動に特に強いこだわりはないので、もしこれまでの挙動の方がよかったという方がいればこのPR、Issueなどでお声かけください。その場合は設定でどちらの挙動も選べるようにするなどを検討しようと思います。