### PR TITLE
候補選択時に/入力で現在の候補の確定後にAbbrevモードに戻れないバグを修正

### DIFF
--- a/macSKK/KeyBinding.swift
+++ b/macSKK/KeyBinding.swift
@@ -112,6 +112,10 @@ struct KeyBinding: Identifiable, Hashable {
                 }
             // abbrevはinputModeがdirect,eisu以外のときのみ受理
             case .abbrev:
+                // 候補選択時は候補決定後に次の入力として扱うので許容する
+                if case .selecting(_) = inputMethod {
+                    return true
+                }
                 if case .direct = inputMode {
                     return false
                 } else if case .eisu = inputMode {

--- a/macSKKTests/KeyBindingTests.swift
+++ b/macSKKTests/KeyBindingTests.swift
@@ -93,6 +93,13 @@ final class KeyBindingTests: XCTestCase {
         XCTAssertTrue(KeyBinding.Action.directAbbrev.accepts(inputMode: .direct, inputMethod: .normal))
         XCTAssertFalse(KeyBinding.Action.directAbbrev.accepts(inputMode: .eisu, inputMethod: .normal))
         XCTAssertFalse(KeyBinding.Action.directAbbrev.accepts(inputMode: .hiragana, inputMethod: .normal))
+        let selecting = SelectingState(prev: SelectingState.PrevState(mode: .hiragana, composing: composing),
+                                       yomi: "a",
+                                       candidates: [Candidate("ア")],
+                                       candidateIndex: 0,
+                                       remain: [],
+                                       completion: false)
+        XCTAssertTrue(KeyBinding.Action.abbrev.accepts(inputMode: .direct, inputMethod: .selecting(selecting)))
     }
 
     func testIsDefault() {


### PR DESCRIPTION
#425 `/recovery /` のような入力をすると、二回目の `/` 入力がAbbrevモード移行として扱われず直接 `/` が入力されてしまう問題を修正します。