### PR TITLE
読みの補完候補があるときShift-Spaceで先頭候補で変換開始する

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -35,6 +35,10 @@ struct KeyBinding: Identifiable, Hashable {
         case enter
         /// デフォルトはSpaceキー
         case space
+        /// 現在の補完候補で変換を開始する。
+        /// 変換候補が補完で表示されているときはspaceと同じ挙動をする。
+        /// デフォルトはShift-Spaceキー
+        case shiftSpace
         /// 前の変換候補に移動する。デフォルトはxキー。
         case backwardCandidate
         /// 補完候補の確定用。デフォルトはTabキー
@@ -289,6 +293,8 @@ struct KeyBinding: Identifiable, Hashable {
                 return KeyBinding(action, [Input(key: .code(0x24), modifierFlags: [], optionalModifierFlags: [.shift, .option])])
             case .space:
                 return KeyBinding(action, [Input(key: .code(0x31), modifierFlags: [])])
+            case .shiftSpace:
+                return KeyBinding(action, [Input(key: .code(0x31), modifierFlags: [.shift])])
             case .backwardCandidate:
                 return KeyBinding(action, [Input(key: .character("x"), modifierFlags: [])])
             case .tab:

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -412,7 +412,7 @@ final class StateMachine {
         case .eisu:
             // 何もしない (OSがIMEの切り替えはしてくれる)
             return true
-        case .space, .unregister, .backwardCandidate, .toggleAndFixKana, .affix, nil:
+        case .space, .shiftSpace, .unregister, .backwardCandidate, .toggleAndFixKana, .affix, nil:
             break
         }
 
@@ -737,6 +737,24 @@ final class StateMachine {
                     return handleComposingStartConvert(action, composing: composing, specialState: specialState)
                 }
             }
+        case .shiftSpace:
+            // 補完が読みのときは変換開始する。そうじゃないときはなにもしない
+            // NOTE: 補完が変換候補のときはシフトをうっかり押しちゃっただけのspaceと同じ挙動でもいいかも?
+            if state.inputMode != .direct {
+                if case .yomi(let yomis, let yomiIndex) = completion, 0 <= yomiIndex && yomiIndex < yomis.count {
+                    // 最初の読みで変換開始
+                    let yomi = yomis[yomiIndex]
+                    let newText = yomi.map({ String($0) })
+                    let completionState = ComposingState(isShift: true,
+                                                         text: newText,
+                                                         okuri: nil,
+                                                         romaji: "",
+                                                         cursor: nil,
+                                                         prevMode: composing.prevMode)
+                    return handleComposingStartConvert(action, composing: completionState, specialState: specialState)
+                }
+            }
+            return true
         case .tab:
             // FIXME: この記号がローマ字に含まれていることも考慮するべき?
             if case .yomi(let yomis, let yomiIndex) = completion {
@@ -1242,7 +1260,7 @@ final class StateMachine {
             } else {
                 return handleSelectingNextPage(action, selecting: selecting, specialState: specialState)
             }
-        case .space:
+        case .space, .shiftSpace:
             if selecting.completion {
                 // TODO 補完を中断して現在の読みで変換開始する
                 return true

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 "KeyBindingActionStickyshift" = "Sticky Shift";
 "KeyBindingActionEnter" = "Enter";
 "KeyBindingActionSpace" = "Space";
+"KeyBindingActionShiftspace" = "Shift-Space";
 "KeyBindingActionBackwardcandidate" = "Select backward candidate";
 "KeyBindingActionTab" = "Tab";
 "KeyBindingActionBackspace" = "Backspace";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 "KeyBindingActionStickyshift" = "Sticky Shift";
 "KeyBindingActionEnter" = "Enter";
 "KeyBindingActionSpace" = "Space";
+"KeyBindingActionShiftspace" = "Shift-Space";
 "KeyBindingActionBackwardcandidate" = "前の変換候補を選択";
 "KeyBindingActionTab" = "Tab";
 "KeyBindingActionBackspace" = "Backspace";

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2274,6 +2274,28 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(Action(keyBind: nil, event: generateNSEvent(character: "c", characterIgnoringModifiers: "c", modifierFlags: .command))))
     }
 
+    @MainActor func testHandleComposingShiftSpace() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.dictionary.setEntries(["あさ": [Word("朝"), Word("麻")]])
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(4).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerSelect, .emphasized("朝")])))
+            XCTAssertEqual(events[2], .fixedText("朝"))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("い")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        stateMachine.completion = .yomi(["あさ"], 0)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(enterAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "i", withShift: true)))
+        stateMachine.completion = .candidates([Candidate("井の頭公園", original: Candidate.Original(midashi: "いのかしらこうえん", word: "井の頭公園"))])
+        // 補完が変換候補の場合はなにもしない
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ", withShift: true)))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleRegisteringEnter() {
         Global.dictionary.setEntries(["お": [Word("尾")]])
 
@@ -3815,7 +3837,7 @@ final class StateMachineTests: XCTestCase {
         case "/":
             return withShift ? nil : .abbrev
         case " ":
-            return .space
+            return withShift ? .shiftSpace : .space
         case "\r":
             return .enter
         case "\t":


### PR DESCRIPTION
#378 読みの補完候補があるときにShift-Spaceを押すと先頭の補完候補で変換開始します。
例えば「Niho」と打ってTabを押すと「にほん」となるとき、Tabの代わりにShift-Spaceを押すと「▼日本」のように「にほん」で変換開始した状態にします。

変換候補の補完候補があるときにShift-Spaceではなにも起きません。
(スペースとして挙動してもいいかも? 実装しない方が楽なので一旦後回し)