### PR TITLE
インストール先をシステムに変更。SKK-JISYO.Lを配布物から削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ APP_PKG_ID := net.mtgto.inputmethod.macSKK.app
 DICT_PKG_ID := net.mtgto.inputmethod.macSKK.dict
 PRODUCT_SIGN_ID := "Developer ID Installer"
 
-.PHONY: all $(DICT)
+.PHONY: all
 
 $(XCARCHIVE):
 	xcodebuild -project macSKK.xcodeproj -scheme macSKK -configuration Release CODE_SIGN_IDENTITY="Developer ID Application" DEVELOPMENT_TEAM=$(APPLE_TEAM_ID) OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO CODE_SIGN_STYLE=Manual -archivePath $(XCARCHIVE) archive
@@ -57,7 +57,7 @@ $(APP_PKG): $(APP)
 	cp -r $< $(WORKDIR)/app/Library/Input\ Methods
 	pkgbuild --root $(WORKDIR)/app --component-plist script/app.plist --identifier $(APP_PKG_ID) --version $(VERSION) --install-location / --scripts $(SCRIPTSDIR) $(APP_PKG)
 
-$(INSTALLER_PKG): $(APP_PKG) $(DICT_PKG)
+$(INSTALLER_PKG): $(APP_PKG)
 	mkdir -p $(WORKDIR)/pkg
 	sed -e "s/%TITLE%/macSKK $(VERSION)/" script/distribution.xml.template > script/distribution.xml
 	productbuild --distribution script/distribution.xml --resources script --package-path $(WORKDIR) $(UNSIGNED_PKG)

--- a/script/distribution.xml.template
+++ b/script/distribution.xml.template
@@ -6,16 +6,12 @@
     <title>%TITLE%</title>
     <welcome file="welcome.rtf"/>
     <license file="license.rtf"/>
-    <domains enable_localSystem="false" enable_anywhere="false" enable_currentUserHome="true"/>
-    <options customize="allow" require-scripts="false" hostArchitectures="x86_64,arm64"/>
+    <domains enable_localSystem="true" enable_anywhere="false" enable_currentUserHome="false"/>
+    <options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>
     <choices-outline>
         <line choice="default" />
-        <line choice="skk-jisyo-l" />
     </choices-outline>
     <choice id="default" title="macSKK" enabled="false">
         <pkg-ref id="net.mtgto.inputmethod.macSKK.app">app.pkg</pkg-ref>
-    </choice>
-    <choice id="skk-jisyo-l" title="SKK-JISYO.L" start_selected="true" description="SKK辞書のうちもっとも大きなものです">
-        <pkg-ref id="net.mtgto.inputmethod.macSKK.dict">dict.pkg</pkg-ref>
     </choice>
 </installer-gui-script>

--- a/script/scripts/postinstall
+++ b/script/scripts/postinstall
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
 asns=$(/usr/bin/lsappinfo find bundleID=net.mtgto.inputmethod.macSKK)
 if [[ "$asns" = ASN* ]]; then
-  osascript -e 'tell application id "net.mtgto.inputmethod.macSKK" to quit'
+  /usr/bin/osascript -e 'tell application id "net.mtgto.inputmethod.macSKK" to quit'
 fi


### PR DESCRIPTION
rel. #351

v2からインストール先をユーザーディレクトリからシステムディレクトリに変更予定です。
その際にSKK-JISYO.Lを梱包するのを止める予定です。(1つのpkgに複数箇所のインストール先を指定できないため)

このPRで実際にインストーラからSKK-JISYO.Lを配布物から削除し、インストール先をシステムディレクトリに変更します。
うーん、ただユーザーディレクトリが選べてもいいような気はする。

Homebrew Cask版のmacSKK https://formulae.brew.sh/cask/macskk を使っている人はすでにシステムディレクトリにインストールしているので特に影響はないはずです。
dmgを自分でダウンロードしてインストール使っている人や私のHomebrew Cask https://github.com/mtgto/homebrew-macSKK を使っている人に影響があります。