### PR TITLE
すでに送り仮名の入力中に`<okuri>`ルールによる送り仮名の上書きをしないよう修正

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1031,58 +1031,61 @@ final class StateMachine {
             // ローマ字が確定してresult.inputがない
             // StickyShiftでokuriが[]になっている、またはShift押しながら入力した
             if let moji = converted.kakutei {
-                // n + 母音以外を入力して「ん」が確定したときや同一の子音を連続入力して促音が確定したときなど
-                if !converted.input.isEmpty {
-                    if !isShift {
-                        addFixedText(moji.string(for: state.inputMode))
-                        state.inputMethod = .normal
-                        return handleNormalPrintable(input: converted.input, action: action, specialState: specialState)
-                    }
-                    let newComposing: ComposingState
-                    if let okuri {
-                        newComposing = ComposingState(isShift: true,
-                                                      text: text,
-                                                      okuri: okuri + [moji],
-                                                      romaji: converted.input)
+                if converted.input.isEmpty {
+                    // いまの入力が送り仮名とならないことを判定
+                    // まだ読み部分が空ならば常に送り仮名ではない
+                    // シフトを押しながら入力した文字がアルファベットじゃないなら送り仮名ではない (記号なので)
+                    // 未確定文字列の先頭にカーソルがあるときはシフト押していてもいなくても送り仮名ではない
+                    if text.isEmpty || (okuri == nil && !(action.shiftIsPressed() && moji.kana.isHiragana)) || composing.cursor == 0 {
+                        if isShift || (action.shiftIsPressed() && moji.kana.isHiragana) {
+                            // シフトを押しながら入力し、`gq,が<okuri>い` のように送り仮名ありのルールを含んでいる場合は送り仮名あり
+                            if let ruleOkuri = Global.kanaRule.okuriTable[composing.romaji + input], action.shiftIsPressed() {
+                                // <okuri> ルール + シフトあり
+                                let yomi = String(moji.kana.dropLast(ruleOkuri.kana.count))
+                                if text.isEmpty && !isShift {
+                                    // 通常モードから <okuri> ルール + シフトあり → かなを確定出力し okuri かなを読みとして composing 開始
+                                    addFixedText(Romaji.Moji(firstRomaji: moji.firstRomaji, kana: yomi).string(for: state.inputMode))
+                                    state.inputMethod = .composing(
+                                        ComposingState(isShift: true, text: ruleOkuri.kana.map { String($0) }, romaji: ""))
+                                    updateMarkedText()
+                                    return true
+                                }
+                                // composingモードから <okuri> ルール + シフトあり → 辞書変換起動
+                                let convertComposing = ComposingState(isShift: true,
+                                                                      text: composing.text + [yomi],
+                                                                      okuri: [ruleOkuri],
+                                                                      romaji: "")
+                                return handleComposingStartConvert(action, composing: convertComposing, specialState: specialState)
+                            }
+                            state.inputMethod = .composing(composing.appendText(moji).resetRomaji().with(isShift: true))
+                        } else {
+                            state.inputMethod = .normal
+                            addFixedText(moji.string(for: state.inputMode))
+                            return true
+                        }
                     } else {
-                        newComposing = ComposingState(isShift: true,
-                                                      text: composing.subText() + [moji.kana] + (composing.remain() ?? []),
-                                                      okuri: action.shiftIsPressed() ? [] : nil,
-                                                      romaji: converted.input,
-                                                      cursor: composing.cursor.map { $0 + 1 })
-                    }
-                    if let inputConverted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: converted.input, input: "") {
-                        return handleComposingPrintable(input: inputConverted.input,
-                                                        converted: inputConverted,
-                                                        action: action,
-                                                        composing: newComposing,
-                                                        specialState: specialState)
-                    }
-                    state.inputMethod = .composing(newComposing)
-                    updateMarkedText()
-                    return true
-                }
-                // 送り仮名トリガーかどうかを判定
-                // まだ読み部分が空ならば常に送り仮名ではない
-                // シフトを押しながら入力した文字がアルファベットじゃないなら送り仮名ではない (記号なので)
-                // 未確定文字列の先頭にカーソルがあるときはシフト押していてもいなくても送り仮名ではない
-                // シフトを押しながら入力し、`gq,が<okuri>い` のように送り仮名ありのルールを含んでいる場合は送り仮名あり
-                let isOkuriTrigger = !text.isEmpty
-                    && (okuri != nil || (action.shiftIsPressed() && moji.kana.isHiragana))
-                    && composing.cursor != 0
-                // 送り仮名が1文字以上確定した時点で変換を開始する
-                // 変換候補がないときは辞書登録へ
-                // カーソル位置がnilじゃないときはその前までで変換を試みる
-                if isOkuriTrigger {
-                    if let ruleOkuri = Global.kanaRule.okuriTable[composing.romaji + input] {
-                        // <okuri> ルール: kana から okuri を除いた部分をよみに追加し ruleOkuri を送り仮名として変換開始
-                        let yomi = String(moji.kana.dropLast(ruleOkuri.kana.count))
-                        let newComposing = ComposingState(isShift: true,
-                                                          text: composing.text + [yomi],
-                                                          okuri: [ruleOkuri],
-                                                          romaji: "")
-                        return handleComposingStartConvert(action, composing: newComposing, specialState: specialState)
-                    } else {
+                        // 送り仮名が1文字以上確定した時点で変換を開始する
+                        // 変換候補がないときは辞書登録へ
+                        // カーソル位置がnilじゃないときはその前までで変換を試みる
+                        // 自動送り仮名検出かつ <okuri> ルールがある場合のみ自動分割
+                        if okuri == nil, let ruleOkuri = Global.kanaRule.okuriTable[composing.romaji + input] {
+                            // <okuri> ルール: kana から okuri を除いた部分をよみに追加し ruleOkuri を送り仮名として変換開始
+                            // カーソルがある場合はカーソル位置に挿入してカーソルを進める
+                            let yomi = String(moji.kana.dropLast(ruleOkuri.kana.count))
+                            let yomiMojis = yomi.map { String($0) }
+                            let newText: [String]
+                            if let cursor = composing.cursor {
+                                newText = Array(composing.text[0..<cursor]) + yomiMojis + Array(composing.text[cursor...])
+                            } else {
+                                newText = composing.text + yomiMojis
+                            }
+                            let newComposing = ComposingState(isShift: true,
+                                                              text: newText,
+                                                              okuri: [ruleOkuri],
+                                                              romaji: "",
+                                                              cursor: composing.cursor.map({ $0 + yomi.count }))
+                            return handleComposingStartConvert(action, composing: newComposing, specialState: specialState)
+                        }
                         let newComposing = ComposingState(isShift: true,
                                                           text: composing.text,
                                                           okuri: (okuri ?? []) + [moji],
@@ -1090,44 +1093,42 @@ final class StateMachine {
                                                           cursor: composing.cursor)
                         return handleComposingStartConvert(action, composing: newComposing, specialState: specialState)
                     }
-                }
-                // シフトなし（またはisShiftでない）→ 確定出力してノーマルモードへ
-                guard isShift || (action.shiftIsPressed() && moji.kana.isHiragana) else {
-                    state.inputMethod = .normal
-                    addFixedText(moji.string(for: state.inputMode))
-                    return true
-                }
-                // composingを更新
-                let newComposing = composing.appendText(moji).resetRomaji().with(isShift: true)
-                if let ruleOkuri = Global.kanaRule.okuriTable[composing.romaji + input] {
-                    let yomi = String(moji.kana.dropLast(ruleOkuri.kana.count))
-                    if action.shiftIsPressed() {
-                        if text.isEmpty && !isShift {
-                            // 通常モードから <okuri> ルール + シフトあり → かなを確定出力し okuri かなを読みとして composing 開始
-                            addFixedText(Romaji.Moji(firstRomaji: moji.firstRomaji, kana: yomi).string(for: state.inputMode))
-                            state.inputMethod = .composing(
-                                ComposingState(isShift: true, text: ruleOkuri.kana.map { String($0) }, romaji: ""))
-                            updateMarkedText()
-                            return true
+                } else {  // !converted.input.isEmpty
+                    // n + 母音以外を入力して「ん」が確定したときや同一の子音を連続入力して促音が確定したときなど
+                    if isShift {
+                        let newComposingState: ComposingState
+                        if let okuri {
+                            newComposingState = ComposingState(isShift: true,
+                                                               text: text,
+                                                               okuri: okuri + [moji],
+                                                               romaji: converted.input)
+                        } else {
+                            newComposingState = ComposingState(isShift: true,
+                                                               text: composing.subText() + [moji.kana] + (composing.remain() ?? []),
+                                                               okuri: action.shiftIsPressed() ? [] : nil,
+                                                               romaji: converted.input,
+                                                               cursor: composing.cursor.map { $0 + 1 })
                         }
-                        // <okuri> ルール + シフトあり → 辞書変換起動
-                        let convertComposing = ComposingState(isShift: true,
-                                                              text: composing.text + [yomi],
-                                                              okuri: [ruleOkuri],
-                                                              romaji: "")
-                        return handleComposingStartConvert(action, composing: convertComposing, specialState: specialState)
+                        if let inputConverted = useKanaRuleIfPresent(inputMode: state.inputMode, romaji: converted.input, input: "") {
+                            return handleComposingPrintable(input: inputConverted.input,
+                                                            converted: inputConverted,
+                                                            action: action,
+                                                            composing: newComposingState,
+                                                            specialState: specialState)
+                        } else {
+                            state.inputMethod = .composing(newComposingState)
+                        }
                     } else {
-                        // <okuri> ルール + シフトなし → kana="がい" のまま追記
-                        state.inputMethod = .composing(newComposing)
+                        addFixedText(moji.string(for: state.inputMode))
+                        state.inputMethod = .normal
+                        return handleNormalPrintable(input: converted.input, action: action, specialState: specialState)
                     }
-                } else {
-                    state.inputMethod = .composing(newComposing)
                 }
                 updateMarkedText()
             } else if Global.kanaRule.isPrefix(input, modifierFlags: action.event.modifierFlags, treatAsAlphabet: action.treatAsAlphabet) {
                 // ローマ字の一部が入力された場合
                 // シフトが押されているかどうかで送り仮名入力かそうでないかに分岐
-                if !text.isEmpty && okuri == nil && action.shiftIsPressed() {
+                if !text.isEmpty && okuri == nil && action.shiftIsPressed() && composing.cursor != 0 {
                     state.inputMethod = .composing(
                         ComposingState(isShift: isShift,
                                        text: text,

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2466,6 +2466,33 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleComposingOkuriRuleWithShiftCursor() {
+        // kana-rule.conf の <okuri> デリミタを含むルール (gq,が<okuri>い) のテストのカーソル移動あり
+        Global.kanaRule = try! Romaji(source: ["a,あ", "ne,ね", "gq,が<okuri>い"].joined(separator: "\n"), initialRomaji: nil)
+        Global.dictionary.setEntries(["ねがi": [Word("願")]])
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(8).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .cursor, .plain("あ")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("n"), .cursor, .plain("あ")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("ね"), .cursor, .plain("あ")])))
+            XCTAssertEqual(events[4], .markedText(MarkedText([.markerCompose, .plain("ねg"), .cursor, .plain("あ")])))
+            XCTAssertEqual(events[5], .markedText(MarkedText([.markerSelect, .emphasized("願い"), .cursor, .plain("あ")])))
+            XCTAssertEqual(events[6], .fixedText("願い"))
+            XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(leftKeyAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "g")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(enterAction))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleRegisteringEnter() {
         Global.dictionary.setEntries(["お": [Word("尾")]])
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2422,7 +2422,7 @@ final class StateMachineTests: XCTestCase {
         Global.kanaRule = try! Romaji(source: ["ne,ね", "gq,が<okuri>い"].joined(separator: "\n"), initialRomaji: nil)
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
-        stateMachine.inputMethodEvent.collect(10).sink { events in
+        stateMachine.inputMethodEvent.collect(17).sink { events in
             XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("n")])))
             XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("ね")])))
             XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain("ねg")])))
@@ -2433,6 +2433,13 @@ final class StateMachineTests: XCTestCase {
             XCTAssertEqual(events[7], .markedText(MarkedText([.markerCompose, .plain("g")])))
             XCTAssertEqual(events[8], .modeChanged(.hiragana))
             XCTAssertEqual(events[9], .markedText(MarkedText([.plain("[登録：が*い]")])))
+            XCTAssertEqual(events[10], .markedText(MarkedText([.markerCompose, .plain("がい")])))
+            XCTAssertEqual(events[11], .markedText(MarkedText([])))
+            XCTAssertEqual(events[12], .markedText(MarkedText([.markerCompose, .plain("n")])))
+            XCTAssertEqual(events[13], .markedText(MarkedText([.markerCompose, .plain("ね")])))
+            XCTAssertEqual(events[14], .markedText(MarkedText([.markerCompose, .plain("ね*g")])))
+            XCTAssertEqual(events[15], .modeChanged(.hiragana))
+            XCTAssertEqual(events[16], .markedText(MarkedText([.plain("[登録：ね*がい]")])))
             expectation.fulfill()
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n", withShift: true)))
@@ -2443,6 +2450,12 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(cancelAction))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "g", withShift: true)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "n", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "e")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "g", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "q")))
         wait(for: [expectation], timeout: 1.0)
     }
 


### PR DESCRIPTION
https://github.com/mtgto/macSKK/issues/431#issuecomment-4192651684

#440 で `nq,な<okuri>い` のように `nQ` という入力で `な*い` (`い`が送り仮名) と入力できる `<okuri>` プリミティブを追加しました。
その実装に不備があり、 `KoNq` のように入力したとき `こ*ない` ではなく `こな*い` で変換をしてしまっていました。
これは `<okuri>` プリミティブが有効なルールがあるとき、`<okuri>` の右の文字を送り仮名として誤って優先していたためです。
これを修正します。