### PR TITLE
辞書ごとに変換結果をユーザー辞書に保存するか設定できる 

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		CE97887B2A9B93EB00F9B196 /* DirectModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE97887A2A9B93EB00F9B196 /* DirectModeView.swift */; };
 		CEA253942E228E2000618E64 /* SKKServDictSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253932E228E2000618E64 /* SKKServDictSettingTests.swift */; };
 		CEA253962E2290AC00618E64 /* SKKServDictSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253952E2290AC00618E64 /* SKKServDictSetting.swift */; };
+		CEA253982E23AB7600618E64 /* DictSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253972E23AB7600618E64 /* DictSetting.swift */; };
+		CEA2539A2E23DA9000618E64 /* DictSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253992E23DA9000618E64 /* DictSettingTests.swift */; };
 		CEA78FAA295EBCAC00B67E25 /* StateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FA9295EBCAC00B67E25 /* StateMachineTests.swift */; };
 		CEA78FAC2960401F00B67E25 /* String+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FAB2960401F00B67E25 /* String+Transform.swift */; };
 		CEA78FAE2961BA1D00B67E25 /* String+TransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */; };
@@ -272,6 +274,8 @@
 		CE97887A2A9B93EB00F9B196 /* DirectModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectModeView.swift; sourceTree = "<group>"; };
 		CEA253932E228E2000618E64 /* SKKServDictSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServDictSettingTests.swift; sourceTree = "<group>"; };
 		CEA253952E2290AC00618E64 /* SKKServDictSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServDictSetting.swift; sourceTree = "<group>"; };
+		CEA253972E23AB7600618E64 /* DictSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictSetting.swift; sourceTree = "<group>"; };
+		CEA253992E23DA9000618E64 /* DictSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictSettingTests.swift; sourceTree = "<group>"; };
 		CEA78FA9295EBCAC00B67E25 /* StateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateMachineTests.swift; sourceTree = "<group>"; };
 		CEA78FAB2960401F00B67E25 /* String+Transform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Transform.swift"; sourceTree = "<group>"; };
 		CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+TransformTests.swift"; sourceTree = "<group>"; };
@@ -523,6 +527,7 @@
 				CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */,
 				CE8DFE082CBEAA1F00A24230 /* Character+AdditionsTests.swift */,
 				CE496C942B440BBD001C623C /* Data+EucJis2004Tests.swift */,
+				CEA253992E23DA9000618E64 /* DictSettingTests.swift */,
 				CEA253932E228E2000618E64 /* SKKServDictSettingTests.swift */,
 				CE06CA332AAC199500E80E5E /* UserDict+Utilities.swift */,
 				CE39FA942BEB942B00E293F0 /* Character+KeyCode.swift */,
@@ -564,6 +569,7 @@
 			isa = PBXGroup;
 			children = (
 				CED7CA5A2A83DE7F004EF988 /* SettingsViewModel.swift */,
+				CEA253972E23AB7600618E64 /* DictSetting.swift */,
 				CEA253952E2290AC00618E64 /* SKKServDictSetting.swift */,
 				CEC376E72965199500D9C432 /* SettingsView.swift */,
 				CEADA44E2B1357090026E2BD /* GeneralView.swift */,
@@ -836,6 +842,7 @@
 				CE0EDA302E10C77E00F96F9A /* DateYomiView.swift in Sources */,
 				CEC061CA2ABB0A7900A11614 /* CompletionViewModel.swift in Sources */,
 				CEF0825D296DB58600646366 /* CandidatesViewModel.swift in Sources */,
+				CEA253982E23AB7600618E64 /* DictSetting.swift in Sources */,
 				CE7F9ADC2AB53E53001B1877 /* CompletionView.swift in Sources */,
 				CE6DBA8D2A845CE400F5A227 /* Release.swift in Sources */,
 				CED7CA5B2A83DE7F004EF988 /* SettingsViewModel.swift in Sources */,
@@ -915,6 +922,7 @@
 			files = (
 				CE118EE52CE0B4DE00A7C300 /* KeyTests.swift in Sources */,
 				4B8E87D82CE068A0004E7461 /* CurrentInputTests.swift in Sources */,
+				CEA2539A2E23DA9000618E64 /* DictSettingTests.swift in Sources */,
 				CE84A3ED295DA818009394C4 /* MemoryDictTests.swift in Sources */,
 				CE06CA342AAC199500E80E5E /* UserDict+Utilities.swift in Sources */,
 				CE84A3E9295DA504009394C4 /* RomajiTests.swift in Sources */,

--- a/macSKK/Candidate.swift
+++ b/macSKK/Candidate.swift
@@ -3,6 +3,10 @@
 
 import Foundation
 
+fileprivate enum MergeError: Error, LocalizedError {
+    case invalidArgument
+}
+
 /**
  * 変換候補
  */
@@ -72,12 +76,31 @@ struct Candidate: Hashable {
         hasher.combine(word)
     }
 
-    /// 注釈を追加する。すでに同じテキストをもつ注釈があれば追加されない。
-    mutating func appendAnnotations(_ annotations: [Annotation]) {
-        for annotation in annotations {
-            if self.annotations.allSatisfy({ $0.text != annotation.text }) {
-                self.annotations.append(annotation)
+    /**
+     * 同じ変換候補を注釈をマージして返す。
+     *
+     * 引数と変換結果が同じでない場合はMergeErrorを返す。
+     *
+     * saveToUserDictは今のところ次の仕様とする
+     * - self, otherのsaveToUserDictが同じ値ならその値
+     * - self, otherのsaveToUserDictが違う値ならtrue
+     */
+    func merge(_ other: Candidate) throws -> Candidate {
+        guard word == other.word else {
+            throw MergeError.invalidArgument
+        }
+        let annotations = other.annotations.reduce(annotations) { result, annotation in
+            if result.allSatisfy( { $0.text != annotation.text } ) {
+                return result + [annotation]
+            } else {
+                return result
             }
         }
+
+        return Candidate(word,
+                         annotations: annotations,
+                         original: original,
+                         saveToUserDict: saveToUserDict || other.saveToUserDict)
     }
 }
+

--- a/macSKK/Candidate.swift
+++ b/macSKK/Candidate.swift
@@ -103,4 +103,3 @@ struct Candidate: Hashable {
                          saveToUserDict: saveToUserDict || other.saveToUserDict)
     }
 }
-

--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -79,4 +79,9 @@ protocol DictProtocol {
      * - 数値変換用の読みは補完候補としない
      */
     func findCompletion(prefix: String) -> String?
+
+    /**
+     * この辞書から返した変換候補をユーザー辞書に保存するかどうか
+     */
+    var saveToUserDict: Bool { get }
 }

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -50,6 +50,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
      * 読み込み専用で保存しないかどうか
      */
     private let readonly: Bool
+    /// この辞書から返した変換候補をユーザー辞書に保存するかどうか
     let saveToUserDict: Bool
 
     /// シリアライズ時に先頭に付ける
@@ -84,7 +85,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         self.id = fileURL.lastPathComponent
         self.fileURL = fileURL
         self.type = type
-        self.dict = MemoryDict(entries: [:], readonly: readonly)
+        self.dict = MemoryDict(entries: [:], readonly: readonly, saveToUserDict: saveToUserDict)
         self.version = NSFileVersion.currentVersionOfItem(at: fileURL)
         self.readonly = readonly
         self.saveToUserDict = saveToUserDict

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -50,6 +50,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
      * 読み込み専用で保存しないかどうか
      */
     private let readonly: Bool
+    let saveToUserDict: Bool
 
     /// シリアライズ時に先頭に付ける
     static let headers = [";; -*- mode: fundamental; coding: utf-8 -*-"]
@@ -78,7 +79,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         return queue
     }()
 
-    init(contentsOf fileURL: URL, type: FileDictType, readonly: Bool) throws {
+    init(contentsOf fileURL: URL, type: FileDictType, readonly: Bool, saveToUserDict: Bool) throws {
         // iCloud Documents使うときには辞書フォルダが複数になりうるけど、それまではひとまずファイル名をIDとして使う
         self.id = fileURL.lastPathComponent
         self.fileURL = fileURL
@@ -86,6 +87,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         self.dict = MemoryDict(entries: [:], readonly: readonly)
         self.version = NSFileVersion.currentVersionOfItem(at: fileURL)
         self.readonly = readonly
+        self.saveToUserDict = saveToUserDict
         super.init()
         load()
         NSFileCoordinator.addFilePresenter(self)

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -94,6 +94,22 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         NSFileCoordinator.addFilePresenter(self)
     }
 
+    private init(id: String, fileURL: URL, type: FileDictType, dict: MemoryDict, readonly: Bool, saveToUserDict: Bool, version: NSFileVersion?, hasUnsavedChanges: Bool) {
+        self.id = id
+        self.fileURL = fileURL
+        self.type = type
+        self.dict = dict
+        self.readonly = readonly
+        self.saveToUserDict = saveToUserDict
+        self.version = version
+        self.hasUnsavedChanges = hasUnsavedChanges
+    }
+
+    func with(saveToUserDict: Bool) -> FileDict {
+        FileDict(id: id, fileURL: fileURL, type: type, dict: dict, readonly: readonly, saveToUserDict: saveToUserDict,
+                 version: version, hasUnsavedChanges: hasUnsavedChanges)
+    }
+
     func load() {
         let operation = BlockOperation {
             var coordinationError: NSError?

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -28,9 +28,12 @@ struct MemoryDict: DictProtocol {
     private(set) var okuriNashiYomis: [String] = []
     /// 送りありの読みの配列。最近変換したものが後に登場する。
     private(set) var okuriAriYomis: [String] = []
+    /// この辞書から返した変換候補をユーザー辞書に保存するかどうか
+    let saveToUserDict: Bool
 
-    init(dictId: FileDict.ID, source: String, readonly: Bool) {
+    init(dictId: FileDict.ID, source: String, readonly: Bool, saveToUserDict: Bool = true) {
         self.readonly = readonly
+        self.saveToUserDict = saveToUserDict
         var dict: [String: [Word]] = [:]
         var okuriNashiYomis: [String] = []
         var okuriAriYomis: [String] = []
@@ -67,9 +70,10 @@ struct MemoryDict: DictProtocol {
         self.okuriAriYomis = okuriAriYomis.reversed()
     }
 
-    init(entries: [String: [Word]], readonly: Bool) {
+    init(entries: [String: [Word]], readonly: Bool, saveToUserDict: Bool = true) {
         self.readonly = readonly
         self.entries = entries
+        self.saveToUserDict = saveToUserDict
         failedEntryCount = 0
         for yomi in entries.keys {
             if yomi.isOkuriAri {
@@ -80,12 +84,13 @@ struct MemoryDict: DictProtocol {
         }
     }
 
-    init(okuriAriEntries: [String: [Word]], okuriNashiEntries: [String: [Word]], readonly: Bool) {
+    init(okuriAriEntries: [String: [Word]], okuriNashiEntries: [String: [Word]], readonly: Bool, saveToUserDict: Bool = true) {
         self.readonly = readonly
         self.entries = okuriAriEntries.merging(okuriNashiEntries) { current, _  in current }
         failedEntryCount = 0
         okuriAriYomis = Array(okuriAriEntries.keys)
         okuriNashiYomis = Array(okuriNashiEntries.keys)
+        self.saveToUserDict = saveToUserDict
     }
 
     var entryCount: Int { return entries.count }

--- a/macSKK/Settings/DictSetting.swift
+++ b/macSKK/Settings/DictSetting.swift
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import Combine
+
+final class DictSetting: ObservableObject, Identifiable {
+    typealias ID = FileDict.ID
+    @Published var filename: String
+    @Published var enabled: Bool
+    @Published var type: FileDictType
+    /// 変換履歴をユーザー辞書に保存するかどうか
+    @Published var saveToUserDict: Bool
+
+    var id: String { filename }
+
+    init(filename: String, enabled: Bool, type: FileDictType, saveToUserDict: Bool) {
+        self.filename = filename
+        self.enabled = enabled
+        self.type = type
+        self.saveToUserDict = saveToUserDict
+    }
+
+    // UserDefaultsのDictionaryを受け取る
+    init?(_ dictionary: [String: Any]) {
+        guard let filename = dictionary["filename"] as? String else { return nil }
+        self.filename = filename
+        guard let enabled = dictionary["enabled"] as? Bool else { return nil }
+        self.enabled = enabled
+        guard let encoding = dictionary["encoding"] as? UInt else { return nil }
+        if let type = dictionary["type"] as? String {
+            if type == "json" {
+                self.type = .json
+            } else if type == "traditional" {
+                self.type = .traditional(String.Encoding(rawValue: encoding))
+            } else {
+                logger.error("不明な辞書設定 \(type) があります。")
+                return nil
+            }
+        } else {
+            // v1.0.1まではJSON形式がなかったので従来形式として扱う
+            self.type = .traditional(String.Encoding(rawValue: encoding))
+        }
+        self.saveToUserDict = dictionary["saveToUserDict"] as? Bool ?? true
+    }
+
+    // UserDefaults用にDictionaryにシリアライズ
+    func encode() -> [String: Any] {
+        let typeValue: String
+        if case .traditional = type {
+            typeValue = "traditional"
+        } else if case .json = type {
+            typeValue = "json"
+        } else {
+            fatalError()
+        }
+        return [
+            "filename": filename,
+            "enabled": enabled,
+            "encoding": type.encoding.rawValue,
+            "type": typeValue,
+            "saveToUserDict": saveToUserDict
+        ]
+    }
+}

--- a/macSKK/Settings/DictSetting.swift
+++ b/macSKK/Settings/DictSetting.swift
@@ -38,6 +38,7 @@ final class DictSetting: ObservableObject, Identifiable {
             // v1.0.1まではJSON形式がなかったので従来形式として扱う
             self.type = .traditional(String.Encoding(rawValue: encoding))
         }
+        // v2.2.1までは存在しなかった設定
         self.saveToUserDict = dictionary["saveToUserDict"] as? Bool ?? true
     }
 

--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -89,7 +89,8 @@ struct DictionariesView: View {
                 DictionaryView(
                     dictSetting: $selectedDictSetting,
                     filename: dictSetting.filename,
-                    encoding: dictSetting.type.encoding
+                    encoding: dictSetting.type.encoding,
+                    saveToUserDict: dictSetting.saveToUserDict,
                 )
             }
             .sheet(isPresented: $isShowingSkkservSheet) {
@@ -137,10 +138,10 @@ struct DictionariesView_Previews: PreviewProvider {
 
     private static func makeSettingsViewModel() -> SettingsViewModel {
         let dictSettings = [
-            DictSetting(filename: "SKK-JISYO.L", enabled: true, type: .traditional(.japaneseEUC)),
-            DictSetting(filename: "SKK-JISYO.sample.utf-8", enabled: false, type: .traditional(.utf8)),
-            DictSetting(filename: "SKK-JISYO.dummy", enabled: true, type: .traditional(.utf8)),
-            DictSetting(filename: "SKK-JISYO.error", enabled: true, type: .traditional(.utf8)),
+            DictSetting(filename: "SKK-JISYO.L", enabled: true, type: .traditional(.japaneseEUC), saveToUserDict: true),
+            DictSetting(filename: "SKK-JISYO.sample.utf-8", enabled: false, type: .traditional(.utf8), saveToUserDict: true),
+            DictSetting(filename: "SKK-JISYO.dummy", enabled: true, type: .traditional(.utf8), saveToUserDict: true),
+            DictSetting(filename: "SKK-JISYO.error", enabled: true, type: .traditional(.utf8), saveToUserDict: true),
         ]
         let settings = try! SettingsViewModel(dictSettings: dictSettings)
         settings.dictLoadingStatuses = [

--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -87,8 +87,9 @@ struct DictionariesView: View {
             .formStyle(.grouped)
             .sheet(item: $selectedDictSetting) { dictSetting in
                 DictionaryView(
-                    dictSetting: $selectedDictSetting,
+                    settingsViewModel: settingsViewModel,
                     filename: dictSetting.filename,
+                    canChangeEncoding: dictSetting.type != .json,
                     encoding: dictSetting.type.encoding,
                     saveToUserDict: dictSetting.saveToUserDict,
                 )

--- a/macSKK/Settings/DictionaryView.swift
+++ b/macSKK/Settings/DictionaryView.swift
@@ -4,10 +4,12 @@
 import SwiftUI
 
 struct DictionaryView: View {
-    @Binding var dictSetting: DictSetting?
+    @StateObject var settingsViewModel: SettingsViewModel
     let filename: String
+    let canChangeEncoding: Bool
     @State var encoding: String.Encoding
     @State var saveToUserDict: Bool
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack {
@@ -22,9 +24,7 @@ struct DictionaryView: View {
                         }
                     }
                     .pickerStyle(.radioGroup)
-                    .disabled(
-                        dictSetting?.type == .json
-                    )
+                    .disabled(!canChangeEncoding)
                     Toggle(isOn: $saveToUserDict) {
                         Text("Save conversion history to User Dictionary")
                     }
@@ -35,14 +35,15 @@ struct DictionaryView: View {
             HStack {
                 Spacer()
                 Button {
-                    if let dictSetting {
+                    if let index = settingsViewModel.dictSettings.firstIndex(where: { $0.id == filename }) {
+                        let dictSetting = settingsViewModel.dictSettings[index]
                         if case .traditional = dictSetting.type {
                             dictSetting.type = .traditional(encoding)
                         }
                         dictSetting.saveToUserDict = saveToUserDict
+                        settingsViewModel.dictSettings[index] = dictSetting
                     }
-                    // このビューを閉じる
-                    dictSetting = nil
+                    dismiss()
                 } label: {
                     Text("Done")
                         .padding([.leading, .trailing])
@@ -59,14 +60,16 @@ struct DictionaryView: View {
 struct DictionaryView_Previews: PreviewProvider {
     static var previews: some View {
         DictionaryView(
-            dictSetting: .constant(nil),
-            filename: "SKK-JISYO.sample.utf-8",
+            settingsViewModel: try! SettingsViewModel(),
+            filename: "SKK-JISYO.sample.json",
+            canChangeEncoding: false,
             encoding: .utf8,
             saveToUserDict: false,
         ).previewDisplayName("SKK-JISYO.sample.utf-8")
         DictionaryView(
-            dictSetting: .constant(nil),
+            settingsViewModel: try! SettingsViewModel(),
             filename: "SKK-JISYO.L",
+            canChangeEncoding: true,
             encoding: .japaneseEUC,
             saveToUserDict: true,
         ).previewDisplayName("SKK-JISYO.L")

--- a/macSKK/Settings/DictionaryView.swift
+++ b/macSKK/Settings/DictionaryView.swift
@@ -7,6 +7,7 @@ struct DictionaryView: View {
     @Binding var dictSetting: DictSetting?
     let filename: String
     @State var encoding: String.Encoding
+    @State var saveToUserDict: Bool
 
     var body: some View {
         VStack {
@@ -24,6 +25,9 @@ struct DictionaryView: View {
                     .disabled(
                         dictSetting?.type == .json
                     )
+                    Toggle(isOn: $saveToUserDict) {
+                        Text("Save conversion history to User Dictionary")
+                    }
                 }
             }
             .formStyle(.grouped)
@@ -35,6 +39,7 @@ struct DictionaryView: View {
                         if case .traditional = dictSetting.type {
                             dictSetting.type = .traditional(encoding)
                         }
+                        dictSetting.saveToUserDict = saveToUserDict
                     }
                     // このビューを閉じる
                     dictSetting = nil
@@ -56,12 +61,14 @@ struct DictionaryView_Previews: PreviewProvider {
         DictionaryView(
             dictSetting: .constant(nil),
             filename: "SKK-JISYO.sample.utf-8",
-            encoding: .utf8
-        ).previewDisplayName("SKK-JISYO.sample.utf-8")        
+            encoding: .utf8,
+            saveToUserDict: false,
+        ).previewDisplayName("SKK-JISYO.sample.utf-8")
         DictionaryView(
             dictSetting: .constant(nil),
             filename: "SKK-JISYO.L",
-            encoding: .japaneseEUC
+            encoding: .japaneseEUC,
+            saveToUserDict: true,
         ).previewDisplayName("SKK-JISYO.L")
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -5,63 +5,6 @@ import Combine
 import Foundation
 import SwiftUI
 
-final class DictSetting: ObservableObject, Identifiable {
-    typealias ID = FileDict.ID
-    @Published var filename: String
-    @Published var enabled: Bool
-    @Published var type: FileDictType
-
-    var id: String { filename }
-    
-    init(filename: String, enabled: Bool, type: FileDictType) {
-        self.filename = filename
-        self.enabled = enabled
-        self.type = type
-    }
-
-    // UserDefaultsのDictionaryを受け取る
-    init?(_ dictionary: [String: Any]) {
-        guard let filename = dictionary["filename"] as? String else { return nil }
-        self.filename = filename
-        guard let enabled = dictionary["enabled"] as? Bool else { return nil }
-        self.enabled = enabled
-        guard let encoding = dictionary["encoding"] as? UInt else { return nil }
-        if let type = dictionary["type"] as? String {
-            if type == "json" {
-                self.type = .json
-            } else if type == "traditional" {
-                self.type = .traditional(String.Encoding(rawValue: encoding))
-            } else {
-                logger.error("不明な辞書設定 \(type) があります。")
-                return nil
-            }
-        } else {
-            // v1.0.1まではJSON形式がなかったので従来形式として扱う
-            self.type = .traditional(String.Encoding(rawValue: encoding))
-        }
-    }
-
-    // UserDefaults用にDictionaryにシリアライズ
-    func encode() -> [String: Any] {
-        let typeValue: String
-        if case .traditional = type {
-            typeValue = "traditional"
-        } else if case .json = type {
-            typeValue = "json"
-        } else {
-            fatalError()
-        }
-        return [
-            "filename": filename,
-            "enabled": enabled,
-            "encoding": type.encoding.rawValue,
-            "type": typeValue
-        ]
-    }
-}
-
-
-
 /// 辞書のエンコーディングとして利用可能なもの
 enum AllowedEncoding: CaseIterable, CustomStringConvertible {
     case utf8
@@ -705,7 +648,8 @@ final class SettingsViewModel: ObservableObject {
                         }
                         self.dictSettings.append(DictSetting(filename: url.lastPathComponent,
                                                              enabled: false,
-                                                             type: type))
+                                                             type: type,
+                                                             saveToUserDict: true))
                     }
                 }
             }.store(in: &cancellables)

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -297,6 +297,9 @@ final class SettingsViewModel: ObservableObject {
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の読み込みに失敗しました!: \(error)")
                             return nil
                         }
+                    } else if let dict, dictSetting.saveToUserDict != dict.saveToUserDict {
+                        logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の変換候補をユーザー辞書に保存する設定を\(dictSetting.saveToUserDict ? "有効" : "無効", privacy: .public)に変更しました")
+                        return dict.with(saveToUserDict: dictSetting.saveToUserDict)
                     } else {
                         return dict
                     }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -289,7 +289,7 @@ final class SettingsViewModel: ObservableObject {
                         let fileURL = dictionariesDirectoryUrl.appendingPathComponent(dictSetting.filename)
                         do {
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
-                            let fileDict = try FileDict(contentsOf: fileURL, type: dictSetting.type, readonly: true)
+                            let fileDict = try FileDict(contentsOf: fileURL, type: dictSetting.type, readonly: true, saveToUserDict: dictSetting.saveToUserDict)
                             logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
                             return fileDict
                         } catch {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -176,7 +176,11 @@ class UserDict: NSObject, DictProtocol {
         for candidate in candidates {
             if let index = result.firstIndex(where: { $0.word == candidate.word }) {
                 // 注釈だけマージする
-                result[index].appendAnnotations(candidate.annotations)
+                do {
+                    result[index] = try result[index].merge(candidate)
+                } catch {
+                    logger.error("異なる変換結果をもつ変換候補同士をマージしようとしました。バグと思われます。")
+                }
             } else {
                 result.append(candidate)
             }

--- a/macSKKTests/CandidateTest.swift
+++ b/macSKKTests/CandidateTest.swift
@@ -6,17 +6,12 @@ import XCTest
 @testable import macSKK
 
 final class CandidateTest: XCTestCase {
-    func testAppendAnnotations() throws {
-        var candidate = Candidate("注釈")
-        XCTAssertEqual(candidate.annotations, [])
-        let annotation1 = Annotation(dictId: "d1", text: "a1")
-        candidate.appendAnnotations([annotation1])
-        XCTAssertEqual(candidate.annotations, [annotation1])
-        let annotation2 = Annotation(dictId: "d2", text: "a1")
-        candidate.appendAnnotations([annotation2])
-        XCTAssertEqual(candidate.annotations, [annotation1], "注釈が同じテキストなら追加されない")
-        let annotation3 = Annotation(dictId: "d3", text: "a3")
-        candidate.appendAnnotations([annotation3])
-        XCTAssertEqual(candidate.annotations, [annotation1, annotation3])
+    func testMerge() throws {
+        let candidate1 = Candidate("言葉", annotations: [Annotation(dictId: "d1", text: "a1")], saveToUserDict: false)
+        let candidate2 = try candidate1.merge(Candidate("言葉", annotations: [Annotation(dictId: "d2", text: "a1")], saveToUserDict: false))
+        XCTAssertEqual(candidate2.annotations.count, 1) // 同じ表記をもつ注釈はマージされる
+        let candidate3 = try candidate2.merge(Candidate("言葉", annotations: [Annotation(dictId: "d3", text: "a3")], saveToUserDict: false))
+        XCTAssertEqual(candidate3.annotations, [Annotation(dictId: "d1", text: "a1"), Annotation(dictId: "d3", text: "a3")])
+        XCTAssertThrowsError(try candidate1.merge(Candidate("違う言葉"))) // wordが異なるCandidate同士のマージはエラーが発生する
     }
 }

--- a/macSKKTests/DictSettingTests.swift
+++ b/macSKKTests/DictSettingTests.swift
@@ -1,0 +1,21 @@
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import macSKK
+
+final class DictSettingTests: XCTestCase {
+    func testInitWithDict() throws {
+        XCTAssertNil(DictSetting([:]))
+        let dictSetting = try XCTUnwrap(DictSetting([
+            "filename": "foo",
+            "enabled": true,
+            "encoding": String.Encoding.utf8.rawValue,
+        ]))
+        //
+        // typeはv2.2.1まで設定としてなかったのでtradditional
+        XCTAssertEqual(dictSetting.type, .traditional(.utf8))
+        // saveToUserDictはv.2.2.1まで設定としてなかったのでtrue
+        XCTAssertTrue(dictSetting.saveToUserDict)
+    }
+}

--- a/macSKKTests/DictSettingTests.swift
+++ b/macSKKTests/DictSettingTests.swift
@@ -12,8 +12,8 @@ final class DictSettingTests: XCTestCase {
             "enabled": true,
             "encoding": String.Encoding.utf8.rawValue,
         ]))
-        //
-        // typeはv2.2.1まで設定としてなかったのでtradditional
+        XCTAssertEqual(dictSetting.filename, "foo")
+        // typeはv1.0.1まで設定としてなかったのでtradditional
         XCTAssertEqual(dictSetting.type, .traditional(.utf8))
         // saveToUserDictはv.2.2.1まで設定としてなかったのでtrue
         XCTAssertTrue(dictSetting.saveToUserDict)

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -12,7 +12,7 @@ final class FileDictTests: XCTestCase {
 
     func testLoadContainsBom() throws {
         let fileURL = Bundle(for: Self.self).url(forResource: "utf8-bom", withExtension: "txt")!
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
         XCTAssertEqual(dict.dict.entries, ["ゆにこーど": [Word("ユニコード")]])
     }
 
@@ -28,7 +28,7 @@ final class FileDictTests: XCTestCase {
             }
         }.store(in: &cancellables)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json")!
-        let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true)
+        let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
         XCTAssertEqual(dict.dict.refer("い", option: nil).map({ $0.word }).sorted(), ["伊", "胃"])
         XCTAssertEqual(dict.dict.refer("あr", option: nil).map({ $0.word }).sorted(), ["在;注釈として解釈されない", "有"])
         wait(for: [expectation], timeout: 1.0)
@@ -44,12 +44,12 @@ final class FileDictTests: XCTestCase {
             }
         }.store(in: &cancellables)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.broken", withExtension: "json")!
-        _ = try FileDict(contentsOf: fileURL, type: .json, readonly: true)
+        _ = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
         wait(for: [expectation], timeout: 1.0)
     }
 
     func testAdd() throws {
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
         XCTAssertEqual(dict.entryCount, 0)
         let word = Word("井")
         XCTAssertFalse(dict.hasUnsavedChanges)
@@ -59,7 +59,7 @@ final class FileDictTests: XCTestCase {
     }
 
     func testDelete() throws {
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true)
+        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
         dict.setEntries(["あr": [Word("有"), Word("在")]], readonly: true)
         XCTAssertFalse(dict.delete(yomi: "あr", word: "或"))
         XCTAssertFalse(dict.hasUnsavedChanges)
@@ -68,7 +68,7 @@ final class FileDictTests: XCTestCase {
     }
 
     func testSerialize() throws {
-        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: false)
+        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: false, saveToUserDict: true)
         XCTAssertEqual(dict.serialize(),
                        [FileDict.headers[0], FileDict.okuriAriHeader, FileDict.okuriNashiHeader, ""].joined(separator: "\n"))
         dict.add(yomi: "あ", word: Word("亜", annotation: Annotation(dictId: "testDict", text: "亜の注釈")))

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -8,8 +8,8 @@ import Combine
 
 final class UserDictTests: XCTestCase {
     @MainActor func testRefer() throws {
-        let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]], readonly: true)
-        let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true)
+        let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊"), Word("位")]], readonly: true, saveToUserDict: false)
+        let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true, saveToUserDict: true)
         let userDict = try UserDict(dicts: [dict1, dict2],
                                     userDictEntries: ["い": [Word("井"), Word("伊")]],
                                     privateMode: CurrentValueSubject<Bool, Never>(false),
@@ -18,11 +18,12 @@ final class UserDictTests: XCTestCase {
                                     dateYomis: [],
                                     dateConversions: [])
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊"], "UserDictのエントリだけを返す")
-        XCTAssertEqual(userDict.referDicts("い").map { $0.word }, ["井", "伊", "胃", "意"])
+        XCTAssertEqual(userDict.referDicts("い").map { $0.word }, ["井", "伊", "胃", "位", "意"])
+        XCTAssertEqual(userDict.referDicts("い").map { $0.saveToUserDict }, [true, true, true, false, true])
     }
 
     @MainActor func testReferDictsMergeAnnotation() throws {
-        let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true)
+        let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true, saveToUserDict: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
         let userDict = try UserDict(dicts: [dict1, dict2],
                                     userDictEntries: [:],

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -7,7 +7,7 @@ import Combine
 @testable import macSKK
 
 final class UserDictTests: XCTestCase {
-    func testRefer() throws {
+    @MainActor func testRefer() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true)
         let userDict = try UserDict(dicts: [dict1, dict2],
@@ -17,10 +17,11 @@ final class UserDictTests: XCTestCase {
                                     findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false),
                                     dateYomis: [],
                                     dateConversions: [])
-        XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊", "胃", "意"])
+        XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊"], "UserDictのエントリだけを返す")
+        XCTAssertEqual(userDict.referDicts("い").map { $0.word }, ["井", "伊", "胃", "意"])
     }
 
-    @MainActor func testReferMergeAnnotation() throws {
+    @MainActor func testReferDictsMergeAnnotation() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true)
         let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
         let userDict = try UserDict(dicts: [dict1, dict2],
@@ -30,13 +31,11 @@ final class UserDictTests: XCTestCase {
                                     findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false),
                                     dateYomis: [],
                                     dateConversions: [])
-        XCTAssertEqual(userDict.refer("い").map({ $0.word }), ["胃", "伊", "胃", "意"], "dict1, dict2に胃が1つずつある")
-        XCTAssertEqual(userDict.refer("い").compactMap({ $0.annotation?.dictId }), ["dict1", "dict2"])
         XCTAssertEqual(userDict.referDicts("い").map({ $0.word }), ["胃", "伊", "意"])
-        XCTAssertEqual(userDict.referDicts("い").map({ $0.annotations.map({ $0.dictId }) }), [["dict1", "dict2"], [], []])
+        XCTAssertEqual(userDict.referDicts("い").map({ $0.annotations.map({ $0.dictId }) }), [["dict1", "dict2"], [], []], "dict1, dict2に胃が1つずつある")
     }
 
-    func testReferWithOption() throws {
+    @MainActor func testReferDictsWithOption() throws {
         let dict = MemoryDict(entries: ["あき>": [Word("空き")],
                                         "あき": [Word("秋")],
                                         ">し": [Word("氏")],
@@ -52,12 +51,12 @@ final class UserDictTests: XCTestCase {
                                     findCompletionFromAllDicts: CurrentValueSubject<Bool, Never>(false),
                                     dateYomis: [],
                                     dateConversions: [])
-        XCTAssertEqual(userDict.refer("あき", option: nil), [Word("安芸"), Word("秋")])
-        XCTAssertEqual(userDict.refer("あき", option: .prefix), [Word("飽き"), Word("空き")])
-        XCTAssertEqual(userDict.refer("あき", option: .suffix), [])
-        XCTAssertEqual(userDict.refer("し", option: nil), [Word("士"), Word("詩")])
-        XCTAssertEqual(userDict.refer("し", option: .suffix), [Word("詞"), Word("氏")])
-        XCTAssertEqual(userDict.refer("し", option: .prefix), [])
+        XCTAssertEqual(userDict.referDicts("あき", option: nil), [Candidate("安芸"), Candidate("秋")])
+        XCTAssertEqual(userDict.referDicts("あき", option: .prefix), [Candidate("飽き"), Candidate("空き")])
+        XCTAssertEqual(userDict.referDicts("あき", option: .suffix), [])
+        XCTAssertEqual(userDict.referDicts("し", option: nil), [Candidate("士"), Candidate("詩")])
+        XCTAssertEqual(userDict.referDicts("し", option: .suffix), [Candidate("詞"), Candidate("氏")])
+        XCTAssertEqual(userDict.referDicts("し", option: .prefix), [])
     }
 
     func testPrivateMode() throws {


### PR DESCRIPTION
#365 SKK辞書ごとに変換結果をユーザー辞書に保存するかどうかを設定できるようにします。
辞書設定のiボタンを押したときに出てくる画面で有効・無効を切り替えてから完了を押したときに反映されます。

保存設定が異なる辞書2つに同じ変換結果がある場合、保存されます。
その場合、保存しない設定の辞書側で注釈をもっているときは注釈ごとユーザー辞書に保存されてしまいます。
注釈ごとに保存するかどうかの設定をもてばいいのですが、だいぶ修正が大きくなってきたのでTODOとします。

<img width="640" height="532" alt="image" src="https://github.com/user-attachments/assets/45d8aedf-f725-43bc-9d6c-6d583bd585c9" />
