### PR TITLE
日付変換の変換結果をユーザー辞書の参照結果の後ろにする

### DIFF
--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -113,17 +113,17 @@ class UserDict: NSObject, DictProtocol {
      */
     @MainActor func referDicts(_ yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
         var result: [Candidate] = []
-        if let dateConversionYomi = dateYomis.first(where: { $0.yomi == yomi }) {
-            let date = Date(timeIntervalSinceNow: dateConversionYomi.timeInterval)
-            let candidates = dateConversions.compactMap { conversion -> Candidate? in
-                guard let word = conversion.dateFormatter.string(for: date) else { return nil }
-                return Candidate(word, saveToUserDict: false)
-            }
-            result = candidates
-        }
         var candidates = refer(yomi, option: option).map { word in
             let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
             return Candidate(word.word, annotations: annotations)
+        }
+        if let dateConversionYomi = dateYomis.first(where: { $0.yomi == yomi }) {
+            let date = Date(timeIntervalSinceNow: dateConversionYomi.timeInterval)
+            let dateCandidates = dateConversions.compactMap { conversion -> Candidate? in
+                guard let word = conversion.dateFormatter.string(for: date) else { return nil }
+                return Candidate(word, saveToUserDict: false)
+            }
+            candidates.append(contentsOf: dateCandidates)
         }
         // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
         if let skkservDict = Global.skkservDict {

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -82,7 +82,7 @@ final class UserDictTests: XCTestCase {
 
     @MainActor func testReferDictsDateConversion() throws {
         let userDict = try UserDict(dicts: [],
-                                    userDictEntries: [:],
+                                    userDictEntries: ["きょう": [Word("今日")]],
                                     privateMode: CurrentValueSubject<Bool, Never>(false),
                                     ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
                                     findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false),
@@ -114,6 +114,10 @@ final class UserDictTests: XCTestCase {
         XCTAssertTrue(candidatesTomorrow.allSatisfy({ $0.saveToUserDict == false }))
         XCTAssertNotNil(candidatesTomorrow[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
         XCTAssertNotNil(candidatesTomorrow[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
+
+        let candidatesKyou = userDict.referDicts("きょう")
+        XCTAssertEqual(candidatesKyou.count, 3)
+        XCTAssertEqual(candidatesKyou.first?.word, "今日") // ユーザー辞書の方が日付変換より前
     }
 
     func testFindCompletionPrivateMode() throws {


### PR DESCRIPTION
#363 日付変換の変換結果がユーザー辞書よりも前にきていたのをユーザー辞書→日付変換→他の辞書、の順にします。
もしかしたら日付変換の変換順は他の辞書よりも後でもいいかもしれない…?