### PR TITLE
読みにスペースを含むエントリを禁止する

### DIFF
--- a/macSKK/Entry.swift
+++ b/macSKK/Entry.swift
@@ -28,7 +28,7 @@ struct Entry: Sendable {
             return nil
         }
         let words = line.split(separator: " /", maxSplits: 1)
-        if words.count != 2 || words[0].last == " " {
+        if words.count != 2 || words[0].contains(" ") {
             return nil
         }
         yomi = String(words[0]).replacing("う゛", with: "ゔ")

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -71,6 +71,7 @@ final class EntryTests: XCTestCase {
         XCTAssertNil(Entry(line: "い  /胃/", dictId: ""), "読みと変換候補の間にスペースが2つある")
         XCTAssertNil(Entry(line: "い /胃/意", dictId: ""), "末尾がスラッシュで終わらない")
         XCTAssertNil(Entry(line: "いt /[った/行]/", dictId: ""), "送り仮名ブロックの変換候補の末尾にスラッシュがない")
+        XCTAssertNil(Entry(line: "い いt /行/", dictId: ""), "読みが複数ある")
     }
 
     func testSerialize() {


### PR DESCRIPTION
エントリの読みが半角スペースで始まったり、途中でスペースを含むようなエントリを読み飛ばすようにします。
#396 のユニットテストで `で でm /[ま/出/出/出/出/出/]/出/出/出/` のような読みが二つあるようなデータを書いていて気付きました。