### PR TITLE
日付変換候補の編集画面で複数のStateを同時に操作していたのを修正

### DIFF
--- a/macSKK/Settings/DateConversion/DateConversionsView.swift
+++ b/macSKK/Settings/DateConversion/DateConversionsView.swift
@@ -88,18 +88,22 @@ struct DateConversionsView: View {
                          relative: dateYomi.relative)
         }
         .sheet(isPresented: $isAddingDateConversionSheet) {
-            DateConversionView(settingsViewModel: settingsViewModel,
-                               id: nil,
-                               format: "",
-                               locale: .enUS,
-                               calendar: .gregorian)
+            DateConversionView(
+                settingsViewModel: settingsViewModel,
+                id: nil,
+                inputs: DateConversionView.Inputs(
+                    format: "",
+                    locale: .enUS,
+                    calendar: .gregorian))
         }
         .sheet(item: $editingDateConversion) { dateConversion in
-            DateConversionView(settingsViewModel: settingsViewModel,
-                               id: dateConversion.id,
-                               format: dateConversion.format,
-                               locale: dateConversion.locale,
-                               calendar: dateConversion.calendar)
+            DateConversionView(
+                settingsViewModel: settingsViewModel,
+                id: dateConversion.id,
+                inputs: DateConversionView.Inputs(
+                    format: dateConversion.format,
+                    locale: dateConversion.locale,
+                    calendar: dateConversion.calendar))
         }
     }
 }


### PR DESCRIPTION
#363 日付変換の変換候補の編集画面で地域や暦法を変えてもプレビューの表示が変わらないことがあるバグを修正します。
1つの操作で同時に二つの `@State` を変えていたのが原因でした。