### PR TITLE
変換候補ビューの色設定の切り替えが反映されない問題を修正

### DIFF
--- a/macSKK/Settings/OptionalBackgroundModifier.swift
+++ b/macSKK/Settings/OptionalBackgroundModifier.swift
@@ -17,18 +17,14 @@ struct OptionalBackgroundModifier: ViewModifier {
             if let cornerRadius {
                 content.background(.regularMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
             } else {
-                content
+                content.background()
             }
         }
     }
 }
 
 extension View {
-    func optionalBackground(_ color: Color?) -> some View {
-        self.modifier(OptionalBackgroundModifier(color: color, cornerRadius: nil))
-    }
-
-    func optionalBackground(_ color: Color?, cornerRadius: CGFloat) -> some View {
-        self.modifier(OptionalBackgroundModifier(color: color, cornerRadius: cornerRadius))
+    func optionalBackground(_ color: Color?, cornerRadius: CGFloat? = nil) -> some View {
+        modifier(OptionalBackgroundModifier(color: color, cornerRadius: cornerRadius))
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -528,8 +528,8 @@ final class SettingsViewModel: ObservableObject {
                 Global.candidatesPanel.viewModel.candidatesBackgroundColor = candidatesBackgroundColor
                 Global.completionPanel.viewModel.candidatesViewModel.candidatesBackgroundColor = candidatesBackgroundColor
             } else {
-                Global.candidatesPanel.viewModel.candidatesBackgroundColor = .clear
-                Global.completionPanel.viewModel.candidatesViewModel.candidatesBackgroundColor = .clear
+                Global.candidatesPanel.viewModel.candidatesBackgroundColor = nil
+                Global.completionPanel.viewModel.candidatesViewModel.candidatesBackgroundColor = nil
             }
         }.store(in: &cancellables)
 
@@ -581,8 +581,8 @@ final class SettingsViewModel: ObservableObject {
                 Global.candidatesPanel.viewModel.annotationBackgroundColor = annotationBackgroundColor
                 Global.completionPanel.viewModel.candidatesViewModel.annotationBackgroundColor = annotationBackgroundColor
             } else {
-                Global.candidatesPanel.viewModel.annotationBackgroundColor = .clear
-                Global.completionPanel.viewModel.candidatesViewModel.annotationBackgroundColor = .clear
+                Global.candidatesPanel.viewModel.annotationBackgroundColor = nil
+                Global.completionPanel.viewModel.candidatesViewModel.annotationBackgroundColor = nil
             }
         }.store(in: &cancellables)
 

--- a/macSKK/View/VerticalCandidatesView.swift
+++ b/macSKK/View/VerticalCandidatesView.swift
@@ -38,7 +38,6 @@ struct VerticalCandidatesView: View {
                             .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 0))
                             .frame(width: 16)
                         Text(candidate.word)
-//                            .font(.system(size: candidates.candidatesFontSize))
                             .font(candidates.candidatesFont)
                             .fixedSize(horizontal: true, vertical: false)
                             .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 4))


### PR DESCRIPTION
#416 #424 の修正に漏れがあったので修正。

- 変換候補ビューの色設定を有効にしてから無効にすると背景色が透過してしまうバグを修正
- 変換候補ビューの色設定を有効にしても切り替わらないバグを修正