### PR TITLE
カタカナで確定した単語を辞書に保存するかの設定項目を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -53,6 +53,8 @@ import Combine
     static var fixedCompletionByPeriod: Bool = true
     /// SKKServから補完候補を検索するか
     static var searchCompletionsSkkserv: Bool = false
+    /// qキーでカタカナで確定したときに辞書に保存するか
+    static var registerKatakana = false
     /// 現在のモードを表示するパネル
     private let inputModePanel: InputModePanel
     /// 変換候補を表示するパネル

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -47,6 +47,9 @@ struct GeneralView: View {
                 Toggle(isOn: $settingsViewModel.showInputIconModal, label: {
                     Text("Show Input Mode Modal")
                 })
+                Toggle(isOn: $settingsViewModel.registerKatakana, label: {
+                    Text("Register fixed katakana word to dict")
+                })
                 Section {
                     Picker("Number of inline candidates", selection: $settingsViewModel.inlineCandidateCount) {
                         ForEach(0..<10) { count in

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -50,4 +50,6 @@ struct UserDefaultsKeys {
     static let dateConversions = "dateConversions"
     // ピリオドで補完候補の最初の要素で確定するか
     static let fixedCompletionByPeriod = "fixedCompletionByPeriod"
+    // qキーでカタカナで確定した場合に辞書に登録するか
+    static let registerKatakana = "registerKatakana"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -618,7 +618,15 @@ final class StateMachine {
                 // 未確定ローマ字はn以外は入力されずに削除される. nだけは"ん"が入力されているとする
                 state.inputMethod = .normal
                 switch state.inputMode {
-                case .hiragana, .hankaku:
+                case .hiragana:
+                    let fixedText = composing.string(for: .katakana, kanaRule: Global.kanaRule)
+                    if Global.registerKatakana {
+                        let yomi = composing.string(for: .hiragana, kanaRule: Global.kanaRule)
+                        addWordToUserDict(yomi: yomi, okuri: nil, candidate: Candidate(fixedText))
+                    }
+                    addFixedText(fixedText)
+                    return true
+                case .hankaku:
                     addFixedText(composing.string(for: .katakana, kanaRule: Global.kanaRule))
                     return true
                 case .katakana:

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Confirm the first completion by period" = "Confirm the first completion by period";
 "Ignore User Dict in Private Mode" = "Ignore User Dict in Private Mode";
 "Show Input Mode Modal" = "Show Input Mode Modal";
+"Register fixed katakana word to dict" = "Register fixed katakana word to dict";
 "Direction of candidate list" = "Direction of candidate list";
 "Enter Key confirms a candidate and sends a newline" = "Enter Key confirms a candidate and sends a newline";
 "Show Completion" = "Show Completion";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Confirm the first completion by period" = "最初の補完候補をピリオドキーで確定する";
 "Ignore User Dict in Private Mode" = "プライベートモードではユーザー辞書を参照しない";
 "Show Input Mode Modal" = "入力モードアイコンを表示";
+"Register fixed katakana word to dict" = "カタカナで確定した単語を辞書に登録する";
 "Direction of candidate list" = "変換候補リストの表示方向";
 "Enter Key confirms a candidate and sends a newline" = "Enterキーで変換候補確定後に改行を入力";
 "Show Completion" = "補完候補を表示";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -222,6 +222,7 @@ struct macSKKApp: App {
             ],
             UserDefaultsKeys.showCandidateForCompletion: true,
             UserDefaultsKeys.fixedCompletionByPeriod: true,
+            UserDefaultsKeys.registerKatakana: false,
         ])
     }
 


### PR DESCRIPTION
#414 qキーで入力中の読みをカタカナへの変換を行った際にユーザー辞書に保存するかどうかの設定を追加します。
デフォルトはfalse (無効) です。
設定画面の一般タブの「カタカナで確定した単語を辞書に登録する」で選択可能です。

qキーは「カタカナ入力中にひらがなで確定する」「半角カタカナ入力中にカタカナで確定する」のにも使えるのですが、辞書登録したい場合はおそらくカタカナだけだろうと思うので、この設定が有効な場合「ひらがな入力中にカタカナで確定する」ときにだけ辞書に保存します。

<img width="640" height="532" alt="image" src="https://github.com/user-attachments/assets/3bc0befd-7bf8-409e-83fb-c1ad1b4b3a11" />