### PR TITLE
Enterキーで変換確定と一緒に改行する設定が永続化されるよう修正

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -483,6 +483,7 @@ final class SettingsViewModel: ObservableObject {
 
         $enterNewLine.dropFirst().sink { enterNewLine in
             logger.log("Enterキーで変換確定と一緒に改行する設定を\(enterNewLine ? "有効" : "無効", privacy: .public)にしました") 
+            UserDefaults.standard.set(enterNewLine, forKey: UserDefaultsKeys.enterNewLine)
             Global.enterNewLine = enterNewLine
         }.store(in: &cancellables)
 


### PR DESCRIPTION
#333 の対応です。

修正前: 当該設定を変更後に `pkill "macSKK"` すると設定が書き戻っていた。
修正後: 同様の操作を行い、設定が保持されることを確認しました。