### PR TITLE
シフトを押していると変化する記号をキーバインド用のキー集合から削除

### DIFF
--- a/macSKK/CurrentInput.swift
+++ b/macSKK/CurrentInput.swift
@@ -17,13 +17,13 @@ struct CurrentInput: Equatable {
         self.modifierFlags = modifierFlags
     }
 
+    /**
+     * > Important: keyBindingInputsViewのキーイベントで取れるNSEventのcharactersIgnoringModifiersはシフトで変わる記号 (Shift-1で!など)
+     *              の場合、"!" になっている。そのようなNSEventの場合、本来をKey.characterとして解釈されるべきところで
+     *              Key.codeとして解釈されてしまうため使用しないこと。
+     */
     init(event: NSEvent) {
-        if event.modifierFlags.contains(.shift), let character = event.characters?.lowercased().first, Key.characters.contains(character) {
-            // Shiftを押しながら入力されたキーはキーバインド設定から登録した場合は (NSEvent#charactersIgnoringModifiersが記号のほうを返すため)
-            // .character("!") のように記号のほうをもっているが、IMKInputController#handleに渡されるNSEventの
-            // charactersIgnoringModifiersは記号のほうではない ("!"なら"1"になっている) ため、charactersのほうを見る
-            key = .character(character)
-        } else if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
+        if let character = event.charactersIgnoringModifiers?.lowercased().first, Key.characters.contains(character) {
             key = .character(character)
         } else {
             key = .code(event.keyCode)

--- a/macSKK/Key.swift
+++ b/macSKK/Key.swift
@@ -17,7 +17,7 @@ enum Key: Hashable, Equatable {
     /// macSKKでkeyCodeベースでなく印字されている文字で取り扱うキーの集合。
     /// Shiftを押しながら入力する記号は含めない。これはIMKInputControllerに渡されるNSEventの
     /// NSEvent#charactersIgnoringModifiersと同じ。
-    static let characters: [Character] = "abcdefghijklmnopqrstuvwxyz1234567890,./;-=`'\\".map { $0 }
+    static let characters: [Character] = "abcdefghijklmnopqrstuvwxyz1234567890,./;-=`'\\@^[]".map { $0 }
 
     /// Inputで管理する修飾キーの集合。ここに含まれてない修飾キーは無視する
     static let allowedModifierFlags: NSEvent.ModifierFlags = [.shift, .control, .function, .option, .command]

--- a/macSKK/Key.swift
+++ b/macSKK/Key.swift
@@ -15,19 +15,22 @@ enum Key: Hashable, Equatable {
     /// 例えば設定でDvorak配列を選んだ状態でoを入力してもkeyCodeはQwerty配列のsのキーと同じになる。
     case code(UInt16)
     /// macSKKでkeyCodeベースでなく印字されている文字で取り扱うキーの集合。
-    /// キーバインド設定画面で使用しているNSEvent#charactersIngoringModifiersはIMKInputControllerへ入力されるNSEventと違い
-    /// Shiftを押しながら入力する記号の場合 (!とか) は記号の方が渡ってくる
-    /// (IMKInputControllerのNSEvent#charactersIgnoringModifiersは1)
-    /// Shiftを押しながら入力する記号も含まれている。
-    static let characters: [Character] = "abcdefghijklmnopqrstuvwxyz1234567890,./;-=`'\\!@#$%^&*()|:<>?\"~".map { $0 }
+    /// Shiftを押しながら入力する記号は含めない。これはIMKInputControllerに渡されるNSEventの
+    /// NSEvent#charactersIgnoringModifiersと同じ。
+    static let characters: [Character] = "abcdefghijklmnopqrstuvwxyz1234567890,./;-=`'\\".map { $0 }
 
     /// Inputで管理する修飾キーの集合。ここに含まれてない修飾キーは無視する
     static let allowedModifierFlags: NSEvent.ModifierFlags = [.shift, .control, .function, .option, .command]
 
     // UserDefaultsからのデコード用
     init?(rawValue: Any) {
-        if let character = rawValue as? String, Self.characters.contains(character) {
-            self = .character(Character(character))
+        if let character = rawValue as? String {
+            if Self.characters.contains(character) {
+                self = .character(Character(character))
+            } else {
+                logger.warning("キーバインドに使えない文字 \"\(character, privacy: .public)\" が指定されています")
+                return nil
+            }
         } else if let keyCode = rawValue as? UInt16 {
             self = .code(keyCode)
         } else {

--- a/macSKK/Settings/KeyEventView.swift
+++ b/macSKK/Settings/KeyEventView.swift
@@ -20,7 +20,10 @@ struct KeyEventView: View {
                 .onAppear {
                     eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
                         characters = event.characters ?? ""
-                        charactersIgnoringModifiers = event.charactersIgnoringModifiers ?? ""
+                        // event.charactersIgnoringModifiersは IMKInputControllerへの入力とは違って
+                        // Shiftを押しながらだと変わる記号はそのままになっているという違いがある。
+                        // そのためIMKInputControllerに渡されるのに近い「修飾キーがないときの入力」を取得する。
+                        charactersIgnoringModifiers = event.characters(byApplyingModifiers: []) ?? ""
                         keyCode = event.keyCode.description
                         var modifiers: [String] = []
                         if event.modifierFlags.contains(.capsLock) {

--- a/macSKKTests/CurrentInputTests.swift
+++ b/macSKKTests/CurrentInputTests.swift
@@ -22,13 +22,16 @@ final class CurrentInputTests: XCTestCase {
     func testCurrentInputCharacterWithShift() {
         let inputQ = CurrentInput(key: .character("q"), modifierFlags: [])
         let inputShiftQ = CurrentInput(key: .character("q"), modifierFlags: .shift)
+        let inputShift1 = CurrentInput(key: .character("1"), modifierFlags: .shift)
         let eventQ = generateKeyEvent(modifierFlags: [], characters: "q")
         let eventShiftQ = generateKeyEvent(modifierFlags: .shift, characters: "q")
-        
+        let eventShift1 = generateKeyEvent(modifierFlags: .shift, characters: "!", charactersIgnoringModifiers: "1")
+
         XCTAssertEqual(inputQ, CurrentInput(event: eventQ))
         XCTAssertEqual(inputShiftQ, CurrentInput(event: eventShiftQ))
         XCTAssertNotEqual(inputQ, CurrentInput(event: eventShiftQ))
         XCTAssertNotEqual(inputShiftQ, CurrentInput(event: eventQ))
+        XCTAssertEqual(inputShift1, CurrentInput(event: eventShift1))
     }
 
     func testCurrentInputKeyCodeWithShift() {


### PR DESCRIPTION
#181 で入れた、シフトキーを押しながらだと変わる記号をキーバインドに登録するための特別な処理を削除します。

- シフトキーで変わる記号をKey.charactersに入れていたのを削除
- CurrentInputで NSEvent.characters も見ていた処理を削除

#181 でキーバインドの変更を設定画面でできるようにしましたが、そのときは設定画面のキー入力イベントの `NSEvent#charactersIngoringModifiers` はIMKInputControllerへ入力されるNSEventと違い、Shiftを押しながら入力する記号の場合 (!とか) は記号の方が渡ってくるということがわかっており、そのような記号を含むキーバインドが登録することを考慮して無理やり使われそうな記号もキーバインド入力で許可するように変更していました。

ですが #317 で `NSEvent.characters(byApplyingModifiers:)` を使えばこのような記号のキーイベントでも本来の印字キーが取れることがわかったためその処理は不要になりました。

懸念としてはすでにそのようなシフトで変わるキーを独自のキーバインドに設定している場合ですが、自動マイグレーションを書くのはけっこう大変なので基本無視することにしようと思います。
#325 でこのように未対応になったキーが登録されたキーバインドが設定されていても全体のキーバインドセット自体は読めるようにしておこうと思います。