### PR TITLE
不要なキーをInfo.plistから削除

### DIFF
--- a/macSKK/Info.plist
+++ b/macSKK/Info.plist
@@ -6,22 +6,10 @@
 	<string>net.mtgto.inputmethod.macSKK_Connection</string>
 	<key>InputMethodServerControllerClass</key>
 	<string>InputController</string>
-	<key>TISInputSourceID</key>
-	<string>net.mtgto.inputmethod.macSKK</string>
 	<key>TISIntendedLanguage</key>
 	<string>ja</string>
 	<key>TISIconIsTemplate</key>
 	<true/>
-	<key>net.mtgto.inputmethod.macSKK.ascii</key>
-	<string>ABC (macSKK)</string>
-	<key>net.mtgto.inputmethod.macSKK.hiragana</key>
-	<string>Hiragana (macSKK)</string>
-	<key>net.mtgto.inputmethod.macSKK.katakana</key>
-	<string>Katakana (macSKK)</string>
-	<key>net.mtgto.inputmethod.macSKK.hankaku</key>
-	<string>Hankaku (macSKK)</string>
-	<key>net.mtgto.inputmethod.macSKK.eisu</key>
-	<string>Eisu (macSKK)</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>


### PR DESCRIPTION
Info.plistを見ていたら最上位階層に `TISInputSourceID` があり、不要そうなことに気付きました。
なにか問題になるわけではないですが、削除します。
またInfoPlist.strings で上書きしているキーたちもついでにInfo.plistから削除します。

参考にしました

- AquaSKK https://github.com/codefirst/aquaskk/blob/4.7.6/platform/mac/proj/AquaSKK-Info.plist
- Mozc https://github.com/google/mozc/blob/2.31.5712.102/src/mac/Info.plist