### PR TITLE
入力モードのアイコン表示を非同期表示する

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -282,10 +282,17 @@ class InputController: IMKInputController {
         if showInputModePanel && !directMode {
             let cursorPosition = cursorPosition(for: textInput)
             if cursorPosition != .zero {
-                Global.inputModePanel.show(at: cursorPosition.origin,
-                                           mode: inputMode,
-                                           privateMode: Global.privateMode.value,
-                                           windowLevel: windowLevel(for: textInput))
+                let windowLevel = windowLevel(for: textInput)
+                // Safariでアドレスバーに移動するときなど、処理が固まることがあるので非同期で実行する
+                // ただしIMKTextInputへのアクセスはsetValue内で同期で行う必要がある
+                Task {
+                    await MainActor.run {
+                        Global.inputModePanel.show(at: cursorPosition.origin,
+                                                   mode: inputMode,
+                                                   privateMode: Global.privateMode.value,
+                                                   windowLevel: windowLevel)
+                    }
+                }
             }
         }
         // キー配列を設定する


### PR DESCRIPTION
#336 入力モードのアイコンを表示するときに `InputController#setValue` 内で同期でやっていた処理を非同期に変更します。
これにより私の環境ではSafari, Dashでアドレスバーにカーソルを移動したときにレインボーカーソルが出なくなったようです。
ただ、 #337 とほとんど同じ処理なので (Task -> Combineにして短時間の複数のイベントをthrottleでまとめるようにした、という違いはある) #337 のときのように不安定になる可能性もあるかもしれません。