### PR TITLE
AZIKの`;,っ`のようなルールがあれば`isPrefix`で`true`となるようにした

### DIFF
--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -86,9 +86,21 @@ class RomajiTests: XCTestCase {
         XCTAssertTrue(kanaRule.isPrefix("kya", modifierFlags: [], treatAsAlphabet: false))
         XCTAssertFalse(kanaRule.isPrefix("kyi", modifierFlags: [], treatAsAlphabet: false))
         XCTAssertFalse(kanaRule.isPrefix("q", modifierFlags: [], treatAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [], treatAsAlphabet: false))
-        XCTAssertFalse(kanaRule.isPrefix(",", modifierFlags: [.shift], treatAsAlphabet: false))
-        XCTAssertTrue(kanaRule.isPrefix(",", modifierFlags: [.shift], treatAsAlphabet: true))
+        XCTAssertTrue(kanaRule.isPrefix(".", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix(".", modifierFlags: [.shift], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix(".", modifierFlags: [.shift], treatAsAlphabet: true))
+        XCTAssertFalse(kanaRule.isPrefix(";", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix(";", modifierFlags: [.shift], treatAsAlphabet: false))
+    }
+
+    func testAzikIsPrefix() throws {
+        let kanaRule = Romaji.azikKanaRule
+        // AZIKには`;,っ`のルールが存在するので`;`で`true`になる。
+        XCTAssertTrue(kanaRule.isPrefix(";", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertTrue(kanaRule.isPrefix(";", modifierFlags: [.shift], treatAsAlphabet: false))
+        // AZIKでも`.,。`でkanaがひらがなではないので`.`はRomaji.defaultKanaRuleと同じになる。
+        XCTAssertTrue(kanaRule.isPrefix(".", modifierFlags: [], treatAsAlphabet: false))
+        XCTAssertFalse(kanaRule.isPrefix(".", modifierFlags: [.shift], treatAsAlphabet: false))
     }
 }
 
@@ -96,6 +108,12 @@ extension Romaji {
     // アプリデフォルトのローマ字かな変換ルール
     static var defaultKanaRule: Romaji {
         let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule", withExtension: "conf")!
+        return try! Romaji(contentsOf: kanaRuleFileURL)
+    }
+
+    // AZIKローマ字かな変換ルール
+    static var azikKanaRule: Romaji {
+        let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule-azik", withExtension: "conf")!
         return try! Romaji(contentsOf: kanaRuleFileURL)
     }
 }


### PR DESCRIPTION
- 従来は`kana-rule.conf`にAZIKの`;,っ`のようなルールがあったとしても、`;`がアルファベットではないため`isPrefix`が`false`となりローマ字かな変換のルールが適用されないようになっていた
- よって上記のようなルールを使って`ッ`を打ち込みたいときに 👇 下記のような入力ができなかった
    1. 現在「ひらがな」モードで`Shift` + `;`を入力する
    2. `▽っ`となる
    3. `q`など「かなカナモード切り替え」キーを押す
- そこで`isPrefix`に、`input`がアルファベットであるという判定の他に下記のルールを追加して上記の変換ができるようにした
    - 現在のローマ字かな変換ルール`Romaji`のテーブルに登録されており
    - かつそれの`kana`がひらがなである