### PR TITLE
ウィンドウレベルやカーソル位置をUI表示時に取得するように遅延させる

### DIFF
--- a/macSKK/Action.swift
+++ b/macSKK/Action.swift
@@ -8,16 +8,13 @@ struct Action {
     let keyBind: KeyBinding.Action?
     /// キーイベント
     let event: NSEvent
-    /// 現在のカーソル位置。正常に取得できない場合はNSRect.zeroになっているかも?
-    let cursorPosition: NSRect
     let textInput: (any IMKTextInput)?
     /// ``Romaji/convertKeyEvent(_:)`` によって変換されたNSEventから生成されたアクションかどうか.
     let treatAsAlphabet: Bool
 
-    init(keyBind: KeyBinding.Action?, event: NSEvent, cursorPosition: NSRect, textInput: (any IMKTextInput)? = nil, treatAsAlphabet: Bool = false) {
+    init(keyBind: KeyBinding.Action?, event: NSEvent, textInput: (any IMKTextInput)? = nil, treatAsAlphabet: Bool = false) {
         self.keyBind = keyBind
         self.event = event
-        self.cursorPosition = cursorPosition
         self.textInput = textInput
         self.treatAsAlphabet = treatAsAlphabet
     }

--- a/macSKK/State.swift
+++ b/macSKK/State.swift
@@ -403,8 +403,6 @@ struct SelectingState: Equatable, MarkedTextProtocol {
     /// 変換候補
     let candidates: [Candidate]
     var candidateIndex: Int = 0
-    /// カーソル位置。この位置を基に変換候補パネルを表示する
-    let cursorPosition: NSRect
     /// カーソル位置より後のテキスト部分。ひらがな(Abbrevモード以外) or 英数(Abbrevモード)の配列
     let remain: [String]?
 
@@ -414,7 +412,6 @@ struct SelectingState: Equatable, MarkedTextProtocol {
             yomi: yomi,
             candidates: candidates,
             candidateIndex: candidateIndex + diff,
-            cursorPosition: cursorPosition,
             remain: remain)
     }
 
@@ -687,7 +684,6 @@ struct Candidates: Equatable {
     /// パネル形式のときの現在ページと最大ページ数。インライン変換中はnil
     let page: Page?
     let selected: Candidate
-    let cursorPosition: NSRect
 }
 
 struct IMEState {

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -231,7 +231,6 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("亜")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         XCTAssertEqual(selectingState.fixedText(dropLast: false), "亜")
@@ -252,7 +251,6 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         XCTAssertEqual(selectingState.fixedText(dropLast: false), "有る")
@@ -265,14 +263,12 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero,
                                             remain: nil)
         XCTAssertEqual(selectingState.markedTextElements(inputMode: .hiragana), [.markerSelect, .emphasized("尾")])
         selectingState = SelectingState(prev: SelectingState.PrevState(mode: .hiragana, composing: composingState),
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero,
                                             remain: ["か", "き"])
         XCTAssertEqual(selectingState.markedTextElements(inputMode: .hiragana), [.markerSelect, .emphasized("尾"), .cursor, .plain("かき")])
     }
@@ -290,7 +286,6 @@ final class StateTests: XCTestCase {
             yomi: "お",
             candidates: [Candidate("尾")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         XCTAssertEqual(selectingState.okuri, nil)
@@ -308,7 +303,6 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         XCTAssertEqual(selectingState.okuri, "る")
@@ -326,7 +320,6 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         XCTAssertNil(selectingState.okuri)
@@ -399,7 +392,6 @@ final class StateTests: XCTestCase {
             yomi: "あ",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         var state = UnregisterState(
@@ -436,7 +428,6 @@ final class StateTests: XCTestCase {
                                             yomi: "い",
                                             candidates: [Candidate("井")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero,
                                             remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
@@ -456,7 +447,6 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero,
                                             remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
@@ -477,7 +467,6 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero,
                                             remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
@@ -503,7 +492,6 @@ final class StateTests: XCTestCase {
                                             yomi: "お",
                                             candidates: [Candidate("尾")],
                                             candidateIndex: 0,
-                                            cursorPosition: .zero,
                                             remain: nil)
         let state = IMEState(inputMode: .hiragana,
                              inputMethod: .selecting(selectingState),
@@ -527,7 +515,6 @@ final class StateTests: XCTestCase {
             yomi: "あr",
             candidates: [Candidate("有")],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         let unregisterState = UnregisterState(prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "yes")
@@ -553,7 +540,6 @@ final class StateTests: XCTestCase {
             yomi: "だい2",
             candidates: [Candidate("第2", original: Candidate.Original(midashi: "だい#", word: "第#"))],
             candidateIndex: 0,
-            cursorPosition: .zero,
             remain: nil
         )
         let unregisterState = UnregisterState(prev: UnregisterState.PrevState(mode: .hiragana, selecting: prevSelectingState), text: "yes")


### PR DESCRIPTION
#336 すべてのキー入力に対して実行していた入力されているウィンドウレベルを取得とカーソル位置の取得するのをやめます。
変換候補パネルの表示や補完候補の表示などUI表示が必要なときにだけ取得するようにしたため、処理が軽くなることが期待できます。
ただこれだけでは私の環境では #336 のレインボーカーソルは完全には防げてなさそうです。