### PR TITLE
読み入力中じゃないのに補完候補が表示されたりするバグを修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -183,19 +183,13 @@ class InputController: IMKInputController {
             }
             .receive(on: DispatchQueue.global())
             .compactMap { (yomi, cursorPosition) -> (String, Completion, NSRect)? in
-                if Global.showCompletion {
-                    if yomi.isEmpty {
-                        return nil
-                    }
-                    if Global.showCandidateForCompletion {
-                        let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi)
-                        return (yomi, .candidates(candidates), cursorPosition)
-                     } else {
-                        let completions = Global.dictionary.findCompletions(prefix: yomi)
-                        return (yomi, .yomi(completions, 0), cursorPosition)
-                    }
+                if Global.showCandidateForCompletion {
+                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi)
+                    return (yomi, .candidates(candidates), cursorPosition)
+                 } else {
+                    let completions = Global.dictionary.findCompletions(prefix: yomi)
+                    return (yomi, .yomi(completions, 0), cursorPosition)
                 }
-                return nil
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (yomi, completion, cursorPosition) in


### PR DESCRIPTION
> v2.4.1 たまに変換確定したあと? などもう表示されないときにも補完候補が表示されっぱなしになる気がする。
https://github.com/mtgto/macSKK/issues/378#issuecomment-3315422902

試しに補完候補検索にスリープを入れてみたところはっきり再現するようになった。
補完候補の検索をバックグラウンドスレッドでやるようにしているため、補完候補検索の間に読みが変わったり変換が開始されてしまうことがありえるがその場合を考慮せずに補完候補を表示しようとしていたのが原因。

補完候補表示するときにメインスレッドで現在入力中の状態が検索前と同じかどうか検査するようにします。