### PR TITLE
補完候補ビューのサイズを計算して余白が表示されないように修正

### DIFF
--- a/macSKK/View/CompletionPanel.swift
+++ b/macSKK/View/CompletionPanel.swift
@@ -23,22 +23,38 @@ class CompletionPanel: NSPanel {
     }
 
     func show(at cursorPoint: NSRect, windowLevel: NSWindow.Level) {
-        level = windowLevel
         var origin = cursorPoint.origin
-
-        if let size = contentViewController?.view.frame.size, let mainScreen = NSScreen.main {
+        let width: CGFloat
+        let height: CGFloat
+        if case let .panel(words, _, _) = viewModel.candidatesViewModel.candidates {
+            switch Global.candidateListDirection.value {
+            case .vertical:
+                width = viewModel.candidatesViewModel.minWidth
+                height = CGFloat(words.count) * viewModel.candidatesViewModel.candidatesLineHeight + CompletionView.footerHeight
+            case .horizontal:
+                width = viewModel.candidatesViewModel.minWidth
+                height = viewModel.candidatesViewModel.candidatesLineHeight + CompletionView.footerHeight
+            }
+        } else {
+            // FIXME: 短い文のときにはそれに合わせて高さを縮める
+            width = viewModel.candidatesViewModel.minWidth
+            height = 200
+        }
+        setContentSize(NSSize(width: width, height: height))
+        if let mainScreen = NSScreen.main {
             let visibleFrame = mainScreen.visibleFrame
-            if origin.x + size.width > visibleFrame.minX + visibleFrame.width {
-                origin.x = visibleFrame.minX + visibleFrame.width - size.width
+            if origin.x + width > visibleFrame.minX + visibleFrame.width {
+                origin.x = visibleFrame.minX + visibleFrame.width - width
             }
             // 1ピクセルの余白を設ける
-            if origin.y - size.height < visibleFrame.minY {
-                origin.y = origin.y + size.height + cursorPoint.height + 1
+            if origin.y - height < visibleFrame.minY {
+                origin.y = origin.y + cursorPoint.height + height + 1
             } else {
-                origin.y -= 1
+                origin.y = origin.y - 1
             }
         }
         setFrameTopLeftPoint(origin)
+        level = windowLevel
         orderFrontRegardless()
     }
 }

--- a/macSKK/View/CompletionView.swift
+++ b/macSKK/View/CompletionView.swift
@@ -6,9 +6,10 @@ import SwiftUI
 /// 補完候補を表示するビュー
 struct CompletionView: View {
     @ObservedObject var viewModel: CompletionViewModel
+    static let footerHeight: CGFloat = 18
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             if case .yomi(let yomi) = viewModel.completion {
                 Text(yomi)
                     .font(.body)
@@ -22,8 +23,8 @@ struct CompletionView: View {
             Text("Tab Completion")
                 .font(.caption)
                 .frame(maxWidth: .infinity)
+                .frame(height: Self.footerHeight)
         }
-        .padding(2)
         .fixedSize()
     }
 }

--- a/macSKK/View/CompletionViewModel.swift
+++ b/macSKK/View/CompletionViewModel.swift
@@ -36,7 +36,7 @@ final class CompletionViewModel: ObservableObject {
         $completion.dropFirst().sink { [weak self] completion in
             guard let self else { return }
             if case .candidates(let words) = completion {
-                logger.log("補完候補が更新されました")
+                logger.debug("補完候補が更新されました")
                 self.candidatesViewModel.candidates = .panel(words: words, currentPage: 0, totalPageCount: 1)
             } else {
                 self.candidatesViewModel.candidates = .inline


### PR DESCRIPTION
macOS 26に変えたからかもしれないですが、補完候補表示の左右に余白が表示されることがあるようでした。
https://github.com/mtgto/macSKK/issues/378#issuecomment-3312550858

変換候補と同様に同じビューのサイズを計算するようにします。