### PR TITLE
変換候補が多いエントリのシリアライズでスタックオーバーフローするのを修正

### DIFF
--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -91,4 +91,10 @@ final class EntryTests: XCTestCase {
             Entry(line: "いt /[った/行/]/入/[った/言/]/", dictId: "")?.serialize(),
             "いt /[った/行/言/]/入/")
     }
+
+    func testSerizalizeLarge() {
+        let line = "い /" + String(repeating: "イ/", count: 10000)
+        let entry = Entry(line: line, dictId: "")!
+        XCTAssertEqual(entry.serialize(), line)
+    }
 }


### PR DESCRIPTION
#386 `Entry.serializeWords(_:)` は再帰呼び出しによる処理を行っていますが、1つの読みに対する変換候補が多いとスタックオーバーフローすることがあるためループによる処理に変更します。