### PR TITLE
デフォルトのローマ字かな変換ルールを使用するかのディレクティブを追加

### DIFF
--- a/macSKK/kana-rule-azik-us.conf
+++ b/macSKK/kana-rule-azik-us.conf
@@ -6,6 +6,8 @@
 # 自分でカスタマイズして使用したい場合はこのファイルを
 # ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Settings/kana-rule.conf
 # に置いてください。
+# デフォルトのルールとの差分だけを記述することも可能です。
+# その場合は #!use-default だけ含む行をどこかに置いてください。
 
 # 各行はカンマ区切りで2-5要素記述する必要があります。
 # 各要素でカンマを使用したい場合は &comma; と記述してください。

--- a/macSKK/kana-rule-azik.conf
+++ b/macSKK/kana-rule-azik.conf
@@ -6,6 +6,8 @@
 # 自分でカスタマイズして使用したい場合はこのファイルを
 # ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Settings/kana-rule.conf
 # に置いてください。
+# デフォルトのルールとの差分だけを記述することも可能です。
+# その場合は #!use-default だけ含む行をどこかに置いてください。
 
 # 各行はカンマ区切りで2-5要素記述する必要があります。
 # 各要素でカンマを使用したい場合は &comma; と記述してください。

--- a/macSKK/kana-rule.conf
+++ b/macSKK/kana-rule.conf
@@ -6,6 +6,8 @@
 # 自分でカスタマイズして使用したい場合はこのファイルを
 # ~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Settings/kana-rule.conf
 # に置いてください。
+# デフォルトのルールとの差分だけを記述することも可能です。
+# その場合は #!use-default だけ含む行をどこかに置いてください。
 
 # 各行はカンマ区切りで2-5要素記述する必要があります。
 # 各要素でカンマを使用したい場合は &comma; と記述してください。

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -14,6 +14,15 @@ class RomajiTests: XCTestCase {
         XCTAssertNoThrow(try Romaji(source: "&comma;,あ", initialRomaji: nil), "カンマを使いたい場合は &comma; と書く")
         XCTAssertNoThrow(try Romaji(source: "+,<shift>っ", initialRomaji: nil), "シフトキーを押しているときの記号のルール")
         XCTAssertThrowsError(try Romaji(source: "+,<shift>+", initialRomaji: nil), "シフトキーを押しているときの記号のルールで左辺と右辺が一致")
+
+        // #!use-default が書かれているルールでは initialRomaji を使う
+        let base = try! Romaji(source: "a,あ", initialRomaji: nil)
+        let withDirective = try! Romaji(source: "#!use-default\ni,い", initialRomaji: base)
+        XCTAssertNotNil(withDirective.convert("a", punctuation: .default).kakutei)
+        XCTAssertNotNil(withDirective.convert("i", punctuation: .default).kakutei)
+        let withoutDirective = try! Romaji(source: "i,い", initialRomaji: base)
+        XCTAssertNil(withoutDirective.convert("a", punctuation: .default).kakutei)
+        XCTAssertNotNil(withoutDirective.convert("i", punctuation: .default).kakutei)
     }
 
     func testConvert() throws {


### PR DESCRIPTION
#439 カスタマイズしたローマ字かな変換ルールに新たなディレクティブ `#!use-default` を追加します。

カスタマイズしたルールファイルのどこかに `#!use-default` と書かれた行があればデフォルトのかな変換ルールを上書きする形で差分だけを記載することが可能になります。
ただAZIKルールの「tw→てい」および「ch→ちゅう」のように、デフォルトのかな変換ルールがあるとうまく動かない場合があるため、ユーザーが選べるようにする措置として追加します。