### PR TITLE
起動時にデフォルトのローマ字かな変換ルールを最初に読み込んでなかったのを修正

### DIFF
--- a/macSKK/SettingsWatcher.swift
+++ b/macSKK/SettingsWatcher.swift
@@ -17,17 +17,13 @@ let notificationNameKanaRuleDidMove = Notification.Name("kanaRuleDidMove")
  * 現状はローマ字かな変換ルールファイル (kana-rule.conf) のみを対象としています。
  */
 final class SettingsWatcher: NSObject, Sendable {
-    private let kanaRuleFileName: String
     private let settingsDirectoryURL: URL
     // MARK: NSFilePresenter
     let presentedItemURL: URL?
     let presentedItemOperationQueue: OperationQueue = OperationQueue()
 
-    @MainActor init(kanaRuleFileName: String = "kana-rule.conf") throws {
-        self.kanaRuleFileName = kanaRuleFileName
-        settingsDirectoryURL = try FileManager.default.url(
-            for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false
-        ).appending(path: "Settings")
+    @MainActor init(settingsDirectoryURL: URL) throws {
+        self.settingsDirectoryURL = settingsDirectoryURL
         if !FileManager.default.fileExists(atPath: settingsDirectoryURL.path) {
             logger.log("設定フォルダがないため作成します")
             try FileManager.default.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -71,7 +71,12 @@ struct macSKKApp: App {
             settingsWatcher = nil
         } else {
             do {
-                settingsWatcher = try SettingsWatcher(kanaRuleFileName: "kana-rule.conf")
+                let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule", withExtension: "conf")!
+                Global.defaultKanaRule = try Romaji(contentsOf: kanaRuleFileURL, initialRomaji: nil)
+                let settingsDirectoryURL = try FileManager.default.url(
+                    for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false
+                ).appending(path: "Settings")
+                settingsWatcher = try SettingsWatcher(settingsDirectoryURL: settingsDirectoryURL)
             } catch {
                 fatalError("ローマ字かな変換ルールの読み込みでエラーが発生しました: \(error)")
             }
@@ -90,8 +95,6 @@ struct macSKKApp: App {
                 if let settingsWatcher {
                     let kanaRules = try settingsWatcher.availableKanaRules()
                     settingsViewModel.kanaRules = kanaRules
-                    let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule", withExtension: "conf")!
-                    Global.defaultKanaRule = try Romaji(contentsOf: kanaRuleFileURL, initialRomaji: nil)
                     if let selectedKanaRule = kanaRules.first(where: { $0.id == settingsViewModel.selectedKanaRule }) {
                         Global.kanaRule = selectedKanaRule
                     } else {


### PR DESCRIPTION
#436 OS再起動などによりmacSKKが再起動されたとき、カスタマイズしているローマ字かな変換ルールを使用している場合にデフォルトのルールの上書きにならない問題を修正します。
カスタムルールの読み込みにはデフォルトのルールを上書きする形で設定するのですが、macSKKの起動時にデフォルトルールより先にカスタムルールを読むようになっていました。