### PR TITLE
日付変換の読みや変換候補を更新しても環境設定に永続化されないバグの修正

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -594,13 +594,17 @@ final class SettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $dateYomis.dropFirst().sink { [weak self] dateYomis in
-            self?.saveDateConversions()
+            if let self {
+                self.saveDateConversions(dateYomis: dateYomis, dateConversions: self.dateConversions)
+            }
             logger.log("日付変換の読みリストを更新しました")
             Global.dictionary.dateYomis = dateYomis
         }.store(in: &cancellables)
 
         $dateConversions.dropFirst().sink { [weak self] dateConversions in
-            self?.saveDateConversions()
+            if let self {
+                self.saveDateConversions(dateYomis: self.dateYomis, dateConversions: dateConversions)
+            }
             logger.log("日付変更の変換候補を更新しました")
             Global.dictionary.dateConversions = dateConversions
         }.store(in: &cancellables)
@@ -839,7 +843,7 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
-    func saveDateConversions() {
+    func saveDateConversions(dateYomis: [DateConversion.Yomi], dateConversions: [DateConversion]) {
         let dict = [
             "yomis": dateYomis.map { $0.encode() },
             "conversions": dateConversions.map({ $0.encode() }),


### PR DESCRIPTION
#363 日付変換の読みと変換候補を設定画面から編集したときにその編集がすぐに永続化されないバグを修正します。
もう一度別の修正をすれば一個前の編集までが永続化されていました。