### PR TITLE
`IMKInputController.setValue(_:forTag:client:)` の処理を一部非同期に変更

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -45,6 +45,8 @@ import Combine
     static var candidateListDirection = CurrentValueSubject<CandidateListDirection, Never>(.vertical)
     /// 現在のキー配列
     static var selectedInputSourceId: String = InputSource.defaultInputSourceId
+    /// 入力モードのモーダルを表示するかどうか
+    static var showInputModePanel: Bool = true
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -43,6 +43,8 @@ import Combine
     static var punctuation: Punctuation = .default
     /// 変換候補パネルの表示方向
     static var candidateListDirection = CurrentValueSubject<CandidateListDirection, Never>(.vertical)
+    /// 現在のキー配列
+    static var selectedInputSourceId: String = InputSource.defaultInputSourceId
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -87,8 +87,7 @@ class InputController: IMKInputController {
                     if !self.directMode {
                         textInput.selectMode(inputMode.rawValue)
                         
-                        let showInputModePanel = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showInputModePanel)
-                        if showInputModePanel {
+                        if Global.showInputModePanel {
                             Global.inputModePanel.show(at: cursorPosition.origin,
                                                        mode: inputMode,
                                                        privateMode: Global.privateMode.value,
@@ -281,6 +280,9 @@ class InputController: IMKInputController {
 
     @MainActor override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
         guard let value = value as? String else { return }
+        if directMode {
+            return
+        }
         guard let inputMode = InputMode(rawValue: value) else { return }
         logger.debug("入力モードが変更されました \(inputMode.rawValue)")
         stateMachine.setMode(inputMode)
@@ -292,8 +294,7 @@ class InputController: IMKInputController {
         // カーソル位置あたりを取得する
         _ = textInput.attributes(forCharacterIndex: 0, lineHeightRectangle: &cursorPosition)
         windowLevel = NSWindow.Level(rawValue: Int(textInput.windowLevel() + 1))
-        let showInputModePanel = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showInputModePanel)
-        if showInputModePanel && !directMode {
+        if Global.showInputModePanel && !directMode {
             Global.inputModePanel.show(at: cursorPosition.origin, mode: inputMode, privateMode: Global.privateMode.value, windowLevel: windowLevel)
         }
         // キー配列を設定する

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -346,11 +346,7 @@ class InputController: IMKInputController {
 
     // キー配列を設定する
     private func setCustomInputSource(textInput: any IMKTextInput) {
-        if let inputSourceID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputSource) {
-            logger.info("InputSourceIDを \(inputSourceID, privacy: .public) に設定します")
-            textInput.overrideKeyboard(withKeyboardNamed: inputSourceID)
-        } else {
-            logger.info("InputSourceIDは選択されていません")
-        }
+        logger.info("InputSourceIDを \(Global.selectedInputSourceId, privacy: .public) に設定します")
+        textInput.overrideKeyboard(withKeyboardNamed: Global.selectedInputSourceId)
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -515,6 +515,7 @@ final class SettingsViewModel: ObservableObject {
         
         $showInputIconModal.dropFirst().sink { showInputModePanel in
             UserDefaults.standard.set(showInputModePanel, forKey: UserDefaultsKeys.showInputModePanel)
+            Global.showInputModePanel = showInputModePanel
             logger.log("入力モードアイコンを\(showInputModePanel ? "表示" : "非表示", privacy: .public)に変更しました")
         }.store(in: &cancellables)
 

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -324,6 +324,7 @@ final class SettingsViewModel: ObservableObject {
         Global.punctuation = Punctuation(comma: comma, period: period)
         Global.ignoreUserDictInPrivateMode.send(ignoreUserDictInPrivateMode)
         Global.candidateListDirection.send(candidateListDirection)
+        Global.selectedInputSourceId = selectedInputSourceId
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
@@ -424,6 +425,7 @@ final class SettingsViewModel: ObservableObject {
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {
                 logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) (\(selectedInputSourceId, privacy: .public)) に設定しました")
                 UserDefaults.standard.set(selectedInputSource.id, forKey: UserDefaultsKeys.selectedInputSource)
+                Global.selectedInputSourceId = selectedInputSource.id
             } else {
                 if let self, !self.inputSources.isEmpty {
                     logger.error("キー配列 \(selectedInputSourceId, privacy: .public) が見つかりませんでした")


### PR DESCRIPTION
#336 SafariやDashでアドレスバーにカーソルを移動するとレインボーカーソルが数秒出ることがある問題を解消します。

フォーカスが当たるテキストフォールドが変更されたときなどに呼ばれる `IMKInputController.setValue(_:forTag:client:)` の処理のうち、Dashアプリでアドレスバーに移動するときに高確率で固まる部分をTaskで囲んだところ私の環境では改善しました。