### PR TITLE
コンテナ外へのシンボリックリンクなどの読み込めないファイルも辞書設定に表示する

### DIFF
--- a/macSKK/URL+Additions.swift
+++ b/macSKK/URL+Additions.swift
@@ -22,6 +22,6 @@ extension URL {
                 return false
             }
         }
-        return true
+        fatalError("isHidden, isReadable, isRegularFileの読み込みに失敗しました")
     }
 }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -339,7 +339,7 @@ class UserDict: NSObject, DictProtocol {
 extension UserDict: NSFilePresenter {
     func presentedSubitemDidAppear(at url: URL) {
         do {
-            if try isValidFile(url) {
+            if try isFile(url) {
                 logger.log("新しいファイル \(url.lastPathComponent, privacy: .public) が作成されました")
                 NotificationCenter.default.post(name: notificationNameDictFileDidAppear, object: url)
             } else {
@@ -366,7 +366,7 @@ extension UserDict: NSFilePresenter {
 
         var relationship: FileManager.URLRelationship = .same
         do {
-            if try isValidFile(url) {
+            if try isFile(url) {
                 try FileManager.default.getRelationship(&relationship, ofDirectoryAt: dictionariesDirectoryURL, toItemAt: url)
                 if case .contains = relationship {
                     logger.log("ファイル \(url.lastPathComponent, privacy: .public) が辞書フォルダに移動または更新されました")
@@ -397,8 +397,13 @@ extension UserDict: NSFilePresenter {
         logger.log("ファイル \(url.lastPathComponent, privacy: .public) が辞書フォルダから削除されます")
     }
 
-    // 辞書ファイルとして問題があるファイルでないかを判定する
-    private func isValidFile(_ fileURL: URL) throws -> Bool {
-        return try fileURL.isReadable()
+    /// ファイルがディレクトリまたは不可視ファイルの場合はfalseを返す
+    /// 読み込み権限がなかったり、App Sandboxのコンテナ外へのシンボリックリンクのように実際には読み込めないファイルについてはtrueを返す
+    private func isFile(_ fileURL: URL) throws -> Bool {
+        let resourceValues = try fileURL.resourceValues(forKeys: [.isDirectoryKey, .isHiddenKey])
+        if let isDirectory = resourceValues.isDirectory, let isHidden = resourceValues.isHidden {
+            return !isDirectory && !isHidden
+        }
+        fatalError("isDirectory, isHiddenの読み込みに失敗しました")
     }
 }


### PR DESCRIPTION
macSKKはApp Sandboxを有効にしており、 `~/Library/Containers/net.mtgto.inputmethod.macSKK/Data` 以下でないファイルの読み込みができません。
https://github.com/mtgto/macSKK/issues/234#issuecomment-2437458313

読み込めないファイルは予め辞書設定一覧に表示しないようにしていたのですが、それよりは実際に読み込もうとしてエラーが見えたほうがわかりやすそうなので、フォルダと不可視ファイル以外は辞書リストに並ぶようにします。
以下は `~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Dictionaries/test.txt` をコンテナ外のREADME.mdへのシンボリックリンクにして読み込みを試みたときのスクリーンショットです。

<img width="640" height="532" alt="image" src="https://github.com/user-attachments/assets/14b95386-050a-426a-b8bf-11bff6ff0e64" />
