### PR TITLE
FileDict/UserDictのSwift 6 Concurrency対応

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ defaults:
 jobs:
   test:
     runs-on: macos-26
+    timeout-minutes: 5
     steps:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
     - name: Select Xcode version

--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -39,12 +39,12 @@ protocol DictProtocol {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - option: 辞書を引くときに接頭辞、接尾辞や送り仮名ブロックから検索するかどうか。nilなら通常のエントリから検索する
      */
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word]
+    @MainActor func refer(_ yomi: String, option: DictReferringOption?) -> [Word]
 
     /**
      * 辞書を逆引きし、最初に見つかった読みを返す
      */
-    func reverseRefer(_ word: String) -> String?
+    @MainActor func reverseRefer(_ word: String) -> String?
 
     /**
      * 辞書にエントリを追加する。
@@ -53,7 +53,7 @@ protocol DictProtocol {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - word: SKK辞書の変換候補。
      */
-    mutating func add(yomi: String, word: Word)
+    @MainActor mutating func add(yomi: String, word: Word)
 
     /**
      * 辞書からエントリを削除する。
@@ -65,7 +65,7 @@ protocol DictProtocol {
      *   - word: SKK辞書の変換候補。
      * - Returns: エントリを削除できたかどうか
      */
-    mutating func delete(yomi: String, word: Word.Word) -> Bool
+    @MainActor mutating func delete(yomi: String, word: Word.Word) -> Bool
 
     /**
      * 現在入力中のprefixに続く入力候補を返す。見つからなければ空配列を返す。
@@ -78,7 +78,7 @@ protocol DictProtocol {
      * - prefixと読みが完全に一致する場合は補完候補とはしない
      * - 数値変換用の読みは補完候補としない
      */
-    func findCompletions(prefix: String) -> [String]
+    @MainActor func findCompletions(prefix: String) -> [String]
 
     /**
      * この辞書から返した変換候補をユーザー辞書に保存するかどうか

--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -29,7 +29,7 @@ enum FileDictType: Equatable {
 }
 
 /// 実ファイルをもつSKK辞書
-class FileDict: NSObject, DictProtocol, Identifiable {
+@MainActor class FileDict: NSObject, DictProtocol, Identifiable {
     // FIXME: URLResourceのfileResourceIdentifierKeyをidとして使ってもいいかもしれない。
     // FIXME: ただしこの値は再起動したら同一性が保証されなくなるのでIDとしての永続化はできない
     // FIXME: iCloud Documentsとかでてくるとディレクトリが複数になるけど、ひとまずファイル名だけもっておけばよさそう。
@@ -38,12 +38,6 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     let type: FileDictType
     /// 自分自身が最後に保存したときのファイルの更新日時。外部からの変更と区別するために使う
     private var fileModificationDate: Date?
-    /// ファイルの書き込み・読み込みを直列で実行するためのキュー
-    private let fileOperationQueue = {
-        let queue = OperationQueue()
-        queue.maxConcurrentOperationCount = 1
-        return queue
-    }()
     /// 保存してない変更があるかどうか (UIDocumentのパクり)
     private(set) var hasUnsavedChanges: Bool = false
     private(set) var dict: MemoryDict
@@ -74,8 +68,8 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     }
 
     // MARK: NSFilePresenter
-    var presentedItemURL: URL? { fileURL }
-    let presentedItemOperationQueue: OperationQueue = {
+    nonisolated var presentedItemURL: URL? { fileURL }
+    nonisolated let presentedItemOperationQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1
         return queue
@@ -91,7 +85,6 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         self.saveToUserDict = saveToUserDict
         self.fileModificationDate = try fileURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
         super.init()
-        load()
         NSFileCoordinator.addFilePresenter(self)
     }
 
@@ -110,64 +103,69 @@ class FileDict: NSObject, DictProtocol, Identifiable {
                  hasUnsavedChanges: hasUnsavedChanges)
     }
 
-    func load() {
-        let operation = BlockOperation {
-            var coordinationError: NSError?
-            var readingError: NSError?
+    func load(queue: OperationQueue = OperationQueue()) async {
+        let id = self.id
+        let fileURL = self.fileURL
+        let type = self.type
+        let readonly = self.readonly
+
+        NotificationCenter.default.post(name: notificationNameDictLoad,
+                                        object: DictLoadEvent(id: id, status: .loading))
+
+        // ファイルI/O + パースはOperationQueue上で実行し、MainActorをブロックしない
+        let result: Result<MemoryDict, any Error> = await withCheckedContinuation { continuation in
             let fileCoordinator = NSFileCoordinator(filePresenter: self)
-            NotificationCenter.default.post(name: notificationNameDictLoad,
-                                            object: DictLoadEvent(id: self.id,
-                                                                  status: .loading))
-            fileCoordinator.coordinate(readingItemAt: self.fileURL, error: &coordinationError) { [weak self] url in
-                if let self {
-                    do {
-                        if case .json = self.type {
-                            let decoder = JSONDecoder()
-                            decoder.keyDecodingStrategy = .convertFromSnakeCase
-                            let jisyo = try decoder.decode(JsonJisyo.self, from: try Data(contentsOf: url))
-                            if jisyo.version != "0.0.0" {
-                                logger.warning("JSON辞書のバージョンが未対応のバージョンのため無視します")
-                                throw FileDictError.decode
-                            }
-                            let okuriAriEntries = jisyo.okuriAri.mapValues({
-                                $0.map { Word($0) }
-                            })
-                            let okuriNashiEntries = jisyo.okuriNasi.mapValues({
-                                $0.map { Word($0) }
-                            })
-                            let memoryDict = MemoryDict(okuriAriEntries: okuriAriEntries, okuriNashiEntries: okuriNashiEntries, readonly: readonly)
-                            self.dict = memoryDict
-                        } else if case .traditional(let encoding) = self.type {
-                            let source = try self.loadString(url, encoding: encoding)
-                            if source.isEmpty {
-                                // 辞書ファイルを書き込み中に読み込んでしまった?
-                                logger.warning("辞書 \(self.id) を読み込んだところ0バイトだったため更新を無視します")
-                            }
-                            let memoryDict = MemoryDict(dictId: self.id, source: source, readonly: readonly)
-                            self.dict = memoryDict
+            let intent = NSFileAccessIntent.readingIntent(with: fileURL, options: [])
+            fileCoordinator.coordinate(with: [intent], queue: queue) { error in
+                if let error {
+                    continuation.resume(returning: .failure(error))
+                    return
+                }
+                let url = intent.url
+                do {
+                    if case .json = type {
+                        let decoder = JSONDecoder()
+                        decoder.keyDecodingStrategy = .convertFromSnakeCase
+                        let jisyo = try decoder.decode(JsonJisyo.self, from: try Data(contentsOf: url))
+                        if jisyo.version != "0.0.0" {
+                            logger.warning("JSON辞書のバージョンが未対応のバージョンのため無視します")
+                            throw FileDictError.decode
                         }
-                        logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")
-                        NotificationCenter.default.post(name: notificationNameDictLoad,
-                                                        object: DictLoadEvent(id: self.id,
-                                                                              status: .loaded(success: dict.entryCount, failure: dict.failedEntryCount)))
-                    } catch {
-                        logger.error("辞書 \(self.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")
-                        NotificationCenter.default.post(name: notificationNameDictLoad,
-                                                        object: DictLoadEvent(id: self.id,
-                                                                              status: .fail(error)))
-                        readingError = error as NSError
+                        let okuriAriEntries = jisyo.okuriAri.mapValues { $0.map { Word($0) } }
+                        let okuriNashiEntries = jisyo.okuriNasi.mapValues { $0.map { Word($0) } }
+                        continuation.resume(returning: .success(MemoryDict(okuriAriEntries: okuriAriEntries, okuriNashiEntries: okuriNashiEntries, readonly: readonly)))
+                    } else if case .traditional(let encoding) = type {
+                        let source = try Self.loadString(url, encoding: encoding)
+                        if source.isEmpty {
+                            // 辞書ファイルを書き込み中に読み込んでしまった?
+                            logger.warning("辞書 \(id) を読み込んだところ0バイトだったため更新を無視します")
+                        }
+                        continuation.resume(returning: .success(MemoryDict(dictId: id, source: source, readonly: readonly)))
+                    } else {
+                        continuation.resume(returning: .failure(FileDictError.decode))
                     }
+                } catch {
+                    continuation.resume(returning: .failure(error))
                 }
             }
-            if let error = coordinationError ?? readingError {
-                logger.error("辞書 \(self.id, privacy: .public) の読み込み中にエラーが発生しました: \(error)")
-            }
         }
-        fileOperationQueue.addOperation(operation)
-        operation.waitUntilFinished()
+
+        // 状態変更は MainActor 上で実行
+        switch result {
+        case .success(let memoryDict):
+            self.dict = memoryDict
+            logger.log("辞書 \(self.id, privacy: .public) から \(self.dict.entries.count) エントリ読み込みました")
+            NotificationCenter.default.post(name: notificationNameDictLoad,
+                                            object: DictLoadEvent(id: self.id,
+                                                                  status: .loaded(success: dict.entryCount, failure: dict.failedEntryCount)))
+        case .failure(let error):
+            logger.error("辞書 \(self.id, privacy: .public) の読み込みでエラーが発生しました: \(error)")
+            NotificationCenter.default.post(name: notificationNameDictLoad,
+                                            object: DictLoadEvent(id: self.id, status: .fail(error)))
+        }
     }
 
-    private func loadString(_ url: URL, encoding: String.Encoding) throws -> String {
+    nonisolated private static func loadString(_ url: URL, encoding: String.Encoding) throws -> String {
         if encoding == .japaneseEUC {
             let data = try Data(contentsOf: url)
             return try data.eucJis2004String()
@@ -190,7 +188,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         return try String(contentsOf: url, encoding: encoding)
     }
 
-    func save() {
+    @MainActor func save() {
         if !hasUnsavedChanges {
             logger.log("辞書 \(self.id, privacy: .public) は変更されていないため保存は行いません")
             return
@@ -279,15 +277,15 @@ class FileDict: NSObject, DictProtocol, Identifiable {
     var failedEntryCount: Int { return dict.failedEntryCount }
 
     // MARK: DictProtocol
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
+    @MainActor func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
         return dict.refer(yomi, option: option)
     }
 
-    func reverseRefer(_ word: String) -> String? {
+    @MainActor func reverseRefer(_ word: String) -> String? {
         return dict.reverseRefer(word)
     }
 
-    func add(yomi: String, word: Word) {
+    @MainActor func add(yomi: String, word: Word) {
         dict.add(yomi: yomi, word: word)
         NotificationCenter.default.post(name: notificationNameDictLoad,
                                         object: DictLoadEvent(id: self.id,
@@ -295,7 +293,7 @@ class FileDict: NSObject, DictProtocol, Identifiable {
         hasUnsavedChanges = true
     }
 
-    func delete(yomi: String, word: Word.Word) -> Bool {
+    @MainActor func delete(yomi: String, word: Word.Word) -> Bool {
         if dict.delete(yomi: yomi, word: word) {
             hasUnsavedChanges = true
             NotificationCenter.default.post(name: notificationNameDictLoad,
@@ -317,31 +315,27 @@ class FileDict: NSObject, DictProtocol, Identifiable {
 }
 
 extension FileDict: NSFilePresenter {
-    // 他プログラムでの書き込みなどでは呼ばれないみたい
-    func presentedItemDidGain(_ version: NSFileVersion) {
-        logger.log("辞書 \(self.id, privacy: .public) のバージョンが更新されたので読み込みます")
-        load()
-    }
-
-    func presentedItemDidLose(_ version: NSFileVersion) {
-        logger.log("辞書 \(self.id, privacy: .public) が更新されたので読み込みます (バージョン情報が消失)")
-        load()
-    }
-
     // NOTE: 外部エディタで編集したときも、自分自身がNSFileCoordinator経由でsaveした場合もこのメソッドは呼ばれる。
     // 更新日時が自分自身で保存したときと同じかどうかで判定する。
-    func presentedItemDidChange() {
+    nonisolated func presentedItemDidChange() {
         // URL#resourceValues はキャッシュされた値があればそれを返してしまうため、最新の更新日時を取得する
-        if let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
-           let modificationDate = attributes[.modificationDate] as? Date {
-            if modificationDate == fileModificationDate {
-                logger.log("辞書 \(self.id, privacy: .public) の変更は自分自身の保存によるもののため読み込みをスキップします")
-                return
-            } else {
-                fileModificationDate = modificationDate
-            }
+        let modificationDate: Date?
+        if let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path) {
+            modificationDate = attributes[.modificationDate] as? Date
+        } else {
+            modificationDate = nil
         }
-        logger.log("辞書 \(self.id, privacy: .public) が変更されたため読み込みます")
-        load()
+        Task { @MainActor in
+            if let modificationDate {
+                if modificationDate == self.fileModificationDate {
+                    logger.log("辞書 \(self.id, privacy: .public) の変更は自分自身の保存によるもののため読み込みをスキップします")
+                    return
+                } else {
+                    self.fileModificationDate = modificationDate
+                }
+            }
+            logger.log("辞書 \(self.id, privacy: .public) が変更されたため読み込みます")
+            await self.load()
+        }
     }
 }

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 /// 実ファイルをもたないSKK辞書
-struct MemoryDict: DictProtocol {
+struct MemoryDict: DictProtocol, Sendable {
     /**
      * 読み込み専用で保存しないかどうか
      *
@@ -114,7 +114,7 @@ struct MemoryDict: DictProtocol {
     var entryCount: Int { return entries.count }
 
     // MARK: DictProtocol
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
+    @MainActor func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
         if let option {
             switch option {
             case .prefix:
@@ -135,7 +135,7 @@ struct MemoryDict: DictProtocol {
         }
     }
 
-    func reverseRefer(_ word: String) -> String? {
+    @MainActor func reverseRefer(_ word: String) -> String? {
         // 全探索
         for (yomi, candidates) in entries {
             if candidates.contains(where: { $0.word == word }) {
@@ -154,7 +154,7 @@ struct MemoryDict: DictProtocol {
     /// - Parameters:
     ///   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
     ///   - word: SKK辞書の変換候補。
-    mutating func add(yomi: String, word: Word) {
+    @MainActor mutating func add(yomi: String, word: Word) {
         if var words = entries[yomi] {
             let removed: Word?
             let index = words.firstIndex { $0.word == word.word && $0.okuri == word.okuri }
@@ -196,7 +196,7 @@ struct MemoryDict: DictProtocol {
     ///   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
     ///   - word: SKK辞書の変換候補。
     /// - Returns: エントリを削除できたかどうか
-    mutating func delete(yomi: String, word: Word.Word) -> Bool {
+    @MainActor mutating func delete(yomi: String, word: Word.Word) -> Bool {
         if let words = entries[yomi] {
             let filtered = words.filter { $0.word != word }
             if words.count != filtered.count {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -139,6 +139,12 @@ enum CandidateListDirection: Int, CaseIterable, Identifiable {
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
+    /// 辞書ファイルの読み込みに使うOperationQueue
+    private let dictLoadQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "net.mtgto.inputmethod.macSKK.dictLoad"
+        return queue
+    }()
     /// CheckUpdaterで取得した最新のリリース。取得前はnil
     @Published var latestRelease: Release? = nil
     /// リリースの確認中かどうか
@@ -361,40 +367,42 @@ final class SettingsViewModel: ObservableObject {
         Global.inputModePanel.updateColorSets(inputModeColorSets)
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
-        $dictSettings.filter({ !$0.isEmpty }).receive(on: DispatchQueue.global()).sink { dictSettings in
-            let enabledDicts = dictSettings.compactMap { dictSetting -> FileDict? in
-                let dict = Global.dictionary.fileDict(id: dictSetting.id)
-                if dictSetting.enabled {
-                    // 無効だった辞書が有効化された、もしくは辞書のエンコーディング設定が変わったら読み込む
-                    if dictSetting.type.encoding != dict?.type.encoding {
-                        let fileURL = dictionariesDirectoryUrl.appendingPathComponent(dictSetting.filename)
-                        do {
-                            logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
-                            let fileDict = try FileDict(contentsOf: fileURL, type: dictSetting.type, readonly: true, saveToUserDict: dictSetting.saveToUserDict)
-                            logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) から \(fileDict.entryCount) エントリ読み込みました")
-                            return fileDict
-                        } catch {
-                            dictSetting.enabled = false
-                            logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の読み込みに失敗しました!: \(error)")
-                            return nil
+        Task {
+            for await dictSettings in $dictSettings.values where !dictSettings.isEmpty {
+                var enabledDicts: [FileDict] = []
+                await withTaskGroup { group in
+                    for dictSetting in dictSettings {
+                        let dict = Global.dictionary.fileDict(id: dictSetting.id)
+                        if dictSetting.enabled {
+                            // 無効だった辞書が有効化された、もしくは辞書のエンコーディング設定が変わったら読み込む
+                            if dictSetting.type.encoding != dict?.type.encoding {
+                                let fileURL = dictionariesDirectoryUrl.appendingPathComponent(dictSetting.filename)
+                                do {
+                                    logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を読み込みます")
+                                    let fileDict = try FileDict(contentsOf: fileURL, type: dictSetting.type, readonly: true, saveToUserDict: dictSetting.saveToUserDict)
+                                    enabledDicts.append(fileDict)
+                                    group.addTask { await fileDict.load(queue: self.dictLoadQueue) }
+                                } catch {
+                                    dictSetting.enabled = false
+                                    logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の読み込みに失敗しました!: \(error)")
+                                }
+                            } else if let dict, dictSetting.saveToUserDict != dict.saveToUserDict {
+                                logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の変換候補をユーザー辞書に保存する設定を\(dictSetting.saveToUserDict ? "有効" : "無効", privacy: .public)に変更しました")
+                                enabledDicts.append(dict.with(saveToUserDict: dictSetting.saveToUserDict))
+                            } else if let dict {
+                                enabledDicts.append(dict)
+                            }
+                        } else {
+                            if dict != nil {
+                                logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を無効化します")
+                            }
                         }
-                    } else if let dict, dictSetting.saveToUserDict != dict.saveToUserDict {
-                        logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) の変換候補をユーザー辞書に保存する設定を\(dictSetting.saveToUserDict ? "有効" : "無効", privacy: .public)に変更しました")
-                        return dict.with(saveToUserDict: dictSetting.saveToUserDict)
-                    } else {
-                        return dict
                     }
-                } else {
-                    if dict != nil {
-                        logger.log("SKK辞書 \(dictSetting.filename, privacy: .public) を無効化します")
-                    }
-                    return nil
                 }
+                Global.dictionary.dicts = enabledDicts
+                UserDefaults.app.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
             }
-            Global.dictionary.dicts = enabledDicts
-            UserDefaults.app.set(self.dictSettings.map { $0.encode() }, forKey: UserDefaultsKeys.dictionaries)
         }
-        .store(in: &cancellables)
 
         $skkservDictSetting.sink { setting in
             if setting.enabled {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -8,9 +8,9 @@ import Foundation
 /// v0.22.0以降はskkservサーバーを辞書としても利用することが可能。
 ///
 /// TODO: ファイル辞書にしかない単語を削除しようとしたときにどうやってそれを記録するか。NG登録?
-class UserDict: NSObject, DictProtocol {
-    static let userDictFilename = "skk-jisyo.utf8"
-    static let ignoredPathExtensions = ["tmp", "bak"]
+@MainActor class UserDict: NSObject, DictProtocol {
+    nonisolated static let userDictFilename = "skk-jisyo.utf8"
+    nonisolated static let ignoredPathExtensions = ["tmp", "bak"]
     let dictionariesDirectoryURL: URL
     let userDictFileURL: URL
     /**
@@ -34,8 +34,8 @@ class UserDict: NSObject, DictProtocol {
     let saveToUserDict = true
 
     // MARK: NSFilePresenter
-    let presentedItemURL: URL?
-    let presentedItemOperationQueue: OperationQueue = OperationQueue()
+    nonisolated let presentedItemURL: URL?
+    nonisolated let presentedItemOperationQueue: OperationQueue = OperationQueue()
 
     init(dicts: [any DictProtocol], userDictEntries: [String: [Word]]? = nil, privateMode: CurrentValueSubject<Bool, Never>, ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>, dateYomis: [DateConversion.Yomi], dateConversions: [DateConversion]) throws {
         self.dicts = dicts
@@ -68,6 +68,9 @@ class UserDict: NSObject, DictProtocol {
         }
         super.init()
         NSFileCoordinator.addFilePresenter(self)
+        if let userDict = self.userDict as? FileDict {
+            Task { await userDict.load() }
+        }
 
         savePublisher
             // 短期間に複数の保存要求があっても60秒に一回にまとめる
@@ -247,7 +250,7 @@ class UserDict: NSObject, DictProtocol {
      * ユーザー辞書のみから検索して他のSKK辞書は参照しない。すべての辞書から参照する場合は ``referDicts(_:option:skkservDict:findFromAllDicts:)`` を使用すること。
      * プライベートモードで入力したエントリは参照しない。
      */
-    func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {
+    @MainActor func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {
         if let userDict {
             if privateMode.value && ignoreUserDictInPrivateMode.value {
                 return []
@@ -265,7 +268,7 @@ class UserDict: NSObject, DictProtocol {
      * プライベートモードで入力したエントリは参照しない。
      * ユーザー辞書以外の辞書は参照しない。
      */
-    func reverseRefer(_ word: String) -> String? {
+    @MainActor func reverseRefer(_ word: String) -> String? {
         if let userDict = userDict {
             if !privateMode.value || !ignoreUserDictInPrivateMode.value {
                 if let yomi = userDict.reverseRefer(word) {
@@ -285,7 +288,7 @@ class UserDict: NSObject, DictProtocol {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - word: SKK辞書の変換候補。
      */
-    func add(yomi: String, word: Word) {
+    @MainActor func add(yomi: String, word: Word) {
         logger.log("ユーザー辞書に読み \(yomi, privacy: .public), 変換 \(word.word, privacy: .public) を登録する")
         if !privateMode.value {
             if let dict = userDict as? FileDict {
@@ -312,7 +315,7 @@ class UserDict: NSObject, DictProtocol {
      *    - word: SKK辞書の変換候補。
      *  - Returns: エントリを削除できたかどうか。プライベートモード時はなにも削除せずに常にtrueを返す。
      */
-    func delete(yomi: String, word: Word.Word) -> Bool {
+    @MainActor func delete(yomi: String, word: Word.Word) -> Bool {
         if privateMode.value {
             return true
         } else if let dict = userDict as? FileDict {
@@ -335,7 +338,7 @@ class UserDict: NSObject, DictProtocol {
      * - prefixと読みが完全に一致する場合は補完候補とはしない
      * - 数値変換用の読みは補完候補としない
      */
-    func findCompletions(prefix: String) -> [String] {
+    @MainActor func findCompletions(prefix: String) -> [String] {
         if prefix.isEmpty {
             return []
         }
@@ -430,7 +433,7 @@ class UserDict: NSObject, DictProtocol {
 }
 
 extension UserDict: NSFilePresenter {
-    func presentedSubitemDidAppear(at url: URL) {
+    nonisolated func presentedSubitemDidAppear(at url: URL) {
         do {
             if try isFile(url) {
                 logger.log("新しいファイル \(url.lastPathComponent, privacy: .public) が作成されました")
@@ -445,7 +448,7 @@ extension UserDict: NSFilePresenter {
     }
 
     // 他フォルダから移動された場合だけでなく他フォルダに移動した場合にも発生する (後者はdidMoveToも発生する)
-    func presentedSubitemDidChange(at url: URL) {
+    nonisolated func presentedSubitemDidChange(at url: URL) {
         // ユーザー辞書のバックアップファイルの場合は無視する
         if Self.ignoredPathExtensions.contains(url.pathExtension) { return }
         // 削除されたときにaccommodatePresentedSubitemDeletionが呼ばれないがこのメソッドは呼ばれるようだった。
@@ -480,7 +483,7 @@ extension UserDict: NSFilePresenter {
     }
 
     // 子要素を他フォルダに移動した場合に発生する
-    func presentedSubitem(at oldURL: URL, didMoveTo newURL: URL) {
+    nonisolated func presentedSubitem(at oldURL: URL, didMoveTo newURL: URL) {
         logger.log("ファイル \(oldURL.lastPathComponent, privacy: .public) が辞書フォルダから移動されました")
         NotificationCenter.default.post(name: notificationNameDictFileDidMove, object: oldURL)
     }
@@ -488,13 +491,13 @@ extension UserDict: NSFilePresenter {
     // NOTE: 本来ディレクトリ内のファイルが削除したときに呼ばれるはずだが、なぜか呼び出されない。
     // macOSのバグかもしれない?
     // @see https://stackoverflow.com/questions/50439658/swift-cocoa-how-to-watch-folder-for-changes#comment120683334_50443763
-    func accommodatePresentedSubitemDeletion(at url: URL) async throws {
+    nonisolated func accommodatePresentedSubitemDeletion(at url: URL) async throws {
         logger.log("ファイル \(url.lastPathComponent, privacy: .public) が辞書フォルダから削除されます")
     }
 
     /// ファイルがディレクトリ、不可視ファイル、またはバックアップ・一時ファイルの場合はfalseを返す
     /// 読み込み権限がなかったり、App Sandboxのコンテナ外へのシンボリックリンクのように実際には読み込めないファイルについてはtrueを返す
-    private func isFile(_ fileURL: URL) throws -> Bool {
+    nonisolated private func isFile(_ fileURL: URL) throws -> Bool {
         if Self.ignoredPathExtensions.contains(fileURL.pathExtension) { return false }
         let resourceValues = try fileURL.resourceValues(forKeys: [.isDirectoryKey, .isHiddenKey])
         if let isDirectory = resourceValues.isDirectory, let isHidden = resourceValues.isHidden {

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -6,17 +6,18 @@ import Combine
 
 @testable import macSKK
 
-final class FileDictTests: XCTestCase {
+@MainActor final class FileDictTests: XCTestCase {
     let fileURL = Bundle(for: FileDictTests.self).url(forResource: "empty", withExtension: "txt")!
     var cancellables: Set<AnyCancellable> = []
 
-    func testLoadContainsBom() throws {
+    func testLoadContainsBom() async throws {
         let fileURL = Bundle(for: Self.self).url(forResource: "utf8-bom", withExtension: "txt")!
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
+        await dict.load()
         XCTAssertEqual(dict.dict.entries, ["ゆにこーど": [Word("ユニコード")]])
     }
 
-    func testLoadJson() throws {
+    func testLoadJson() async throws {
         let expectation = XCTestExpectation()
         NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { notification in
             if let loadEvent = notification.object as? DictLoadEvent {
@@ -29,12 +30,13 @@ final class FileDictTests: XCTestCase {
         }.store(in: &cancellables)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json")!
         let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
+        await dict.load()
         XCTAssertEqual(dict.dict.refer("い", option: nil).map({ $0.word }).sorted(), ["伊", "胃"])
         XCTAssertEqual(dict.dict.refer("あr", option: nil).map({ $0.word }).sorted(), ["在;注釈として解釈されない", "有"])
-        wait(for: [expectation], timeout: 1.0)
+        await fulfillment(of: [expectation], timeout: 1.0)
     }
 
-    func testLoadJsonBroken() throws {
+    func testLoadJsonBroken() async throws {
         let expectation = XCTestExpectation()
         NotificationCenter.default.publisher(for: notificationNameDictLoad).sink { notification in
             if let loadEvent = notification.object as? DictLoadEvent {
@@ -44,8 +46,9 @@ final class FileDictTests: XCTestCase {
             }
         }.store(in: &cancellables)
         let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.broken", withExtension: "json")!
-        _ = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
-        wait(for: [expectation], timeout: 1.0)
+        let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
+        await dict.load()
+        await fulfillment(of: [expectation], timeout: 1.0)
     }
 
     func testAdd() throws {

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -127,7 +127,7 @@ class MemoryDictTests: XCTestCase {
         // okuriAriYomisはソートしてない。そのうちするかも
     }
 
-    func testAdd() throws {
+    @MainActor func testAdd() throws {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertEqual(dict.entryCount, 0)
         let word1 = Word("井")
@@ -158,7 +158,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.refer("いt", option: nil), [Word("行", okuri: "った"), Word("行")])
     }
 
-    func testDelete() throws {
+    @MainActor func testDelete() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")], "え": [Word("絵"), Word("柄")]], readonly: false)
         XCTAssertFalse(dict.entries.isEmpty)
         XCTAssertEqual(dict.okuriAriYomis, ["あr"])
@@ -183,14 +183,14 @@ class MemoryDictTests: XCTestCase {
         XCTAssertTrue(dict.entries.isEmpty)
     }
 
-    func testDeleteOkuriBlock() throws {
+    @MainActor func testDeleteOkuriBlock() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有", okuri: "る"), Word("有", okuri: "り"), Word("有")]], readonly: false)
         XCTAssertTrue(dict.delete(yomi: "あr", word: "有"))
         XCTAssertEqual(dict.refer("あr", option: nil), [], "あr を読みとして持つ変換候補が全て削除された")
         XCTAssertEqual(dict.okuriAriYomis, [])
     }
 
-    func testFindCompletions() {
+    @MainActor func testFindCompletions() {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertEqual(dict.findCompletions(prefix: ""), [], "辞書が空だと空")
         dict.add(yomi: "あいうえおか", word: Word("アイウエオカ"))
@@ -203,7 +203,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.findCompletions(prefix: "だい"), [], "数値変換の読みは補完候補とはしない")
     }
 
-    func testFindCompletionsBinarySearch() {
+    @MainActor func testFindCompletionsBinarySearch() {
         let source = """
             ;; okuri-ari entries.
             ;; okuri-nasi entries.
@@ -229,7 +229,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.findCompletions(prefix: "え"), [])
     }
 
-    func testReferWithOption() {
+    @MainActor func testReferWithOption() {
         let dict = MemoryDict(entries: ["あき>": [Word("空き")],
                                         "あき": [Word("秋")],
                                         ">し": [Word("氏")],
@@ -246,7 +246,7 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.refer("いt", option: .okuri("った")), [Word("行", okuri: "った"), Word("言")])
     }
 
-    func testReverseRefer() {
+    @MainActor func testReverseRefer() {
         let dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")], "え": [Word("絵"), Word("柄")]], readonly: false)
         XCTAssertEqual(dict.reverseRefer("絵"), "え")
         XCTAssertEqual(dict.reverseRefer("柄"), "え")

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -6,7 +6,7 @@ import Combine
 
 @testable import macSKK
 
-final class UserDictTests: XCTestCase {
+@MainActor final class UserDictTests: XCTestCase {
     @MainActor func testRefer() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊"), Word("位")]], readonly: true, saveToUserDict: false)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true, saveToUserDict: true)


### PR DESCRIPTION
Swift 6でSwift Concurrency関連の警告が出ないように修正します。
#260 のリベンジ。

- FileDict, UserDict, MemoryDictを`@MainActor`化
- DictProtocolのメソッドに`@MainActor`を付与、MemoryDictをSendable準拠
- UserDictの初期化時にFileDict.loadを非同期で呼び出すよう変更
- FileDict.loadをBlockOperation+waitUntilFinishedによる同期実装から NSFileCoordinator coordinate(with:queue:byAccessor:) + withCheckedContinuationによる非同期実装に変更。 OperationQueueを引数で受け取れるようにし、呼び出し元が制御可能に
- SettingsViewModelの辞書読み込みをwithTaskGroupによる並列化に変更し、 全辞書のロード完了後にGlobal.dictionary.dictsを設定するよう修正