### PR TITLE
`CandidatesViewModel.minWidth`の計算に`candidatesFontSize`を使う

### DIFF
--- a/macSKK/View/CandidatesViewModel.swift
+++ b/macSKK/View/CandidatesViewModel.swift
@@ -95,7 +95,7 @@ final class CandidatesViewModel: ObservableObject {
 
         $candidates.combineLatest(Global.candidateListDirection).map { candidates, listDirection in
             if case let .panel(words, currentPage, totalPageCount) = candidates {
-                let font = NSFont.preferredFont(forTextStyle: .body)
+                let font = NSFont.systemFont(ofSize: self.candidatesFontSize)
                 switch listDirection {
                 case .vertical:
                     let listWidth = words.map { candidate -> CGFloat in


### PR DESCRIPTION
Issueを立てようかとも思ったのですが、割と簡単そうだったので作業してしまいました 🙏 

- 候補を表示する際のフォントサイズ`candidatesFontSize`を変更していた場合、下記のように候補がはみ出ることがあった
    - <img width="217" height="311" alt="image" src="https://github.com/user-attachments/assets/4a31fe73-70b2-42cd-8707-a0432aa1a717" />
    - フォントサイズ18での例
- `VerticalCandidatesView`/`HorizontalCandidatesView`では下記のように表示しているので、候補パネルの幅の計算に用いるフォントサイズに`candidatesFontSize`を指定するようにした
    - https://github.com/mtgto/macSKK/blob/7127293f122c48388e992cce9f9a38b2f9af4427/macSKK/View/VerticalCandidatesView.swift#L41-L42
    - https://github.com/mtgto/macSKK/blob/7127293f122c48388e992cce9f9a38b2f9af4427/macSKK/View/HorizontalCandidatesView.swift#L44-L45
- これによって候補がきちんとおさまるようになった
    - <img width="260" height="330" alt="image" src="https://github.com/user-attachments/assets/4e70a0a6-1880-41c6-a8c1-bd473992fed7" />

（これで解決したものの、一方で`.horizontal`の時ははみ出なかったのは少し謎…… 🤔 ）
