### PR TITLE
ユーザー辞書を保存する必要がないときは入力メニューに保存メニューアイテムは表示しない

### DIFF
--- a/macSKK/AppDelegate.swift
+++ b/macSKK/AppDelegate.swift
@@ -5,8 +5,10 @@ import Cocoa
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")
-        Global.dictionary.save()
+        if Global.dictionary.hasUnsavedChanges {
+            logger.log("アプリケーションが終了する前にユーザー辞書の永続化を行います")
+            Global.dictionary.save()
+        }
         return .terminateNow
     }
 }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -245,9 +245,11 @@ class InputController: IMKInputController {
         preferenceMenu.addItem(
             withTitle: String(localized: "MenuItemPreference", comment: "Preferences…"),
             action: #selector(showSettings), keyEquivalent: "")
-        preferenceMenu.addItem(
-            withTitle: String(localized: "MenuItemSaveDict", comment: "Save User Dictionary"),
-            action: #selector(saveDict), keyEquivalent: "")
+        if Global.dictionary.hasUnsavedChanges {
+            preferenceMenu.addItem(
+                withTitle: String(localized: "MenuItemSaveDict", comment: "Save User Dictionary"),
+                action: #selector(saveDict), keyEquivalent: "")
+        }
         let privateModeItem = NSMenuItem(title: String(localized: "MenuItemPrivateMode", comment: "Private mode"),
                                          action: #selector(togglePrivateMode),
                                          keyEquivalent: "")

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -334,6 +334,14 @@ class UserDict: NSObject, DictProtocol {
         }
         return nil
     }
+
+    var hasUnsavedChanges: Bool {
+        if let dict = userDict as? FileDict {
+            return dict.hasUnsavedChanges
+        } else {
+            return false
+        }
+    }
 }
 
 extension UserDict: NSFilePresenter {


### PR DESCRIPTION
「ユーザー辞書を今すぐ保存」というメニューアイテムは保存してないデータがあるときだけ表示するようにします。
最初NSMenuItemのisEnabledをfalseにしてみたんですが、入力メニューではisEnabledは無視されるようです。

<img width="229" height="142" alt="image" src="https://github.com/user-attachments/assets/89f764ad-6ff6-4139-9ccc-2700770db39c" />

また余計なログを出さないように、アプリの終了時に保存してないデータがないときは保存を呼ばないようにします。