### PR TITLE
キーバインド設定にある未対応なactionなどは無視して読み込みは完了させる

### DIFF
--- a/macSKK/KeyBindingSet.swift
+++ b/macSKK/KeyBindingSet.swift
@@ -59,8 +59,10 @@ struct KeyBindingSet: Identifiable, Hashable {
         }
         for dict in keyBindings {
             guard let keyBinding = KeyBinding(dict: dict) else {
-                logger.warning("キーバインド \(id, privacy: .public) の読み込みに失敗しました")
-                return nil
+                // 読み込めないKeyBindingは無視して次に進める。
+                // 設定から更新すると読み込めなかったKeyBindingを除いて永続化される。
+                logger.warning("キーバインド \(id, privacy: .public) に読み込めないエントリが見つかりました")
+                continue
             }
             values.append(keyBinding)
         }

--- a/macSKKTests/KeyBindingTests.swift
+++ b/macSKKTests/KeyBindingTests.swift
@@ -39,12 +39,22 @@ final class KeyBindingTests: XCTestCase {
     func testEncodeAndDecode() {
         let binding1 = KeyBinding(.abbrev, [KeyBinding.Input(key: .character("/"), modifierFlags: [])])
         let binding2 = KeyBinding(dict: binding1.encode())
-        XCTAssertEqual(binding1.action, binding2!.action)
-        XCTAssertEqual(binding1.inputs, binding2!.inputs)
+        XCTAssertEqual(binding1.action, binding2?.action)
+        XCTAssertEqual(binding1.inputs, binding2?.inputs)
         // キーが不足していたらデコードしない
         XCTAssertNil(KeyBinding(dict: [:]))
         XCTAssertNil(KeyBinding(dict: ["action": "abbrev"]))
         XCTAssertNil(KeyBinding(dict: ["inputs": []]))
+        // actionが文字列でなかったり登録されていないものだったり、inputsが配列でない場合はデコードしない
+        XCTAssertNil(KeyBinding(dict: ["action": 1]))
+        XCTAssertNil(KeyBinding(dict: ["action": "thisIsTest"]))
+        XCTAssertNil(KeyBinding(dict: ["action": "abbrev", "inputs": [:]]))
+        // actionが正常であればinputsが殻でも許容する
+        let binding3 = KeyBinding(.stickyShift, [])
+        let binding4 = KeyBinding(dict: binding3.encode())
+        XCTAssertEqual(binding3.action, binding4?.action)
+        XCTAssertEqual(binding3.inputs, binding4?.inputs)
+        XCTAssertEqual(KeyBinding(dict: ["action": "stickyShift", "inputs": []])?.action, .stickyShift)
     }
 
     func testInputAccepts() {


### PR DESCRIPTION
キーバインドセットの読み込みで、現在のバージョンで対応してないキーバインドが見つかった場合など不明な値があっても読み込みを続行するようにします。
これが原因で、例えば新しいバージョンのmacSKKで作成したキーバインドセットが古いバージョンで読み込めなくなるようなことが起きにくくなります。

これが役立つ例として #305 では新たに "affix" というキーバインドを追加しました。
ローカル開発時に #305 のデバッグ時に設定した "affix" 設定があるせいで別ブランチの開発時にキーバインドセットが読み込めなくなってしまっていました。
このPRによって現在のバージョンで未対応のキーバインドが設定されていてもとりあえず読み込めるようにはなります。

これは開発者が助かる場合ですが、同じようなことはなんらかの理由で古いバージョンのmacSKKを使わないといけなくなったときなどにも有用なことがありそうです。