### PR TITLE
補完候補で読みを表示するときの余白を消していたのを修正。高さ計算を修正

### DIFF
--- a/macSKK/View/CompletionPanel.swift
+++ b/macSKK/View/CompletionPanel.swift
@@ -36,9 +36,9 @@ class CompletionPanel: NSPanel {
                 height = viewModel.candidatesViewModel.candidatesLineHeight + CompletionView.footerHeight
             }
         } else {
-            // FIXME: 短い文のときにはそれに合わせて高さを縮める
             width = viewModel.candidatesViewModel.minWidth
-            height = 200
+            // 読みのときの足さは1行 + "Tabで補完" + 上下のパディング4
+            height = CompletionView.yomiHeight + CompletionView.footerHeight + 4
         }
         setContentSize(NSSize(width: width, height: height))
         if let mainScreen = NSScreen.main {

--- a/macSKK/View/CompletionView.swift
+++ b/macSKK/View/CompletionView.swift
@@ -7,12 +7,14 @@ import SwiftUI
 struct CompletionView: View {
     @ObservedObject var viewModel: CompletionViewModel
     static let footerHeight: CGFloat = 18
+    static let yomiHeight: CGFloat = 16
 
     var body: some View {
         VStack(spacing: 0) {
             if case .yomi(let yomi) = viewModel.completion {
                 Text(yomi)
                     .font(.body)
+                    .frame(height: Self.yomiHeight)
             } else if case .candidates(let words) = viewModel.completion {
                 if case .vertical = Global.candidateListDirection.value {
                     VerticalCandidatesView(candidates: viewModel.candidatesViewModel, words: words, currentPage: 0, totalPageCount: 1)
@@ -25,6 +27,7 @@ struct CompletionView: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: Self.footerHeight)
         }
+        .padding(viewModel.padding)
         .fixedSize()
     }
 }

--- a/macSKK/View/CompletionViewModel.swift
+++ b/macSKK/View/CompletionViewModel.swift
@@ -14,6 +14,13 @@ final class CompletionViewModel: ObservableObject {
     @Published var completion: CurrentCompletion
     @Published var candidatesViewModel: CandidatesViewModel
     private var cancellables: Set<AnyCancellable> = []
+    var padding: CGFloat {
+        if case .yomi = completion {
+            2
+        } else {
+            0
+        }
+    }
 
     init(completion: CurrentCompletion, candidatesFontSize: Int, annotationFontSize: Int) {
         self.completion = completion


### PR DESCRIPTION
https://github.com/mtgto/macSKK/issues/378#issuecomment-3324322422
#398 で補完候補ビューのサイズに手を入れました。そのときに読みの補完候補表示にバグを入れてしまったので修正します。

- 上下左右の余白の復活
- 最初の表示時にカーソルよりもずっと下に表示されることがあるのを修正
  - 変換候補表示のときと同じで固定で200pxと置いていたミス