### PR TITLE
テスト実行時はUserDefaultsを別にする

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		CEA253962E2290AC00618E64 /* SKKServDictSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253952E2290AC00618E64 /* SKKServDictSetting.swift */; };
 		CEA253982E23AB7600618E64 /* DictSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253972E23AB7600618E64 /* DictSetting.swift */; };
 		CEA2539A2E23DA9000618E64 /* DictSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253992E23DA9000618E64 /* DictSettingTests.swift */; };
+		CEA253E62E2E852000618E64 /* UserDefaults+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA253E52E2E852000618E64 /* UserDefaults+App.swift */; };
 		CEA78FAA295EBCAC00B67E25 /* StateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FA9295EBCAC00B67E25 /* StateMachineTests.swift */; };
 		CEA78FAC2960401F00B67E25 /* String+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FAB2960401F00B67E25 /* String+Transform.swift */; };
 		CEA78FAE2961BA1D00B67E25 /* String+TransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */; };
@@ -276,6 +277,7 @@
 		CEA253952E2290AC00618E64 /* SKKServDictSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServDictSetting.swift; sourceTree = "<group>"; };
 		CEA253972E23AB7600618E64 /* DictSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictSetting.swift; sourceTree = "<group>"; };
 		CEA253992E23DA9000618E64 /* DictSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictSettingTests.swift; sourceTree = "<group>"; };
+		CEA253E52E2E852000618E64 /* UserDefaults+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+App.swift"; sourceTree = "<group>"; };
 		CEA78FA9295EBCAC00B67E25 /* StateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateMachineTests.swift; sourceTree = "<group>"; };
 		CEA78FAB2960401F00B67E25 /* String+Transform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Transform.swift"; sourceTree = "<group>"; };
 		CEA78FAD2961BA1D00B67E25 /* String+TransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+TransformTests.swift"; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				CE1B006B2BA54D9800C830FD /* SKKServService.swift */,
 				CED0984C2B779E4700F2E844 /* UNNotifier.swift */,
 				CEB52CC72E0974AF0025542F /* DateConversion.swift */,
+				CEA253E52E2E852000618E64 /* UserDefaults+App.swift */,
 				CEA78FAB2960401F00B67E25 /* String+Transform.swift */,
 				CED7F51E2AB5F4A7007FC6BD /* Character+Additions.swift */,
 				CE496C902B440892001C623C /* URL+Additions.swift */,
@@ -860,6 +863,7 @@
 				CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */,
 				CEADA4512B1358D40026E2BD /* InputSource.swift in Sources */,
 				CE84A3E7295DA4DA009394C4 /* Romaji.swift in Sources */,
+				CEA253E62E2E852000618E64 /* UserDefaults+App.swift in Sources */,
 				CE1B006D2BA54DE400C830FD /* SKKServClientProtocol.swift in Sources */,
 				CE1B006A2BA5490E00C830FD /* SKKServDictView.swift in Sources */,
 				94DB63242D329CBF005250B8 /* HorizontalCandidatesView.swift in Sources */,

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -57,9 +57,9 @@ import Combine
     init() {
         inputModePanel = InputModePanel()
         candidatesPanel = CandidatesPanel(
-            showAnnotationPopover: UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation),
-            candidatesFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidatesFontSize),
-            annotationFontSize: UserDefaults.standard.integer(forKey: UserDefaultsKeys.annotationFontSize)
+            showAnnotationPopover: UserDefaults.app.bool(forKey: UserDefaultsKeys.showAnnotation),
+            candidatesFontSize: UserDefaults.app.integer(forKey: UserDefaultsKeys.candidatesFontSize),
+            annotationFontSize: UserDefaults.app.integer(forKey: UserDefaultsKeys.annotationFontSize)
         )
         completionPanel = CompletionPanel()
     }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -88,7 +88,7 @@ class InputController: IMKInputController {
                     if !self.directMode {
                         textInput.selectMode(inputMode.rawValue)
                         
-                        let showInputModePanel = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showInputModePanel)
+                        let showInputModePanel = UserDefaults.app.bool(forKey: UserDefaultsKeys.showInputModePanel)
                         if showInputModePanel {
                             displayInputModePanel.send(inputMode)
                         }
@@ -98,7 +98,7 @@ class InputController: IMKInputController {
         }.store(in: &cancellables)
         stateMachine.candidateEvent.sink { [weak self] candidates in
             if let self {
-                let showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
+                let showAnnotation = UserDefaults.app.bool(forKey: UserDefaultsKeys.showAnnotation)
                 Global.candidatesPanel.setShowAnnotationPopover(showAnnotation)
                 if let candidates {
                     // 下線のスタイルがthickのときに被らないように1ピクセル下に余白を設ける
@@ -137,7 +137,7 @@ class InputController: IMKInputController {
             self?.stateMachine.didDoubleSelectCandidate(doubleSelected)
         }.store(in: &cancellables)
         selectedWord.removeDuplicates().compactMap({ $0 }).sink { [weak self] word in
-            if UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation) {
+            if UserDefaults.app.bool(forKey: UserDefaultsKeys.showAnnotation) {
                 if let self, let systemAnnotation = SystemDict.lookup(word, for: Global.systemDict), !systemAnnotation.isEmpty {
                     Global.candidatesPanel.setSystemAnnotation(systemAnnotation, for: word)
                     Global.candidatesPanel.show(windowLevel: windowLevel(for: textInput))
@@ -190,7 +190,7 @@ class InputController: IMKInputController {
                 }
             }.store(in: &cancellables)
 
-        stateMachine.inlineCandidateCount = UserDefaults.standard.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
+        stateMachine.inlineCandidateCount = UserDefaults.app.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
         NotificationCenter.default.publisher(for: notificationNameInlineCandidateCount)
             .sink { [weak self] notification in
                 if let inlineCandidateCount = notification.object as? Int, inlineCandidateCount >= 0 {
@@ -304,7 +304,7 @@ class InputController: IMKInputController {
             return
         }
         
-        let showInputModePanel = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showInputModePanel)
+        let showInputModePanel = UserDefaults.app.bool(forKey: UserDefaultsKeys.showInputModePanel)
         if showInputModePanel && !directMode {
             // Safariでアドレスバーに移動するときなど、処理が固まることがあるので非同期で実行する
             // ただしIMKTextInputへのアクセスはsetValue内で同期で行う必要がある
@@ -367,7 +367,7 @@ class InputController: IMKInputController {
 
     // キー配列を設定する
     private func setCustomInputSource(textInput: any IMKTextInput) {
-        if let inputSourceID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputSource) {
+        if let inputSourceID = UserDefaults.app.string(forKey: UserDefaultsKeys.selectedInputSource) {
             logger.info("InputSourceIDを \(inputSourceID, privacy: .public) に設定します")
             textInput.overrideKeyboard(withKeyboardNamed: inputSourceID)
         } else {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -202,20 +202,20 @@ final class SettingsViewModel: ObservableObject {
 
     init(dictionariesDirectoryUrl: URL) throws {
         self.dictionariesDirectoryUrl = dictionariesDirectoryUrl
-        if let bundleIdentifiers = UserDefaults.standard.array(forKey: "directModeBundleIdentifiers") as? [String] {
+        if let bundleIdentifiers = UserDefaults.app.array(forKey: "directModeBundleIdentifiers") as? [String] {
             directModeApplications = bundleIdentifiers.map { DirectModeApplication(bundleIdentifier: $0) }
         }
-        if let selectedInputSourceId = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputSource) {
+        if let selectedInputSourceId = UserDefaults.app.string(forKey: UserDefaultsKeys.selectedInputSource) {
             self.selectedInputSourceId = selectedInputSourceId
         } else {
             selectedInputSourceId = InputSource.defaultInputSourceId
         }
-        showAnnotation = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showAnnotation)
-        inlineCandidateCount = UserDefaults.standard.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
-        candidatesFontSize = UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidatesFontSize)
-        annotationFontSize = UserDefaults.standard.integer(forKey: UserDefaultsKeys.annotationFontSize)
-        findCompletionFromAllDicts = UserDefaults.standard.bool(forKey: UserDefaultsKeys.findCompletionFromAllDicts)
-        workaroundApplications = UserDefaults.standard.array(forKey: UserDefaultsKeys.workarounds)?.compactMap { workaround in
+        showAnnotation = UserDefaults.app.bool(forKey: UserDefaultsKeys.showAnnotation)
+        inlineCandidateCount = UserDefaults.app.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
+        candidatesFontSize = UserDefaults.app.integer(forKey: UserDefaultsKeys.candidatesFontSize)
+        annotationFontSize = UserDefaults.app.integer(forKey: UserDefaultsKeys.annotationFontSize)
+        findCompletionFromAllDicts = UserDefaults.app.bool(forKey: UserDefaultsKeys.findCompletionFromAllDicts)
+        workaroundApplications = UserDefaults.app.array(forKey: UserDefaultsKeys.workarounds)?.compactMap { workaround in
             if let workaround = workaround as? Dictionary<String, Any>, let bundleIdentifier = workaround["bundleIdentifier"] as? String,
                 let insertBlankString = workaround["insertBlankString"] as? Bool {
                 // treatFirstCharacterAsMarkedTextはv2.1+ で追加された
@@ -227,13 +227,13 @@ final class SettingsViewModel: ObservableObject {
                 return nil
             }
         } ?? []
-        guard let skkservDictSettingDict = UserDefaults.standard.dictionary(forKey: UserDefaultsKeys.skkservClient),
+        guard let skkservDictSettingDict = UserDefaults.app.dictionary(forKey: UserDefaultsKeys.skkservClient),
         let skkservDictSetting = SKKServDictSetting(skkservDictSettingDict) else {
             fatalError("skkservClientの設定がありません")
         }
         self.skkservDictSetting = skkservDictSetting
 
-        let customizedKeyBindingSets = UserDefaults.standard.array(forKey: UserDefaultsKeys.keyBindingSets)?.compactMap {
+        let customizedKeyBindingSets = UserDefaults.app.array(forKey: UserDefaultsKeys.keyBindingSets)?.compactMap {
             if let dict = $0 as? [String: Any] {
                 KeyBindingSet(dict: dict)
             } else {
@@ -241,25 +241,25 @@ final class SettingsViewModel: ObservableObject {
             }
         }
         let keyBindingSets = [KeyBindingSet.defaultKeyBindingSet] + (customizedKeyBindingSets ?? [])
-        let selectedKeyBindingSetId = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedKeyBindingSetId) ?? KeyBindingSet.defaultId
+        let selectedKeyBindingSetId = UserDefaults.app.string(forKey: UserDefaultsKeys.selectedKeyBindingSetId) ?? KeyBindingSet.defaultId
         self.keyBindingSets = keyBindingSets
         self.selectedKeyBindingSet = keyBindingSets.first(where: { $0.id == selectedKeyBindingSetId }) ?? KeyBindingSet.defaultKeyBindingSet
-        if let systemDictId = UserDefaults.standard.string(forKey: UserDefaultsKeys.systemDict), let systemDict = SystemDict.Kind(rawValue: systemDictId) {
+        if let systemDictId = UserDefaults.app.string(forKey: UserDefaultsKeys.systemDict), let systemDict = SystemDict.Kind(rawValue: systemDictId) {
             self.systemDict = systemDict
         } else {
             self.systemDict = .daijirin
         }
 
-        selectCandidateKeys = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectCandidateKeys)!
-        enterNewLine = UserDefaults.standard.bool(forKey: UserDefaultsKeys.enterNewLine)
-        showCompletion = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showCompletion)
-        selectingBackspace = SelectingBackspace(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.selectingBackspace)) ?? SelectingBackspace.default
-        comma = Punctuation.Comma(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
-        period = Punctuation.Period(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
-        ignoreUserDictInPrivateMode = UserDefaults.standard.bool(forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
-        showInputIconModal = UserDefaults.standard.bool(forKey: UserDefaultsKeys.showInputModePanel)
-        candidateListDirection = CandidateListDirection(rawValue: UserDefaults.standard.integer(forKey: UserDefaultsKeys.candidateListDirection)) ?? .vertical
-        if let dateConversionDict = UserDefaults.standard.dictionary(forKey: UserDefaultsKeys.dateConversions),
+        selectCandidateKeys = UserDefaults.app.string(forKey: UserDefaultsKeys.selectCandidateKeys)!
+        enterNewLine = UserDefaults.app.bool(forKey: UserDefaultsKeys.enterNewLine)
+        showCompletion = UserDefaults.app.bool(forKey: UserDefaultsKeys.showCompletion)
+        selectingBackspace = SelectingBackspace(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.selectingBackspace)) ?? SelectingBackspace.default
+        comma = Punctuation.Comma(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
+        period = Punctuation.Period(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
+        ignoreUserDictInPrivateMode = UserDefaults.app.bool(forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
+        showInputIconModal = UserDefaults.app.bool(forKey: UserDefaultsKeys.showInputModePanel)
+        candidateListDirection = CandidateListDirection(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.candidateListDirection)) ?? .vertical
+        if let dateConversionDict = UserDefaults.app.dictionary(forKey: UserDefaultsKeys.dateConversions),
            let dateConversionsRaw = dateConversionDict["conversions"] as? [[String: Any]],
            let dateYomisRaw = dateConversionDict["yomis"] as? [[String: Any]] {
             dateYomis = dateYomisRaw.compactMap({ DateConversion.Yomi(dict: $0) })
@@ -311,7 +311,7 @@ final class SettingsViewModel: ObservableObject {
                 }
             }
             Global.dictionary.dicts = enabledDicts
-            UserDefaults.standard.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
+            UserDefaults.app.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
         }
         .store(in: &cancellables)
 
@@ -324,12 +324,12 @@ final class SettingsViewModel: ObservableObject {
                 logger.log("skkserv辞書は無効化されています")
                 Global.skkservDict = nil
             }
-            UserDefaults.standard.set(setting.encode(), forKey: UserDefaultsKeys.skkservClient)
+            UserDefaults.app.set(setting.encode(), forKey: UserDefaultsKeys.skkservClient)
         }.store(in: &cancellables)
 
         $directModeApplications.dropFirst().sink { applications in
             let bundleIdentifiers = applications.map { $0.bundleIdentifier }
-            UserDefaults.standard.set(bundleIdentifiers, forKey: UserDefaultsKeys.directModeBundleIdentifiers)
+            UserDefaults.app.set(bundleIdentifiers, forKey: UserDefaultsKeys.directModeBundleIdentifiers)
             Global.directModeBundleIdentifiers.send(bundleIdentifiers)
         }
         .store(in: &cancellables)
@@ -340,7 +340,7 @@ final class SettingsViewModel: ObservableObject {
                 "insertBlankString": $0.insertBlankString,
                 "treatFirstCharacterAsMarkedText": $0.treatFirstCharacterAsMarkedText,
             ] }
-            UserDefaults.standard.set(settings, forKey: UserDefaultsKeys.workarounds)
+            UserDefaults.app.set(settings, forKey: UserDefaultsKeys.workarounds)
         }.store(in: &cancellables)
 
         $workaroundApplications.sink { applications in
@@ -401,7 +401,7 @@ final class SettingsViewModel: ObservableObject {
         $selectedInputSourceId.removeDuplicates().sink { [weak self] selectedInputSourceId in
             if let selectedInputSource = self?.inputSources.first(where: { $0.id == selectedInputSourceId }) {
                 logger.info("キー配列を \(selectedInputSource.localizedName, privacy: .public) (\(selectedInputSourceId, privacy: .public)) に設定しました")
-                UserDefaults.standard.set(selectedInputSource.id, forKey: UserDefaultsKeys.selectedInputSource)
+                UserDefaults.app.set(selectedInputSource.id, forKey: UserDefaultsKeys.selectedInputSource)
             } else {
                 if let self, !self.inputSources.isEmpty {
                     logger.error("キー配列 \(selectedInputSourceId, privacy: .public) が見つかりませんでした")
@@ -410,43 +410,43 @@ final class SettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $showAnnotation.dropFirst().sink { showAnnotation in
-            UserDefaults.standard.set(showAnnotation, forKey: UserDefaultsKeys.showAnnotation)
+            UserDefaults.app.set(showAnnotation, forKey: UserDefaultsKeys.showAnnotation)
             logger.log("注釈表示を\(showAnnotation ? "表示" : "非表示", privacy: .public)に変更しました")
         }.store(in: &cancellables)
 
         $inlineCandidateCount.dropFirst().sink { inlineCandidateCount in
-            UserDefaults.standard.set(inlineCandidateCount, forKey: UserDefaultsKeys.inlineCandidateCount)
+            UserDefaults.app.set(inlineCandidateCount, forKey: UserDefaultsKeys.inlineCandidateCount)
             NotificationCenter.default.post(name: notificationNameInlineCandidateCount, object: inlineCandidateCount)
             logger.log("インラインで表示する変換候補の数を\(inlineCandidateCount)個に変更しました")
         }.store(in: &cancellables)
 
         $candidatesFontSize.dropFirst().sink { candidatesFontSize in
-            UserDefaults.standard.set(candidatesFontSize, forKey: UserDefaultsKeys.candidatesFontSize)
+            UserDefaults.app.set(candidatesFontSize, forKey: UserDefaultsKeys.candidatesFontSize)
             NotificationCenter.default.post(name: notificationNameCandidatesFontSize, object: candidatesFontSize)
             logger.log("変換候補のフォントサイズを\(candidatesFontSize)に変更しました")
         }.store(in: &cancellables)
 
         $annotationFontSize.dropFirst().sink { annotationFontSize in
-            UserDefaults.standard.set(annotationFontSize, forKey: UserDefaultsKeys.annotationFontSize)
+            UserDefaults.app.set(annotationFontSize, forKey: UserDefaultsKeys.annotationFontSize)
             NotificationCenter.default.post(name: notificationNameAnnotationFontSize, object: annotationFontSize)
             logger.log("注釈のフォントサイズを\(annotationFontSize)に変更しました")
         }.store(in: &cancellables)
 
         $selectCandidateKeys.dropFirst().sink { selectCandidateKeys in
-            UserDefaults.standard.set(selectCandidateKeys, forKey: UserDefaultsKeys.selectCandidateKeys)
+            UserDefaults.app.set(selectCandidateKeys, forKey: UserDefaultsKeys.selectCandidateKeys)
             Global.selectCandidateKeys = selectCandidateKeys.lowercased().map { $0 }
             logger.log("変換候補決定のキーを\"\(selectCandidateKeys, privacy: .public)\"に変更しました")
         }.store(in: &cancellables)
 
         $findCompletionFromAllDicts.dropFirst().sink { findCompletionFromAllDicts in
-            UserDefaults.standard.set(findCompletionFromAllDicts, forKey: UserDefaultsKeys.findCompletionFromAllDicts)
+            UserDefaults.app.set(findCompletionFromAllDicts, forKey: UserDefaultsKeys.findCompletionFromAllDicts)
             NotificationCenter.default.post(name: notificationNameFindCompletionFromAllDicts, object: findCompletionFromAllDicts)
             logger.log("一般の辞書を使って補完するかを\(findCompletionFromAllDicts)に変更しました")
         }.store(in: &cancellables)
 
         $keyBindingSets.dropFirst().sink { keyBindingSets in
             // デフォルトのキーバインド以外をUserDefaultsに保存する
-            UserDefaults.standard.set(keyBindingSets.filter({ $0.id != KeyBindingSet.defaultId }).map { $0.encode() },
+            UserDefaults.app.set(keyBindingSets.filter({ $0.id != KeyBindingSet.defaultId }).map { $0.encode() },
                                       forKey: UserDefaultsKeys.keyBindingSets)
             Global.keyBinding = keyBindingSets.first { $0.id == selectedKeyBindingSetId } ?? KeyBindingSet.defaultKeyBindingSet
         }.store(in: &cancellables)
@@ -454,32 +454,32 @@ final class SettingsViewModel: ObservableObject {
         $selectedKeyBindingSet.dropFirst().sink { selectedKeyBindingSet in
             if Global.keyBinding.id != selectedKeyBindingSet.id {
                 logger.log("キーバインドのセットを \(Global.keyBinding.id, privacy: .public) から \(selectedKeyBindingSet.id, privacy: .public) に変更しました")
-                UserDefaults.standard.set(selectedKeyBindingSet.id, forKey: UserDefaultsKeys.selectedKeyBindingSetId)
+                UserDefaults.app.set(selectedKeyBindingSet.id, forKey: UserDefaultsKeys.selectedKeyBindingSetId)
                 Global.keyBinding = selectedKeyBindingSet
             }
         }.store(in: &cancellables)
 
         $enterNewLine.dropFirst().sink { enterNewLine in
             logger.log("Enterキーで変換確定と一緒に改行する設定を\(enterNewLine ? "有効" : "無効", privacy: .public)にしました") 
-            UserDefaults.standard.set(enterNewLine, forKey: UserDefaultsKeys.enterNewLine)
+            UserDefaults.app.set(enterNewLine, forKey: UserDefaultsKeys.enterNewLine)
             Global.enterNewLine = enterNewLine
         }.store(in: &cancellables)
 
         $showCompletion.dropFirst().sink { showCompletion in
             logger.log("補完候補表示を\(showCompletion ? "表示" : "非表示", privacy: .public)に変更しました")
-            UserDefaults.standard.set(showCompletion, forKey: UserDefaultsKeys.showCompletion)
+            UserDefaults.app.set(showCompletion, forKey: UserDefaultsKeys.showCompletion)
             Global.showCompletion = showCompletion
         }.store(in: &cancellables)
 
         $systemDict.dropFirst().sink { systemDict in
             logger.log("注釈で使用するシステム辞書を \(systemDict.rawValue, privacy: .public) に変更しました")
-            UserDefaults.standard.set(systemDict.rawValue, forKey: UserDefaultsKeys.systemDict)
+            UserDefaults.app.set(systemDict.rawValue, forKey: UserDefaultsKeys.systemDict)
             Global.systemDict = systemDict
         }.store(in: &cancellables)
 
         $selectingBackspace.dropFirst().sink { selectingBackspace in
             logger.log("変換候補選択時のバックスペースの挙動を \(selectingBackspace.description, privacy: .public) に変更しました")
-            UserDefaults.standard.set(selectingBackspace.rawValue, forKey: UserDefaultsKeys.selectingBackspace)
+            UserDefaults.app.set(selectingBackspace.rawValue, forKey: UserDefaultsKeys.selectingBackspace)
             Global.selectingBackspace = selectingBackspace
         }.store(in: &cancellables)
 
@@ -487,22 +487,22 @@ final class SettingsViewModel: ObservableObject {
             logger.log("句読点の入力が変更されました。 カンマ: \(comma.description, privacy: .public), ピリオド: \(period.description, privacy: .public)")
             let punctuation = Punctuation(comma: comma, period: period)
             Global.punctuation = punctuation
-            UserDefaults.standard.set(punctuation.rawValue, forKey: UserDefaultsKeys.punctuation)
+            UserDefaults.app.set(punctuation.rawValue, forKey: UserDefaultsKeys.punctuation)
         }.store(in: &cancellables)
 
         $ignoreUserDictInPrivateMode.dropFirst().sink { ignoreUserDictInPrivateMode in
             logger.log("プライベートモードでユーザー辞書を \(ignoreUserDictInPrivateMode ? "参照しない" : "参照する", privacy: .public) に変更しました")
             Global.ignoreUserDictInPrivateMode.send(ignoreUserDictInPrivateMode)
-            UserDefaults.standard.set(ignoreUserDictInPrivateMode, forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
+            UserDefaults.app.set(ignoreUserDictInPrivateMode, forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
         }.store(in: &cancellables)
         
         $showInputIconModal.dropFirst().sink { showInputModePanel in
-            UserDefaults.standard.set(showInputModePanel, forKey: UserDefaultsKeys.showInputModePanel)
+            UserDefaults.app.set(showInputModePanel, forKey: UserDefaultsKeys.showInputModePanel)
             logger.log("入力モードアイコンを\(showInputModePanel ? "表示" : "非表示", privacy: .public)に変更しました")
         }.store(in: &cancellables)
 
         $candidateListDirection.dropFirst().sink { candidateListDirection in
-            UserDefaults.standard.set(candidateListDirection.rawValue, forKey: UserDefaultsKeys.candidateListDirection)
+            UserDefaults.app.set(candidateListDirection.rawValue, forKey: UserDefaultsKeys.candidateListDirection)
             logger.log("変換候補リストを\(candidateListDirection == .vertical ? "縦" : "横", privacy: .public)で表示するように変更しました")
             Global.candidateListDirection.send(candidateListDirection)
         }.store(in: &cancellables)
@@ -768,6 +768,6 @@ final class SettingsViewModel: ObservableObject {
             "yomis": dateYomis.map { $0.encode() },
             "conversions": dateConversions.map({ $0.encode() }),
         ]
-        UserDefaults.standard.set(dict, forKey: UserDefaultsKeys.dateConversions)
+        UserDefaults.app.set(dict, forKey: UserDefaultsKeys.dateConversions)
     }
 }

--- a/macSKK/UserDefaults+App.swift
+++ b/macSKK/UserDefaults+App.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension UserDefaults {
+    // ユニットテスト実行時に本体アプリ設定と別にしておく
+    static var app: UserDefaults {
+        isTest() ? UserDefaults(suiteName: "net.mtgto.inputmethod.macSKK.test")! : .standard
+    }
+}

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -87,7 +87,7 @@ class UserDict: NSObject, DictProtocol {
             } else {
                 logger.log("プライベートモードが解除されました")
             }
-            UserDefaults.standard.set(privateMode, forKey: UserDefaultsKeys.privateMode)
+            UserDefaults.app.set(privateMode, forKey: UserDefaultsKeys.privateMode)
         }
         .store(in: &cancellables)
     }

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -59,7 +59,7 @@ struct macSKKApp: App {
             ).appendingPathComponent("Dictionaries")
             let settingsViewModel = try SettingsViewModel(dictionariesDirectoryUrl: dictionariesDirectoryUrl)
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
-            Global.privateMode.send(UserDefaults.standard.bool(forKey: UserDefaultsKeys.privateMode))
+            Global.privateMode.send(UserDefaults.app.bool(forKey: UserDefaultsKeys.privateMode))
 
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
             Global.dictionary = try UserDict(dicts: [],
@@ -176,7 +176,7 @@ struct macSKKApp: App {
     }
 
     private static func setupUserDefaults() {
-        UserDefaults.standard.register(defaults: [
+        UserDefaults.app.register(defaults: [
             UserDefaultsKeys.dictionaries: [],
             UserDefaultsKeys.directModeBundleIdentifiers: [String](),
             UserDefaultsKeys.selectedInputSource: InputSource.defaultInputSourceId,
@@ -241,7 +241,7 @@ struct macSKKApp: App {
             }
             return nil
         }
-        let dictSettings = UserDefaults.standard.array(forKey: "dictionaries")?.compactMap { obj in
+        let dictSettings = UserDefaults.app.array(forKey: "dictionaries")?.compactMap { obj in
             if let setting = obj as? [String: Any], let dictSetting = DictSetting(setting) {
                 if validFilenames.contains(dictSetting.filename) {
                     return dictSetting
@@ -253,7 +253,7 @@ struct macSKKApp: App {
             // 再起動してもおそらく同じ理由でこけるので、リセットしちゃう
             // TODO: Notification Center経由でユーザーにも破壊的処理が起きたことを通知してある
             logger.error("環境設定の辞書設定が壊れています")
-            UserDefaults.standard.removeObject(forKey: "dictionaries")
+            UserDefaults.app.removeObject(forKey: "dictionaries")
             return
         }
         settingsViewModel.dictSettings = dictSettings
@@ -268,7 +268,7 @@ struct macSKKApp: App {
     }
 
     private func setupDirectMode() {
-        if let bundleIdentifiers = UserDefaults.standard.array(forKey: "directModeBundleIdentifiers") as? [String] {
+        if let bundleIdentifiers = UserDefaults.app.array(forKey: "directModeBundleIdentifiers") as? [String] {
             Global.directModeBundleIdentifiers.send(bundleIdentifiers)
         }
     }


### PR DESCRIPTION
ユニットテスト実行時に `UserDefaults.init?(suiteName: String?)` を使い、本体設定とは別インスタンスを使うようにします。
Xcodeで実行するとStateMachineTestsの実行でプライベートモードになってしまうといった実害が出ていたのがこれで解決します。