### PR TITLE
build_restart.shの対象に/Library/Input Methods/macSKK.appを追加

### DIFF
--- a/build_restart.sh
+++ b/build_restart.sh
@@ -3,8 +3,19 @@
 set -e
 # ビルド
 xcodebuild -workspace macSKK.xcodeproj/project.xcworkspace -scheme macSKK -configuration Debug DEVELOPMENT_TEAM= clean archive -archivePath build/archive.xcarchive
+
 # 上書き
-rm -rf ~/Library/Input\ Methods/macSKK.app
-cp -r build/archive.xcarchive/Products/Library/Input\ Methods/macSKK.app ~/Library/Input\ Methods/
+if [[ -d ~/Library/Input\ Methods/macSKK.app ]]; then
+    echo "Update ~/Library/Input Methods/macSKK.app"
+
+    rm -rf ~/Library/Input\ Methods/macSKK.app
+    cp -r build/archive.xcarchive/Products/Library/Input\ Methods/macSKK.app ~/Library/Input\ Methods/
+elif [[ -d /Library/Input\ Methods/macSKK.app ]]; then
+    echo "Update /Library/Input Methods/macSKK.app"
+
+    sudo rm -rf /Library/Input\ Methods/macSKK.app
+    sudo cp -r build/archive.xcarchive/Products/Library/Input\ Methods/macSKK.app /Library/Input\ Methods/
+fi
+
 # 再起動
 pkill "macSKK"


### PR DESCRIPTION
build_restart.shについて`/Library/Input Methods/macSKK.app`にmacSKKがインストールされていても動作するようにする変更です。