### PR TITLE
skkservから受信する最小のバイト数を1にする

### DIFF
--- a/SKKServClient/Network/SKKServProtocol.swift
+++ b/SKKServClient/Network/SKKServProtocol.swift
@@ -18,7 +18,7 @@ final class SKKServProtocol: NWProtocolFramerImplementation {
     func handleInput(framer: NWProtocolFramer.Instance) -> Int {
         while true {
             var received: Data? = nil
-            _ = framer.parseInput(minimumIncompleteLength: 4, maximumLength: 1024 * 1024) { buffer, isComplete -> Int in
+            _ = framer.parseInput(minimumIncompleteLength: 1, maximumLength: 1024 * 1024) { buffer, isComplete -> Int in
                 // 直前のリクエストがサーバーのバージョン要求、サーバーのホスト名とIPアドレスのリスト要求の場合はスペースが終端記号となりLFは送られない
                 // NOTE: 2024-03-15現在、yaskkserv2はIPアドレスのリスト要求の場合、スペースが終端記号になっていない
                 if let lastRequest, let buffer, let index = buffer.firstIndex(of: lastRequest.terminateCharacter) {


### PR DESCRIPTION
skkservからの読み込みにおいて、skkservへの接続機能を最初にリリースした #145 の時点で `NWProtocolFramer.Instance.parseInput(minimumIncompleteLength:maximumLength:parse:)` のminimumIncompleteLengthを4にしていました。
この値はAPIドキュメント↓によると「パースに必要な最小バイト数」なんですが、skkservのようにシンプルなプロトコルの場合終端文字しか決まってなかったりします。そのため[サーバーの実装によっては](https://github.com/gitusp/azoo-key-skkserv)補完候補要求に対して "4\n" の2文字だけを返すものがあるようです。そのような環境ではRead Timeoutを設定してない設定画面から読もうとすると無限に待ち続けてしまうようです。
https://developer.apple.com/documentation/network/nwprotocolframer/instance/parseinput(minimumincompletelength:maximumlength:parse:)

いきなり終端文字を返してきた場合にも読み込みを中断できるようにminimumIncompleteLengthを1にします。