### PR TITLE
設定から最新バージョンの取得に失敗した場合にログを出す

### DIFF
--- a/macSKK/Settings/SoftwareUpdateView.swift
+++ b/macSKK/Settings/SoftwareUpdateView.swift
@@ -52,7 +52,11 @@ struct SoftwareUpdateView: View {
 
     private func fetchReleases() {
         Task {
-            try await _ = settingsViewModel.fetchLatestRelease()
+            do {
+                try await _ = settingsViewModel.fetchLatestRelease()
+            } catch {
+                logger.error("最新バージョンの取得に失敗しました: \(error)")
+            }
         }
     }
 }


### PR DESCRIPTION
設定画面のソフトウェアアップデートから「アップデートを確認」したとき、何らかの理由で失敗した場合にログに出すようにします。