### PR TITLE
xterm.jsのワークアラウンドにC-jのモード変更を追加

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -90,6 +90,11 @@ final class StateMachine {
                 inputMethodEventSubject.send(.modeChanged(.hiragana))
                 if specialState != nil {
                     updateMarkedText()
+                } else if enableMarkedTextWorkaround {
+                    // 確定文字を未確定文字列として入力するワークアラウンド
+                    state.inputMethod = .composing(
+                        ComposingState(isShift: false, text: [], romaji: "", fixedWorkaroundText: FixedWorkaroundText(text: "", displayText: "[かな]")))
+                    updateMarkedText()
                 }
                 return true
             }

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -115,7 +115,7 @@ final class StateMachineTests: XCTestCase {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         stateMachine.enableMarkedTextWorkaround = true
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(9).sink { events in
+        stateMachine.inputMethodEvent.collect(11).sink { events in
             XCTAssertEqual(events[0], .modeChanged(.katakana))
             XCTAssertEqual(events[1], .markedText(MarkedText([.plain("[カナ]")])))
             XCTAssertEqual(events[2], .markedText(MarkedText([])))
@@ -125,12 +125,15 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[6], .modeChanged(.direct))
             XCTAssertEqual(events[7], .markedText(MarkedText([.plain("[英数]")])))
             XCTAssertEqual(events[8], .markedText(MarkedText([])))
+            XCTAssertEqual(events[9], .modeChanged(.hiragana))
+            XCTAssertEqual(events[10], .markedText(MarkedText([.plain("[かな]")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "l")))
         XCTAssertFalse(stateMachine.handle(printableKeyEventAction(character: "q")))
+        XCTAssertTrue(stateMachine.handle(hiraganaAction))
         wait(for: [expectation], timeout: 1.0)
     }
 


### PR DESCRIPTION
#356 xterm.jsのワークアラウンドにCtrl-jのひらがなへのモード変換時に未確定文字列で `[かな]` を入力します。
VSCodeのClaude Code拡張やHyperではこれにより改行よりも優先してモード変換できるようになります。

このワークアラウンドが有効なときにVSCodeのClaude Code拡張で改行を入れたい場合は Option + Enterなどを使ってください。

## 動画

Hyperで録ったもの。最初アアアのあとにC-jを入力しました。

https://github.com/user-attachments/assets/b09cd02e-f2ba-4bba-a8b6-1312499de766

