### PR TITLE
複製時のキーバインドセット名のデフォルトを設定

### DIFF
--- a/macSKK/Settings/KeyBinding/KeyBindingView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingView.swift
@@ -44,7 +44,8 @@ struct KeyBindingView: View {
         }
         .padding([.top, .leading, .trailing])
         .sheet(item: $editingKeyBindingSetMode) { mode in
-            KeyBindingSetView(settingsViewModel: settingsViewModel, mode: $editingKeyBindingSetMode, id: settingsViewModel.selectedKeyBindingSet.id)
+            let copyId = String(format: String(localized: "DuplicatedKeyBindingName"), settingsViewModel.selectedKeyBindingSet.id)
+            KeyBindingSetView(settingsViewModel: settingsViewModel, mode: $editingKeyBindingSetMode, id: copyId)
         }
         .confirmationDialog("Delete", isPresented: $isShowingConfirmDeleteAlert) {
             Button("Cancel", role: .cancel) {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -136,3 +136,4 @@
 "SelectingBackspaceDropLastAlways" = "Delete a last character & commit always";
 "Follow Romaji-Kana Rule" = "Follow Romaji-Kana Rule";
 "EnterKey" = "Enter \"%@\"";
+"DuplicatedKeyBindingName" = "Copy of %@";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -136,3 +136,4 @@
 "SelectingBackspaceDropLastAlways" = "常に一文字削除して確定";
 "Follow Romaji-Kana Rule" = "ローマ字かな変換ルールに従う";
 "EnterKey" = "\"%@\" を入力";
+"DuplicatedKeyBindingName" = "%@ のコピー";


### PR DESCRIPTION
キーバインドセットを複製するときのデフォルト名を "XXX のコピー" (英語ロケールでは "Copy of XXX") にします。
#328 のようなケースでもとりあえず複製はできるようになるかなと思います。

<img width="640" alt="image" src="https://github.com/user-attachments/assets/7306902b-ddcd-4c98-84a3-5b4d3ba6f588" />
