### PR TITLE
ファイル辞書がないときに辞書フォルダ監視をしないバグを修正

### DIFF
--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -40,30 +40,34 @@ struct DictionariesView: View {
                     Text("SKKServ")
                 }
                 Section {
-                    List {
-                        ForEach($settingsViewModel.dictSettings) { dictSetting in
-                            HStack(alignment: .top) {
-                                Toggle(isOn: dictSetting.enabled) {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(dictSetting.id)
-                                            .font(.body)
-                                        Text(loadingStatus(setting: dictSetting.wrappedValue))
-                                            .font(.footnote)
+                    if settingsViewModel.dictSettings.isEmpty {
+                        Text("SettingsFileDictionariesEmpty")
+                    } else {
+                        List {
+                            ForEach($settingsViewModel.dictSettings) { dictSetting in
+                                HStack(alignment: .top) {
+                                    Toggle(isOn: dictSetting.enabled) {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(dictSetting.id)
+                                                .font(.body)
+                                            Text(loadingStatus(setting: dictSetting.wrappedValue))
+                                                .font(.footnote)
+                                        }
                                     }
+                                    .toggleStyle(.switch)
+                                    Button {
+                                        selectedDictSetting = dictSetting.wrappedValue
+                                    } label: {
+                                        Image(systemName: "info.circle")
+                                            .resizable()
+                                            .frame(width: 16, height: 16)
+                                    }
+                                    .buttonStyle(.borderless)
                                 }
-                                .toggleStyle(.switch)
-                                Button {
-                                    selectedDictSetting = dictSetting.wrappedValue
-                                } label: {
-                                    Image(systemName: "info.circle")
-                                        .resizable()
-                                        .frame(width: 16, height: 16)
-                                }
-                                .buttonStyle(.borderless)
+                                .padding(EdgeInsets(top: 4, leading: 2, bottom: 4, trailing: 2))
+                            }.onMove { from, to in
+                                settingsViewModel.dictSettings.move(fromOffsets: from, toOffset: to)
                             }
-                            .padding(EdgeInsets(top: 4, leading: 2, bottom: 4, trailing: 2))
-                        }.onMove { from, to in
-                            settingsViewModel.dictSettings.move(fromOffsets: from, toOffset: to)
                         }
                     }
                 } header: {
@@ -131,7 +135,7 @@ struct DictionariesView_Previews: PreviewProvider {
         case dummy
     }
 
-    static var previews: some View {
+    private static func makeSettingsViewModel() -> SettingsViewModel {
         let dictSettings = [
             DictSetting(filename: "SKK-JISYO.L", enabled: true, type: .traditional(.japaneseEUC)),
             DictSetting(filename: "SKK-JISYO.sample.utf-8", enabled: false, type: .traditional(.utf8)),
@@ -145,6 +149,11 @@ struct DictionariesView_Previews: PreviewProvider {
             "SKK-JISYO.dummy": .loading,
             "SKK-JISYO.error": .fail(DictionariesViewPreviewError.dummy)
         ]
-        return DictionariesView(settingsViewModel: settings)
+        return settings
+    }
+
+    static var previews: some View {
+        DictionariesView(settingsViewModel: makeSettingsViewModel())
+        DictionariesView(settingsViewModel: try! SettingsViewModel(dictSettings: [])).previewDisplayName("辞書が空のとき")
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -415,11 +415,6 @@ final class SettingsViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        // 空以外のdictSettingsがセットされたときに一回だけ実行する
-        $dictSettings.filter({ !$0.isEmpty }).first().sink { [weak self] _ in
-            self?.setupNotification()
-        }.store(in: &cancellables)
-
         $selectedInputSourceId.removeDuplicates().sink { [weak self] selectedInputSourceId in
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {
                 logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) (\(selectedInputSourceId, privacy: .public)) に設定しました")
@@ -620,8 +615,6 @@ final class SettingsViewModel: ObservableObject {
      * enabled=falseでfileDictsに追加されてしまい、読み込みスキップされたというログがでてしまうため。
      */
     func setupNotification() {
-        assert(dictSettings.isEmpty, "dictSettingsが空の状態でsetupNotificationしようとしました。バグと思われます。")
-
         NotificationCenter.default.publisher(for: notificationNameDictFileDidAppear).receive(on: RunLoop.main)
             .sink { [weak self] notification in
                 if let self, let url = notification.object as? URL {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 "SettingsNoteDictionaries" = "If you want to add a dictionary, place your dictionary file in the dictionary folder and activate it on this panel.";
 "SettingsFileDictionariesTitle" = "Dictionary files";
 "SettingsFileDictionariesSubtitle" = "You can reorder the priorities of dictionary by drag & drop";
+"SettingsFileDictionariesEmpty" = "There is no dictionary file.";
 "SettingsNoteDirectMode" = "Set Front-Most to target app and select \"Direct input from (AppName)\" in Input Menu.";
 "SettingsNoteWorkaround" = "you can enable/disable workaround settings from the Input Menu when the target app is in Front-Most.";
 "SettingsHeaderWorkaroundApplication" = "Workaround settings for the application";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 "SettingsNoteDictionaries" = "辞書を追加したい場合は辞書フォルダに辞書ファイルを置き、この画面で有効化してください。";
 "SettingsFileDictionariesTitle" = "ファイル辞書";
 "SettingsFileDictionariesSubtitle" = "項目をドラッグすることで優先順位を入れ替え可能です。";
+"SettingsFileDictionariesEmpty" = "ファイル辞書がありません";
 "SettingsNoteDirectMode" = "日本語変換を行いたくないアプリが最前面の状態で、入力メニューから \"(アプリ名)では直接入力\" を選択してください。";
 "SettingsNoteWorkaround" = "設定したいアプリが最前面の状態で、入力メニューからも互換性の設定の有効・無効を設定できます。";
 "SettingsHeaderWorkaroundApplication" = "アプリケーションの互換性の設定";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -236,6 +236,8 @@ struct macSKKApp: App {
             return
         }
         settingsViewModel.dictSettings = dictSettings
+        // 辞書フォルダの監視をセットアップ
+        settingsViewModel.setupNotification()
     }
 
     // UNNotificationの設定


### PR DESCRIPTION
#299 起動時にユーザー辞書以外のSKKファイル辞書が `~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries` にないとき、新しいファイルの作成やファイルの削除(移動)を監視する機能が動かないようになっていました。
これを修正します。

またファイル辞書が1つもないときに辞書設定画面で一個もないことがわかるようにします。

<img width="752" alt="empty-file-dict" src="https://github.com/user-attachments/assets/88c1fc60-4119-4743-9d2c-a841b1281032" />

