### PR TITLE
変換候補の横方向表示で現在選択されている候補の色が見えないバグを修正

### DIFF
--- a/macSKK/View/HorizontalCandidatesView.swift
+++ b/macSKK/View/HorizontalCandidatesView.swift
@@ -48,6 +48,7 @@ struct HorizontalCandidatesView: View {
                             .padding(.trailing, 8)
                     }
                     .frame(height: candidates.candidatesLineHeight)
+                    .background(candidates.selected == candidate ? Color.accentColor : Color.clear)
                 }
                 if candidates.showPage {
                     Text("\(currentPage + 1) / \(totalPageCount)")


### PR DESCRIPTION
#428
#424 の修正で、変換候補の横表示で現在選択中の候補の強調表示を誤って消してしまったのを戻します。