### PR TITLE
macOS 13ではキーイベントの情報をUCKeyTranslateで取得する

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		CEB088902A7F73B400EFD1E3 /* Pasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0888F2A7F73B400EFD1E3 /* Pasteboard.swift */; };
 		CEB141702A8773DB005E7252 /* SKK-JISYO.test.utf8 in Resources */ = {isa = PBXBuildFile; fileRef = CEB1416F2A8773DB005E7252 /* SKK-JISYO.test.utf8 */; };
 		CEB141722A87D16C005E7252 /* DictionaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB141712A87D16C005E7252 /* DictionaryView.swift */; };
+		CEBEE7872D97D25800C73B6D /* NSEvent+CoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBEE7862D97D25800C73B6D /* NSEvent+CoreService.swift */; };
 		CEC061C82ABB0A0100A11614 /* CompletionPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC061C72ABB0A0100A11614 /* CompletionPanel.swift */; };
 		CEC061CA2ABB0A7900A11614 /* CompletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC061C92ABB0A7900A11614 /* CompletionViewModel.swift */; };
 		CEC376E82965199500D9C432 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC376E72965199500D9C432 /* SettingsView.swift */; };
@@ -275,6 +276,7 @@
 		CEB088952A81353400EFD1E3 /* DictionaryServiceExtention.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DictionaryServiceExtention.h; sourceTree = "<group>"; };
 		CEB1416F2A8773DB005E7252 /* SKK-JISYO.test.utf8 */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SKK-JISYO.test.utf8"; sourceTree = "<group>"; };
 		CEB141712A87D16C005E7252 /* DictionaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryView.swift; sourceTree = "<group>"; };
+		CEBEE7862D97D25800C73B6D /* NSEvent+CoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSEvent+CoreService.swift"; sourceTree = "<group>"; };
 		CEC061C72ABB0A0100A11614 /* CompletionPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPanel.swift; sourceTree = "<group>"; };
 		CEC061C92ABB0A7900A11614 /* CompletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionViewModel.swift; sourceTree = "<group>"; };
 		CEC376E72965199500D9C432 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				CE496C902B440892001C623C /* URL+Additions.swift */,
 				CED987402BB953E7001B40F9 /* Data+EucJis2004.swift */,
 				CE485A892A8FA5C6008271EF /* UserNotificationDelegate.swift */,
+				CEBEE7862D97D25800C73B6D /* NSEvent+CoreService.swift */,
 				CE7F9ADA2AB53E31001B1877 /* View */,
 				CEC376E929651DE000D9C432 /* Settings */,
 				CEB088922A81342E00EFD1E3 /* macSKK-Bridging-Header.h */,
@@ -824,6 +827,7 @@
 				CE5ECF362957034B00E7BE7D /* macSKKApp.swift in Sources */,
 				CEC061C82ABB0A0100A11614 /* CompletionPanel.swift in Sources */,
 				CE4CB5CC2AD557D90046FA34 /* NumberEntry.swift in Sources */,
+				CEBEE7872D97D25800C73B6D /* NSEvent+CoreService.swift in Sources */,
 				CEF3D86C2B9C022900BD1D3A /* WorkaroundApplicationView.swift in Sources */,
 				CE11C7B52BDD461C00A35F3D /* Global.swift in Sources */,
 				CE84A3DE29571797009394C4 /* Action.swift in Sources */,

--- a/macSKK/NSEvent+CoreService.swift
+++ b/macSKK/NSEvent+CoreService.swift
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+import CoreServices
+import Carbon.HIToolbox.TextInputSources
+
+extension NSEvent {
+    /**
+     * キーイベントについて、修飾キーが押されてないときの文字列を返す。
+     * 例えば Shift-aなら "A" ではなく "a"、Shift-1なら "!" ではなく "1" を返す。
+     * 正常に取得できなかった場合は`nil`を返す
+     *
+     * > NOTE: macOS 13では ``NSEvent/characters(byApplyingModifiers:)`` がnilを返す問題が発覚したため、
+     *         そのような環境用にCoreServicesの古いAPIで取得している。
+     */
+    var charactersWithoutModifiers: String? {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let layoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+
+        let keyLayoutPtr = unsafeBitCast(CFDataGetBytePtr(unsafeBitCast(layoutData, to: CFData.self)),
+                                         to: UnsafePointer<UCKeyboardLayout>.self)
+        var deadKeyState: UInt32 = 0
+        let maxStringLength = 4
+        var actualStringLength = 0
+        var unicodeString = [UniChar](repeating: 0, count: maxStringLength)
+
+        let status = UCKeyTranslate(
+            keyLayoutPtr,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            0,
+            UInt32(LMGetKbdType()),
+            OptionBits(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            maxStringLength,
+            &actualStringLength,
+            &unicodeString
+        )
+
+        guard status == noErr else {
+            logger.warning("入力されたキーの情報が取得できませんでした: status=\(status)")
+            return nil
+        }
+
+        return String(utf16CodeUnits: unicodeString, count: actualStringLength)
+    }
+}

--- a/macSKK/Settings/KeyBinding/KeyBindingInputsView.swift
+++ b/macSKK/Settings/KeyBinding/KeyBindingInputsView.swift
@@ -150,7 +150,14 @@ struct KeyBindingInputsView: View {
                     if let newEditingInput {
                         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
                             let key: Key
-                            if let character = event.characters(byApplyingModifiers: [])?.first, Key.characters.contains(character) {
+                            let character = if #available(macOS 14, *) {
+                                event.characters(byApplyingModifiers: [])?.first
+                            } else {
+                                // macOS 13では ``NSEvent/characters(byApplyingModifiers:)`` がnilを返すので使用しない
+                                // https://github.com/mtgto/example-characters-by-applying-modifiers/issues/1
+                                event.charactersWithoutModifiers?.first
+                            }
+                            if let character, Key.characters.contains(character) {
                                 key = .character(character)
                             } else {
                                 key = .code(event.keyCode)

--- a/macSKK/Settings/KeyEventView.swift
+++ b/macSKK/Settings/KeyEventView.swift
@@ -23,7 +23,11 @@ struct KeyEventView: View {
                         // event.charactersIgnoringModifiersは IMKInputControllerへの入力とは違って
                         // Shiftを押しながらだと変わる記号はそのままになっているという違いがある。
                         // そのためIMKInputControllerに渡されるのに近い「修飾キーがないときの入力」を取得する。
-                        charactersIgnoringModifiers = event.characters(byApplyingModifiers: []) ?? ""
+                        if #available(macOS 14, *) {
+                            charactersIgnoringModifiers = event.characters(byApplyingModifiers: []) ?? ""
+                        } else {
+                            charactersIgnoringModifiers = event.charactersWithoutModifiers ?? ""
+                        }
                         keyCode = event.keyCode.description
                         var modifiers: [String] = []
                         if event.modifierFlags.contains(.capsLock) {


### PR DESCRIPTION
#330
キーバインド設定で、入力したキーの情報を取得するのに #317 で [`NSEvent.characters(byApplyingModifiers:)`](https://developer.apple.com/documentation/appkit/nsevent/characters(byapplyingmodifiers:)) を使うようにしました。
ところが、macOS 13.7.4ではこのAPIがnilを返してしまうようです。
macOS 14.7.2や15.3.2では問題ありませんでした。
https://github.com/mtgto/example-characters-by-applying-modifiers/issues/1

macOS 13ではCore ServicesのUnicode Utilitiesの[UCKeyTranslate](https://developer.apple.com/documentation/coreservices/1390584-uckeytranslate)というAPIを使って入力したキーの情報を取得するようにします。
※Unicode Utilities自体がDeprecatedなのでmacOS 13でだけ利用します。