### PR TITLE
Ctrl-Jで確定するときひらがなモードに変わってしまうのを修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1235,6 +1235,10 @@ final class StateMachine {
         }
 
         switch action.keyBind {
+        case .hiragana:
+            // 選択中の変換候補で確定
+            fixCurrentSelect()
+            return true
         case .enter:
             // 選択中の変換候補で確定
             fixCurrentSelect()
@@ -1301,7 +1305,7 @@ final class StateMachine {
                 }
             }
             return true
-        case .stickyShift, .hiragana, .hankakuKana:
+        case .stickyShift, .hankakuKana:
             fixCurrentSelect()
             return handle(action)
         case .cancel:


### PR DESCRIPTION
#434 カナモードなどひらがなモード以外のとき、読みを入力中や変換候補の選択中にCtrl-Jで確定させるとひらがなモードに戻るようになっていました。
AquaSKK, ddskk, skkeletonなどの挙動は単に入力中文字列の確定だけが行われるようです。
このため入力中のCtrl-Jでひらがなモードに戻していたのはバグと認識し、モードを戻さないようにします。