### PR TITLE
SKK-JISYO.Lの特別扱いをやめる

### DIFF
--- a/macSKK/Settings/DictionaryView.swift
+++ b/macSKK/Settings/DictionaryView.swift
@@ -22,19 +22,8 @@ struct DictionaryView: View {
                     }
                     .pickerStyle(.radioGroup)
                     .disabled(
-                        // SKK-JISYO.Lは特定の文字コードでmacSKKに同梱される。（Makefileでビルド時にダウンロードしている）
-                        // ユーザーがこれをnkfなどでUTF-8に変更したとしても、macSKKのバージョンをアップデートするたびに
-                        // 上書きされて文字コードが異なって読み込みエラーとなる可能性がある。
-                        // 従ってファイル名が`SKK-JISYO.L`な場合は文字コードの変更を禁止する。
-                        // （文字コードを変更したい場合は、SKK-JISYO.Lをdisableにして別名で辞書ディレクトリーに設置するべきと思われる）
-                        filename == "SKK-JISYO.L" || dictSetting?.type == .json
+                        dictSetting?.type == .json
                     )
-                    if filename == "SKK-JISYO.L" {
-                        HStack {
-                            Image(systemName: "exclamationmark.triangle")
-                            Text("Unable to change encoding SKK-JISYO.L")
-                        }
-                    }
                 }
             }
             .formStyle(.grouped)

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -41,7 +41,6 @@
 "Filename" = "Filename";
 "Dictionary Setting" = "Dictionary Setting";
 "Encoding" = "Encoding";
-"Unable to change encoding SKK-JISYO.L" = "Unable to change encoding of SKK-JISYO.L because it's bundled with macSKK.";
 "UNNewVersionTitle" = "A new version is available";
 "UNNewVersionBody" = "macSKK %@ is now available.";
 "UNUserDictReadErrorTitle" = "Error";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -41,7 +41,6 @@
 "Filename" = "ファイル名";
 "Dictionary Setting" = "辞書の設定";
 "Encoding" = "エンコーディング";
-"Unable to change encoding SKK-JISYO.L" = "SKK-JISYO.LはmacSKKに同梱されているためエンコーディングを変更できません";
 "UNNewVersionTitle" = "新しいバージョンがあります";
 "UNNewVersionBody" = "macSKKの新しいバージョン %@ がリリースされています。";
 "UNUserDictReadErrorTitle" = "エラー";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -173,9 +173,7 @@ struct macSKKApp: App {
 
     private static func setupUserDefaults() {
         UserDefaults.standard.register(defaults: [
-            UserDefaultsKeys.dictionaries: [
-                DictSetting(filename: "SKK-JISYO.L", enabled: true, type: .traditional(.japaneseEUC)).encode()
-            ],
+            UserDefaultsKeys.dictionaries: [],
             UserDefaultsKeys.directModeBundleIdentifiers: [String](),
             UserDefaultsKeys.selectedInputSource: InputSource.defaultInputSourceId,
             UserDefaultsKeys.showAnnotation: true,


### PR DESCRIPTION
#360

v2からインストール先をユーザーディレクトリからシステムディレクトリに変更予定です。
その際にSKK-JISYO.Lを梱包するのを止める予定です。(1つのpkgに複数箇所のインストール先を指定できないため)

このPRではそれに先立ちSKK-JISYO.Lを梱包していたことによる特別扱いを廃止します。

- SKK-JISYO.Lをデフォルト辞書設定として記録していたのを削除
- エンコーディングを変更できないようにしていたのを削除