### PR TITLE
独自のかなルールを置いているとクラッシュするバグを修正

### DIFF
--- a/macSKK/URL+Additions.swift
+++ b/macSKK/URL+Additions.swift
@@ -22,6 +22,7 @@ extension URL {
                 return false
             }
         }
-        fatalError("isHidden, isReadable, isRegularFileの読み込みに失敗しました")
+        logger.warning("isHidden, isReadable, isRegularFileの読み込みに失敗しました")
+        return true
     }
 }


### PR DESCRIPTION
#382 kana-rule.conf を置いているとv2.3.1でクラッシュすることがわかりました。
v2.3.1でfatalErrorにした行を元に戻します。