### PR TITLE
SKKServの補完候補の応答で重複要素や入力済みの読みと同じ候補は除外する

### DIFF
--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -71,7 +71,13 @@ struct SKKServDict {
                 logger.debug("skkservから補完候補が見つからなかったレスポンスが返りました")
                 return []
             }
-            return result.dropFirst(2).split(separator: "/").map { String($0) }
+            let completions = result.dropFirst(2).split(separator: "/").map { String($0) }
+            // 重複した候補、読みと同じ候補、読みを接頭辞としてもたない候補は除去
+            return completions.reduce(into: []) { acc, item in
+                if !acc.contains(item) && item.hasPrefix(prefix) && item != prefix {
+                    acc.append(item)
+                }
+            }
         } catch {
             if let error = error as? SKKServClientError {
                 switch error {

--- a/macSKKTests/SKKServDictTests.swift
+++ b/macSKKTests/SKKServDictTests.swift
@@ -35,8 +35,13 @@ final class SKKServDictTests: XCTestCase {
 
     func testFindCompletion() async throws {
         let service = MockedSKKServService(response: "1/ほかん/ほかく/")
-        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false)
+        var dict = SKKServDict(destination: destination, service: service, saveToUserDict: false)
         XCTAssertEqual(dict.findCompletions(prefix: "ほか"), ["ほかん", "ほかく"])
+        // 重複した補完候補、読みと同じ候補、読みを接頭辞としてもたない候補は除外する
+        dict = SKKServDict(destination: destination,
+                           service: MockedSKKServService(response: "1/ほかん/ほかん/ほか/ほげ/"),
+                           saveToUserDict: false)
+        XCTAssertEqual(dict.findCompletions(prefix: "ほか"), ["ほかん"])
     }
 
     func testFindCompletionNotFound() async throws {


### PR DESCRIPTION
#295 #378 SKKServから補完候補を取得したとき、重複した候補が含まれていたり入力した読みと同じ候補が返ってきた場合は除外するようにします。