### PR TITLE
補完候補をすべての辞書から探す設定が起動時に読み込めてなかったのを修正

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -278,6 +278,7 @@ final class SettingsViewModel: ObservableObject {
         Global.punctuation = Punctuation(comma: comma, period: period)
         Global.ignoreUserDictInPrivateMode.send(ignoreUserDictInPrivateMode)
         Global.candidateListDirection.send(candidateListDirection)
+        Global.findCompletionFromAllDicts.send(findCompletionFromAllDicts)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in


### PR DESCRIPTION
#180 で追加した「ユーザー辞書だけでなくすべての辞書から補完を探す」という設定が起動後に一回変更しないと反映されていなかった (常に無効になっていた) バグを修正します。