### PR TITLE
MarkedText.attributedStringのリファクタ

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		CEE2D9772A99FE1B00A4CD76 /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE2D9762A99FE1B00A4CD76 /* Word.swift */; };
 		CEE2D9792A99FEC700A4CD76 /* CandidateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE2D9782A99FEC700A4CD76 /* CandidateTest.swift */; };
 		CEE3717529653112000DB2C3 /* SoftwareUpdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE3717429653112000DB2C3 /* SoftwareUpdateView.swift */; };
+		CEE748822FA6388A00818B33 /* MarkedTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE748812FA6388A00818B33 /* MarkedTextTests.swift */; };
 		CEF03F7F2C69AA8F009B05B2 /* SKK-JISYO.broken.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF03F7E2C69AA8F009B05B2 /* SKK-JISYO.broken.json */; };
 		CEF0823629685C0800646366 /* StateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF0823529685C0800646366 /* StateTests.swift */; };
 		CEF0823A296BCDB000646366 /* InputModePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF08239296BCDB000646366 /* InputModePanel.swift */; };
@@ -345,6 +346,7 @@
 		CEE2D9762A99FE1B00A4CD76 /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
 		CEE2D9782A99FEC700A4CD76 /* CandidateTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CandidateTest.swift; sourceTree = "<group>"; };
 		CEE3717429653112000DB2C3 /* SoftwareUpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateView.swift; sourceTree = "<group>"; };
+		CEE748812FA6388A00818B33 /* MarkedTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkedTextTests.swift; sourceTree = "<group>"; };
 		CEF03F7E2C69AA8F009B05B2 /* SKK-JISYO.broken.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "SKK-JISYO.broken.json"; sourceTree = "<group>"; };
 		CEF0823529685C0800646366 /* StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateTests.swift; sourceTree = "<group>"; };
 		CEF08239296BCDB000646366 /* InputModePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModePanel.swift; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 		CE5ECF462957034D00E7BE7D /* macSKKTests */ = {
 			isa = PBXGroup;
 			children = (
+				CEE748812FA6388A00818B33 /* MarkedTextTests.swift */,
 				CEF0823529685C0800646366 /* StateTests.swift */,
 				CEA78FA9295EBCAC00B67E25 /* StateMachineTests.swift */,
 				CEE2D9782A99FEC700A4CD76 /* CandidateTest.swift */,
@@ -971,6 +974,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEE748822FA6388A00818B33 /* MarkedTextTests.swift in Sources */,
 				CE118EE52CE0B4DE00A7C300 /* KeyTests.swift in Sources */,
 				4B8E87D82CE068A0004E7461 /* CurrentInputTests.swift in Sources */,
 				CEA2539A2E23DA9000618E64 /* DictSettingTests.swift in Sources */,

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -47,6 +47,8 @@ import Combine
     static var selectingBackspace: SelectingBackspace = .default
     /// カンマかピリオドを入力したときに入力する句読点の設定
     static var punctuation: Punctuation = .default
+    /// ▽と▼の表示
+    static var showMarkedTextMarker: ShowMarkedTextMarker = .always
     /// 変換候補パネルの表示方向
     static var candidateListDirection = CurrentValueSubject<CandidateListDirection, Never>(.vertical)
     /// ピリオドで補完候補の最初の要素で確定するか

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -67,12 +67,12 @@ class InputController: IMKInputController {
                     }
                     textInput.insertText(text, replacementRange: Self.notFoundRange)
                 case .markedText(let markedText):
-                    let attributedText = markedText.attributedString
-                    let cursorRange: NSRange = markedText.cursorRange() ?? Self.notFoundRange
+                    let attributedText = markedText.attributedString(Global.showMarkedTextMarker)
+                    let cursorRange: NSRange = markedText.cursorRange(Global.showMarkedTextMarker) ?? Self.notFoundRange
                     // Thingsのメモ欄などで最初の一文字をShift押しながら入力すると "▽あ" が直接入力されてしまうことがあるのを回避するワークグラウンド
                     if case .markerCompose = markedText.elements.first, markedText.elements.count == 2,
                        case let .plain(text) = markedText.elements[1], text.count == 1 {
-                        textInput.setMarkedText(NSAttributedString(MarkedText.Element.markerCompose.attributedString),
+                        textInput.setMarkedText(NSAttributedString(MarkedText([.markerCompose]).attributedString(Global.showMarkedTextMarker)),
                                                 selectionRange: cursorRange,
                                                 replacementRange: Self.notFoundRange)
                     }

--- a/macSKK/MarkedText.swift
+++ b/macSKK/MarkedText.swift
@@ -37,45 +37,6 @@ struct MarkedText: Equatable {
         /// カーソル
         case cursor
 
-        var attributedString: AttributedString {
-            switch self {
-            case .markerCompose:
-                return Self.plain(visibleMarkerText).attributedString
-            case .markerSelect:
-                return Self.emphasized(visibleMarkerText).attributedString
-            case .plain(let text):
-                return AttributedString(text, attributes: .init([.underlineStyle: NSUnderlineStyle.single.rawValue]))
-            case .emphasized(let text):
-                return AttributedString(text, attributes: .init([.underlineStyle: NSUnderlineStyle.thick.rawValue]))
-            case .cursor:
-                return AttributedString("", attributes: .init([.cursor: NSCursor.iBeam]))
-            }
-        }
-
-        private var visibleMarkerText: String {
-            ShowMarkedTextMarker.current == .always ? (markerText ?? "") : ""
-        }
-
-        var markerText: String? {
-            switch self {
-            case .markerCompose:
-                return "▽"
-            case .markerSelect:
-                return "▼"
-            case .plain, .emphasized, .cursor:
-                return nil
-            }
-        }
-
-        var isMarker: Bool {
-            switch self {
-            case .markerCompose, .markerSelect:
-                return true
-            case .plain, .emphasized, .cursor:
-                return false
-            }
-        }
-
         var text: String? {
             switch self {
             case .plain(let text), .emphasized(let text):
@@ -91,29 +52,40 @@ struct MarkedText: Equatable {
         self.elements = elements
     }
 
-    var attributedString: AttributedString {
-        if let first = elements.first {
-            var result = elements.dropFirst().reduce(first.attributedStringForFallback(showMarkerFallback), { result, current in
-                return result + current.attributedStringForFallback(showMarkerFallback)
-            })
-            if !elements.contains(where: { $0 == .cursor }) {
-                result.append(Element.cursor.attributedString)
+    func attributedString(_ showMarkedTextMarker: ShowMarkedTextMarker) -> AttributedString {
+        let showMarker = resolveShowMarker(showMarkedTextMarker)
+        var result = AttributedString()
+        for element in elements {
+            switch element {
+            case .markerCompose:
+                if showMarker {
+                    result += AttributedString("▽", attributes: .init([.underlineStyle: NSUnderlineStyle.single.rawValue]))
+                }
+            case .markerSelect:
+                if showMarker {
+                    result += AttributedString("▼", attributes: .init([.underlineStyle: NSUnderlineStyle.thick.rawValue]))
+                }
+            case .plain(let text):
+                result += AttributedString(text, attributes: .init([.underlineStyle: NSUnderlineStyle.single.rawValue]))
+            case .emphasized(let text):
+                result += AttributedString(text, attributes: .init([.underlineStyle: NSUnderlineStyle.thick.rawValue]))
+            case .cursor:
+                result += AttributedString("", attributes: .init([.cursor: NSCursor.iBeam]))
             }
-            return result
-        } else {
-            return AttributedString()
         }
+        if !elements.contains(where: { $0 == .cursor }) {
+            result += AttributedString("", attributes: .init([.cursor: NSCursor.iBeam]))
+        }
+        return result
     }
 
-    func cursorRange() -> NSRange? {
+    func cursorRange(_ showMarkedTextMarker: ShowMarkedTextMarker) -> NSRange? {
         var location: Int = 0
-        let showMarkerFallback = showMarkerFallback
+        let showMarker = resolveShowMarker(showMarkedTextMarker)
         for element in elements {
             switch element {
             case .markerSelect, .markerCompose:
-                if ShowMarkedTextMarker.current == .always || showMarkerFallback {
-                    location += 1
-                }
+                if showMarker { location += 1 }
             case .plain(let string):
                 location += string.count
             case .emphasized(let string):
@@ -127,34 +99,15 @@ struct MarkedText: Equatable {
 
     /// showMarkedTextMarkerの設定が.minimalのとき、▽や▼を消すと未確定文字列が空になる場合だけマーカーを表示する。
     /// この挙動が必要な理由は.minimalの説明を参照。
-    private var showMarkerFallback: Bool {
-        // 設定が.minimalかつ、マーカーが表示対象に入っているけれどvisibleMarkerTextで消されている場合のみ処理する。
-        guard ShowMarkedTextMarker.current == .minimal, elements.contains(where: \.isMarker) else {
+    private func resolveShowMarker(_ showMarkedTextMarker: ShowMarkedTextMarker) -> Bool {
+        switch showMarkedTextMarker {
+        case .always:
+            return true
+        case .never:
             return false
+        case .minimal:
+            // .plainや.emphasizedのテキストが空の場合は未確定文字列が空になるので▽や▼を出す必要がある。
+            return elements.compactMap(\.text).allSatisfy(\.isEmpty)
         }
-        // .plainや.emphasizedのテキストが空の場合は未確定文字列が空になるので▽や▼を出す必要がある。
-        return elements.compactMap(\.text).allSatisfy(\.isEmpty)
-    }
-}
-
-private extension MarkedText.Element {
-    func attributedStringForFallback(_ showMarkerFallback: Bool) -> AttributedString {
-        if showMarkerFallback {
-            switch self {
-            case .markerCompose:
-                return Self.plain("▽").attributedString
-            case .markerSelect:
-                return Self.emphasized("▼").attributedString
-            case .plain, .emphasized, .cursor:
-                break
-            }
-        }
-        return attributedString
-    }
-}
-
-private extension ShowMarkedTextMarker {
-    static var current: Self {
-        Self(rawValue: UserDefaults.app.string(forKey: UserDefaultsKeys.showMarkedTextMarker) ?? "") ?? .always
     }
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -401,6 +401,7 @@ final class SettingsViewModel: ObservableObject {
         Global.findCompletionFromAllDicts = findCompletionFromAllDicts
         Global.registerKatakana = registerKatakana
         Global.inputModePanel.updateColorSets(inputModeColorSets)
+        Global.showMarkedTextMarker = showMarkedTextMarker
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         Task {
@@ -768,6 +769,7 @@ final class SettingsViewModel: ObservableObject {
         $showMarkedTextMarker.dropFirst().sink { showMarkedTextMarker in
             UserDefaults.app.set(showMarkedTextMarker.rawValue, forKey: UserDefaultsKeys.showMarkedTextMarker)
             logger.log("▽と▼の表示を\(showMarkedTextMarker.description, privacy: .public)に変更しました")
+            Global.showMarkedTextMarker = showMarkedTextMarker
         }.store(in: &cancellables)
 
         $candidateListDirection.dropFirst().sink { candidateListDirection in

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -58,6 +58,7 @@ struct macSKKApp: App {
             let settingsViewModel = try SettingsViewModel(dictionariesDirectoryUrl: dictionariesDirectoryUrl)
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
             Global.privateMode.send(UserDefaults.app.bool(forKey: UserDefaultsKeys.privateMode))
+            Global.showMarkedTextMarker = ShowMarkedTextMarker(rawValue: UserDefaults.app.string(forKey: UserDefaultsKeys.showMarkedTextMarker) ?? "") ?? .always
 
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
             Global.dictionary = try UserDict(dicts: [],

--- a/macSKKTests/MarkedTextTests.swift
+++ b/macSKKTests/MarkedTextTests.swift
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+
+@testable import macSKK
+
+final class MarkedTextTests: XCTestCase {
+    func testAttributedStringAlways() {
+        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(.always).characters), "▽あ")
+        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(.always).characters), "▼阿")
+        // abbrevなど未確定文字列が空のケース
+        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(.always).characters), "▽")
+    }
+
+    func testAttributedStringMinimal() {
+        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(.minimal).characters), "あ")
+        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(.minimal).characters), "阿")
+        // abbrevなど未確定文字列が空のときはフォールバックで▽を表示する
+        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(.minimal).characters), "▽")
+        XCTAssertEqual(String(MarkedText([.markerCompose, .plain(""), .cursor]).attributedString(.minimal).characters), "▽")
+    }
+
+    func testAttributedStringNever() {
+        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(.never).characters), "あ")
+        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(.never).characters), "阿")
+        // neverは未確定文字列が空でもマーカーを表示しない
+        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(.never).characters), "")
+    }
+
+    func testCursorRange() {
+        // カーソルがない場合は末尾にカーソルが追加され cursorRange は nil
+        XCTAssertNil(MarkedText([.markerCompose, .plain("あ")]).cursorRange(.always))
+        // カーソル位置がマーカーと文字数の合算になっている
+        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor]).cursorRange(.always), NSRange(location: 2, length: 0))
+        // マーカー非表示時はカーソル位置にマーカー分が含まれない
+        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor]).cursorRange(.never), NSRange(location: 1, length: 0))
+        // カーソルが中間位置にある場合
+        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor, .plain("い")]).cursorRange(.always), NSRange(location: 2, length: 0))
+    }
+}

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -10,10 +10,6 @@ final class StateTests: XCTestCase {
         Global.kanaRule = Romaji.defaultKanaRule
     }
 
-    @MainActor override func tearDown() {
-        UserDefaults.app.set(ShowMarkedTextMarker.always.rawValue, forKey: UserDefaultsKeys.showMarkedTextMarker)
-    }
-
     func testComposingStateAppendText() throws {
         var state = ComposingState(
             isShift: true, text: ["あ", "い"], okuri: nil, romaji: "", cursor: nil)
@@ -26,36 +22,6 @@ final class StateTests: XCTestCase {
         XCTAssertEqual(state.cursor, 3)
         state = state.moveCursorRight()
         XCTAssertNil(state.cursor, "末尾まで移動したらカーソルはnilになる")
-    }
-
-    @MainActor func testMarkedTextMarkerAlways() {
-        UserDefaults.app.set(ShowMarkedTextMarker.always.rawValue, forKey: UserDefaultsKeys.showMarkedTextMarker)
-        let markedText = MarkedText([.markerCompose, .plain("あ"), .cursor])
-
-        XCTAssertEqual(String(markedText.attributedString.characters), "▽あ")
-        XCTAssertEqual(markedText.cursorRange(), NSRange(location: 2, length: 0))
-    }
-
-    @MainActor func testMarkedTextMarkerMinimal() {
-        UserDefaults.app.set(ShowMarkedTextMarker.minimal.rawValue, forKey: UserDefaultsKeys.showMarkedTextMarker)
-
-        // abbrevなどで未確定文字列が空になる場合は▽や▼を出す。
-        let emptyMarkedText = MarkedText([.markerCompose, .cursor])
-        XCTAssertEqual(String(emptyMarkedText.attributedString.characters), "▽")
-        XCTAssertEqual(emptyMarkedText.cursorRange(), NSRange(location: 1, length: 0))
-
-        // 通常の入力時は▽や▼は表示しない。
-        let nonEmptyMarkedText = MarkedText([.markerCompose, .plain("あ"), .cursor])
-        XCTAssertEqual(String(nonEmptyMarkedText.attributedString.characters), "あ")
-        XCTAssertEqual(nonEmptyMarkedText.cursorRange(), NSRange(location: 1, length: 0))
-    }
-
-    @MainActor func testMarkedTextMarkerNever() {
-        UserDefaults.app.set(ShowMarkedTextMarker.never.rawValue, forKey: UserDefaultsKeys.showMarkedTextMarker)
-        let markedText = MarkedText([.markerCompose, .plain("あ"), .cursor])
-
-        XCTAssertEqual(String(markedText.attributedString.characters), "あ")
-        XCTAssertEqual(markedText.cursorRange(), NSRange(location: 1, length: 0))
     }
 
     func testComposingStateString() {


### PR DESCRIPTION
rel. #457

- MarkedText.attributedString/cursorRangeの中でUserDefaultsを複数回呼ぶようになっていたので、算出プロパティからShowMarkedTextMarkerを引数で受け取るように変更。
- Globalに現在のマーカーの表示・非表示の設定をもつようにして、InputControllerから渡すように変更。
- MarkedTextのユニットテストを追加。