### PR TITLE
`<shift>`ルールと競合するローマ字かな変換ルールがある場合は確定できる変換を優先する

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1017,17 +1017,6 @@ final class StateMachine {
 
         switch state.inputMode {
         case .hiragana, .katakana, .hankaku:
-            // lowercaseMapにエントリがある場合はエントリの方のキーが入力されたと見做す
-            if let mappedEvent = Global.kanaRule.convertKeyEvent(action.event) {
-                return handleComposing(
-                    Action(keyBind: Global.keyBinding.action(event: mappedEvent, inputMode: state.inputMode, inputMethod: state.inputMethod),
-                           event: mappedEvent,
-                           textInput: action.textInput,
-                           treatAsAlphabet: true),
-                    composing: composing,
-                    specialState: specialState
-                )
-            }
             // ローマ字が確定してresult.inputがない
             // StickyShiftでokuriが[]になっている、またはShift押しながら入力した
             if let moji = converted.kakutei {
@@ -1145,6 +1134,17 @@ final class StateMachine {
                 }
                 updateMarkedText()
             } else {
+                // lowercaseMapにエントリがある場合はエントリの方のキーが入力されたと見做す
+                if let mappedEvent = Global.kanaRule.convertKeyEvent(action.event) {
+                    return handleComposing(
+                        Action(keyBind: Global.keyBinding.action(event: mappedEvent, inputMode: state.inputMode, inputMethod: state.inputMethod),
+                               event: mappedEvent,
+                               textInput: action.textInput,
+                               treatAsAlphabet: true),
+                        composing: composing,
+                        specialState: specialState
+                    )
+                }
                 // 非ローマ字で特殊な記号でない場合。数字が読みとして使われている場合などを想定。
                 if okuri == nil {
                     // ローマ字が残っていた場合は消去してキー入力をそのままくっつける

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -284,6 +284,22 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    // https://github.com/mtgto/macSKK/issues/455
+    @MainActor func testHandleNormalKanaRuleShiftSemicolon() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.kanaRule = try! Romaji(source: ";,っ\nz:,：\n:,<shift>;", initialRomaji: nil)
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.plain("z")])))
+            XCTAssertEqual(events[1], .fixedText("："))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "z")))
+        // 英字配列で `:` 入力 (`:` はShift+;)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ":", characterIgnoringModifier: ";", withShift: true)))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleNormalSpace() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         let expectation = XCTestExpectation()
@@ -1759,6 +1775,22 @@ final class StateMachineTests: XCTestCase {
         }.store(in: &cancellables)
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: false)))
         XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ";")))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // https://github.com/mtgto/macSKK/issues/455
+    @MainActor func testHandleComposeKanaRuleShiftSemicolon() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        Global.kanaRule = try! Romaji(source: ";,っ\nz:,：\n:,<shift>;", initialRomaji: nil)
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(2).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("z")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("：")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "z", withShift: true)))
+        // 英字配列で `:` 入力 (`:` はShift+;)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ":", characterIgnoringModifier: ";", withShift: true)))
         wait(for: [expectation], timeout: 1.0)
     }
 


### PR DESCRIPTION
#455 次のような `<shift>` ありのローマ字かな変換ルールを使っているときに英字キーボードで `z:` (英字キーボードの場合、シフト押しながらセミコロンでコロン入力) を入力すると `：` が確定入力されるように修正する。

```
;,っ
z:,：
:,<shift>;
```

`z:` 入力したとき、 `:` の処理で、 `z:` というエントリがあるかの確認の前に `:,<shift>;` の対応を行ってしまっていた。
確定するローマ字かな変換があるかどうかを見て、ないときに `<shift>` ルールを適用するように処理順序を変更する。