### PR TITLE
数値変換の対象辞書にSKKServを入れてなかったのを修正

### DIFF
--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -171,6 +171,18 @@ class UserDict: NSObject, DictProtocol {
                                          saveToUserDict: dict.saveToUserDict)
                     })
                 }
+                if let skkservDict = Global.skkservDict {
+                    let skkservCandidates: [Candidate] = skkservDict.refer(midashi, option: option).compactMap { word in
+                        guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
+                        guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
+                        let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                        return Candidate(convertedWord,
+                                         annotations: annotations,
+                                         original: Candidate.Original(midashi: midashi, word: word.word),
+                                         saveToUserDict: skkservDict.saveToUserDict)
+                    }
+                    candidates.append(contentsOf: skkservCandidates)
+                }
             }
         }
         for candidate in candidates {


### PR DESCRIPTION
#380 数値変換の参照候補辞書にSKKServを入れていなかったのを修正します。