### PR TITLE
アプリケーション互換性設定に「空のときには▽▼を表示」を追加

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -24,6 +24,8 @@ import Combine
     static let insertBlankStringBundleIdentifiers = CurrentValueSubject<[String], Never>([])
     /// 1文字目を常に未確定扱いするワークアラウンドを適用するBundle Identifierの集合
     static let treatFirstCharacterAsMarkedTextBundleIdentifiers = CurrentValueSubject<[String], Never>([])
+    /// 空のときには▽▼を表示するワークアラウンドを適用するBundle Identifierの集合
+    static let showMarkerWhenEmptyBundleIdentifiers = CurrentValueSubject<[String], Never>([])
     /// ユーザー辞書だけでなくすべての辞書から補完候補を検索するか？
     static var findCompletionFromAllDicts = false
     /// 現在のローマ字かな変換ルール
@@ -47,8 +49,8 @@ import Combine
     static var selectingBackspace: SelectingBackspace = .default
     /// カンマかピリオドを入力したときに入力する句読点の設定
     static var punctuation: Punctuation = .default
-    /// ▽と▼の表示
-    static var showMarkedTextMarker: ShowMarkedTextMarker = .always
+    /// ▽と▼を表示するか
+    static var showMarkedTextMarker: Bool = true
     /// 変換候補パネルの表示方向
     static var candidateListDirection = CurrentValueSubject<CandidateListDirection, Never>(.vertical)
     /// ピリオドで補完候補の最初の要素で確定するか

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -34,6 +34,8 @@ class InputController: IMKInputController {
     private var insertBlankString: Bool = false
     /// 1文字目を常に未確定扱いするワークアラウンドを適用するかどうか
     private var treatFirstCharacterAsMarkedText: Bool = false
+    /// 空のときには▽▼を表示するワークアラウンドを適用するかどうか
+    private var showMarkerWhenEmpty: Bool = false
 
     @MainActor override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         super.init(server: server, delegate: delegate, client: inputClient)
@@ -67,12 +69,18 @@ class InputController: IMKInputController {
                     }
                     textInput.insertText(text, replacementRange: Self.notFoundRange)
                 case .markedText(let markedText):
-                    let attributedText = markedText.attributedString(Global.showMarkedTextMarker)
-                    let cursorRange: NSRange = markedText.cursorRange(Global.showMarkedTextMarker) ?? Self.notFoundRange
+                    let showMarker: Bool
+                    if showMarkerWhenEmpty && !Global.showMarkedTextMarker {
+                        showMarker = markedText.elements.compactMap(\.text).allSatisfy(\.isEmpty)
+                    } else {
+                        showMarker = Global.showMarkedTextMarker
+                    }
+                    let attributedText = markedText.attributedString(showMarker)
+                    let cursorRange: NSRange = markedText.cursorRange(showMarker) ?? Self.notFoundRange
                     // Thingsのメモ欄などで最初の一文字をShift押しながら入力すると "▽あ" が直接入力されてしまうことがあるのを回避するワークグラウンド
                     if case .markerCompose = markedText.elements.first, markedText.elements.count == 2,
                        case let .plain(text) = markedText.elements[1], text.count == 1 {
-                        textInput.setMarkedText(NSAttributedString(MarkedText([.markerCompose]).attributedString(Global.showMarkedTextMarker)),
+                        textInput.setMarkedText(NSAttributedString(MarkedText([.markerCompose]).attributedString(showMarker)),
                                                 selectionRange: cursorRange,
                                                 replacementRange: Self.notFoundRange)
                     }
@@ -158,6 +166,11 @@ class InputController: IMKInputController {
                 let enabled = bundleIdentifiers.contains(bundleIdentifier)
                 self.treatFirstCharacterAsMarkedText = enabled
                 self.stateMachine.enableMarkedTextWorkaround = enabled
+            }
+        }.store(in: &cancellables)
+        Global.showMarkerWhenEmptyBundleIdentifiers.sink { [weak self] bundleIdentifiers in
+            if let bundleIdentifier = self?.targetApp.bundleIdentifier {
+                self?.showMarkerWhenEmpty = bundleIdentifiers.contains(bundleIdentifier)
             }
         }.store(in: &cancellables)
         // 読みが更新されたときに補完候補の検索を行う処理
@@ -320,6 +333,9 @@ class InputController: IMKInputController {
             let treatFirstCharacterAsMarkedTextMenuItem = NSMenuItem(title: String(localized: "MenuItemTreadFirstCharacterAsMarkedText"), action: #selector(toggleTreatFirstCharacterAsMarkedText), keyEquivalent: "")
             treatFirstCharacterAsMarkedTextMenuItem.state = treatFirstCharacterAsMarkedText ? .on : .off
             preferenceMenu.addItem(treatFirstCharacterAsMarkedTextMenuItem)
+            let showMarkerWhenEmptyMenuItem = NSMenuItem(title: String(localized: "MenuItemShowMarkerWhenEmpty"), action: #selector(toggleShowMarkerWhenEmpty), keyEquivalent: "")
+            showMarkerWhenEmptyMenuItem.state = showMarkerWhenEmpty ? .on : .off
+            preferenceMenu.addItem(showMarkerWhenEmptyMenuItem)
         }
         let skkservMenuItem = NSMenuItem(
             title: String(localized: "MenuItemSKKServ", comment: "SKKServ"),
@@ -408,6 +424,13 @@ class InputController: IMKInputController {
     @objc func toggleTreatFirstCharacterAsMarkedText() {
         if let bundleIdentifier = targetApp.bundleIdentifier {
             NotificationCenter.default.post(name: notificationNameToggleTreatFirstCharacterAsMarkedText, object: bundleIdentifier)
+        }
+    }
+
+    /// 現在最前面にあるアプリで、ワークアラウンドの空のときには▽▼を表示するかの有効無効を切り替える
+    @objc func toggleShowMarkerWhenEmpty() {
+        if let bundleIdentifier = targetApp.bundleIdentifier {
+            NotificationCenter.default.post(name: notificationNameToggleShowMarkerWhenEmpty, object: bundleIdentifier)
         }
     }
 

--- a/macSKK/MarkedText.swift
+++ b/macSKK/MarkedText.swift
@@ -52,8 +52,7 @@ struct MarkedText: Equatable {
         self.elements = elements
     }
 
-    func attributedString(_ showMarkedTextMarker: ShowMarkedTextMarker) -> AttributedString {
-        let showMarker = resolveShowMarker(showMarkedTextMarker)
+    func attributedString(_ showMarker: Bool) -> AttributedString {
         var result = AttributedString()
         for element in elements {
             switch element {
@@ -79,9 +78,8 @@ struct MarkedText: Equatable {
         return result
     }
 
-    func cursorRange(_ showMarkedTextMarker: ShowMarkedTextMarker) -> NSRange? {
+    func cursorRange(_ showMarker: Bool) -> NSRange? {
         var location: Int = 0
-        let showMarker = resolveShowMarker(showMarkedTextMarker)
         for element in elements {
             switch element {
             case .markerSelect, .markerCompose:
@@ -95,19 +93,5 @@ struct MarkedText: Equatable {
             }
         }
         return nil
-    }
-
-    /// showMarkedTextMarkerの設定が.minimalのとき、▽や▼を消すと未確定文字列が空になる場合だけマーカーを表示する。
-    /// この挙動が必要な理由は.minimalの説明を参照。
-    private func resolveShowMarker(_ showMarkedTextMarker: ShowMarkedTextMarker) -> Bool {
-        switch showMarkedTextMarker {
-        case .always:
-            return true
-        case .never:
-            return false
-        case .minimal:
-            // .plainや.emphasizedのテキストが空の場合は未確定文字列が空になるので▽や▼を出す必要がある。
-            return elements.compactMap(\.text).allSatisfy(\.isEmpty)
-        }
     }
 }

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -54,11 +54,8 @@ struct GeneralView: View {
                 Toggle(isOn: $settingsViewModel.showInputIconModal, label: {
                     Text("Show Input Mode Modal")
                 })
-                Picker("Show Marked Text Marker", selection: $settingsViewModel.showMarkedTextMarker) {
-                    ForEach(ShowMarkedTextMarker.allCases) { showMarkedTextMarker in
-                        Text(showMarkedTextMarker.description).tag(showMarkedTextMarker)
-                    }
-                }
+                Toggle("Show Marked Text Marker", isOn: $settingsViewModel.showMarkedTextMarker)
+                    .toggleStyle(.switch)
                 HStack {
                     Spacer()
                     Button("Customize Input Mode Colors…") {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -61,6 +61,8 @@ struct WorkaroundApplication: Identifiable, Equatable {
     let insertBlankString: Bool
     /// 1文字目を常に未確定扱いするか
     let treatFirstCharacterAsMarkedText: Bool
+    /// 空のときには▽▼を表示するか
+    let showMarkerWhenEmpty: Bool
     var icon: NSImage?
     var displayName: String?
 
@@ -74,6 +76,7 @@ struct WorkaroundApplication: Identifiable, Equatable {
         return WorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                      insertBlankString: insertBlankString,
                                      treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                     showMarkerWhenEmpty: showMarkerWhenEmpty,
                                      icon: icon,
                                      displayName: displayName)
     }
@@ -82,6 +85,16 @@ struct WorkaroundApplication: Identifiable, Equatable {
         return WorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                      insertBlankString: insertBlankString,
                                      treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                     showMarkerWhenEmpty: showMarkerWhenEmpty,
+                                     icon: icon,
+                                     displayName: displayName)
+    }
+
+    func with(showMarkerWhenEmpty: Bool) -> Self {
+        return WorkaroundApplication(bundleIdentifier: bundleIdentifier,
+                                     insertBlankString: insertBlankString,
+                                     treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                     showMarkerWhenEmpty: showMarkerWhenEmpty,
                                      icon: icon,
                                      displayName: displayName)
     }
@@ -137,38 +150,6 @@ enum CandidateListDirection: Int, CaseIterable, Identifiable {
     }
 }
 
-/// ▽と▼の表示
-enum ShowMarkedTextMarker: String, CaseIterable, Identifiable {
-    typealias ID = String
-    var id: ID { rawValue }
-
-    /// 表示する
-    case always
-    /// できるだけ表示しない（入力処理を優先）
-    /// ▽と▼を表示しない場合、未確定文字列を入力中にもかかわらず未確定文字列が空になってしまう場合がある。
-    /// 具体的にはabbrevやStickyShiftで入力を開始した場合。
-    /// この場合において、以下のような特定のアプリケーションにおいてスラッシュやセミコロンが直接入力されてしまう。
-    /// この症状を避けるため、未確定文字列が空になるときは▽と▼を表示するようにする。
-    /// - IntelliJ IDEA
-    /// - Ghostty
-    /// - Kitty
-    /// - VSCode内蔵のTerminal
-    /// （なお、普通にシフトキーを押して入力を開始した際に最初の文字を消すと▽が表示されるが、許容する）
-    case minimal
-    /// まったく表示しない
-    case never
-
-    var description: String {
-        switch self {
-        case .always:
-            String(localized: "ShowMarkedTextMarkerAlways")
-        case .minimal:
-            String(localized: "ShowMarkedTextMarkerMinimal")
-        case .never:
-            String(localized: "ShowMarkedTextMarkerNever")
-        }
-    }
-}
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
@@ -242,8 +223,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var ignoreUserDictInPrivateMode: Bool
     /// 入力モードのモーダルを表示するかどうか
     @Published var showInputIconModal: Bool
-    /// ▽と▼の表示
-    @Published var showMarkedTextMarker: ShowMarkedTextMarker
+    /// ▽と▼を表示するか
+    @Published var showMarkedTextMarker: Bool
     /// 変換候補リストの表示方向
     @Published var candidateListDirection: CandidateListDirection
     /// 日時変換の読みリスト
@@ -310,9 +291,12 @@ final class SettingsViewModel: ObservableObject {
                 let insertBlankString = workaround["insertBlankString"] as? Bool {
                 // treatFirstCharacterAsMarkedTextはv2.1+ で追加された
                 let treatFirstCharacterAsMarkedText = workaround["treatFirstCharacterAsMarkedText"] as? Bool ?? false
+                // showMarkerWhenEmptyはv2.15+ で追加された
+                let showMarkerWhenEmpty = workaround["showMarkerWhenEmpty"] as? Bool ?? false
                 return WorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                              insertBlankString: insertBlankString,
-                                             treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText)
+                                             treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                             showMarkerWhenEmpty: showMarkerWhenEmpty)
             } else {
                 return nil
             }
@@ -352,7 +336,7 @@ final class SettingsViewModel: ObservableObject {
         period = Punctuation.Period(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.punctuation)) ?? .default
         ignoreUserDictInPrivateMode = UserDefaults.app.bool(forKey: UserDefaultsKeys.ignoreUserDictInPrivateMode)
         showInputIconModal = UserDefaults.app.bool(forKey: UserDefaultsKeys.showInputModePanel)
-        showMarkedTextMarker = ShowMarkedTextMarker(rawValue: UserDefaults.app.string(forKey: UserDefaultsKeys.showMarkedTextMarker) ?? "") ?? .always
+        showMarkedTextMarker = UserDefaults.app.bool(forKey: UserDefaultsKeys.showsMarkedTextMarker)
         candidateListDirection = CandidateListDirection(rawValue: UserDefaults.app.integer(forKey: UserDefaultsKeys.candidateListDirection)) ?? .vertical
         if let dateConversionDict = UserDefaults.app.dictionary(forKey: UserDefaultsKeys.dateConversions),
            let dateConversionsRaw = dateConversionDict["conversions"] as? [[String: Any]],
@@ -476,6 +460,7 @@ final class SettingsViewModel: ObservableObject {
                 "bundleIdentifier": $0.bundleIdentifier,
                 "insertBlankString": $0.insertBlankString,
                 "treatFirstCharacterAsMarkedText": $0.treatFirstCharacterAsMarkedText,
+                "showMarkerWhenEmpty": $0.showMarkerWhenEmpty,
             ] }
             UserDefaults.app.set(settings, forKey: UserDefaultsKeys.workarounds)
         }.store(in: &cancellables)
@@ -483,6 +468,7 @@ final class SettingsViewModel: ObservableObject {
         $workaroundApplications.sink { applications in
             Global.insertBlankStringBundleIdentifiers.send(applications.filter { $0.insertBlankString }.map { $0.bundleIdentifier })
             Global.treatFirstCharacterAsMarkedTextBundleIdentifiers.send(applications.filter { $0.treatFirstCharacterAsMarkedText }.map { $0.bundleIdentifier })
+            Global.showMarkerWhenEmptyBundleIdentifiers.send(applications.filter { $0.showMarkerWhenEmpty }.map { $0.bundleIdentifier })
         }.store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: notificationNameToggleDirectMode)
@@ -511,7 +497,8 @@ final class SettingsViewModel: ObservableObject {
                         logger.log("Bundle Identifier \"\(bundleIdentifier, privacy: .public)\" の空文字挿入の互換性が設定されました。")
                         self.workaroundApplications.append(WorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                                                                  insertBlankString: true,
-                                                                                 treatFirstCharacterAsMarkedText: false))
+                                                                                 treatFirstCharacterAsMarkedText: false,
+                                                                                 showMarkerWhenEmpty: false))
                     }
                 }
             }
@@ -529,7 +516,26 @@ final class SettingsViewModel: ObservableObject {
                         logger.log("Bundle Identifier \"\(bundleIdentifier, privacy: .public)\" の1文字目を常に未確定扱いする互換性が設定されました。")
                         self.workaroundApplications.append(WorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                                                                  insertBlankString: false,
-                                                                                 treatFirstCharacterAsMarkedText: true))
+                                                                                 treatFirstCharacterAsMarkedText: true,
+                                                                                 showMarkerWhenEmpty: false))
+                    }
+                }
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: notificationNameToggleShowMarkerWhenEmpty)
+            .sink { [weak self] notification in
+                if let self, let bundleIdentifier = notification.object as? String {
+                    if let index = self.workaroundApplications.firstIndex(where: { $0.bundleIdentifier == bundleIdentifier }) {
+                        let newShowMarkerWhenEmpty = !self.workaroundApplications[index].showMarkerWhenEmpty
+                        logger.log("Bundle Identifier \"\(bundleIdentifier, privacy: .public)\" の空のときには▽▼を表示する互換性が\(newShowMarkerWhenEmpty ? "設定" : "解除", privacy: .public)されました。")
+                        self.workaroundApplications[index] = self.workaroundApplications[index].with(showMarkerWhenEmpty: newShowMarkerWhenEmpty)
+                    } else {
+                        logger.log("Bundle Identifier \"\(bundleIdentifier, privacy: .public)\" の空のときには▽▼を表示する互換性が設定されました。")
+                        self.workaroundApplications.append(WorkaroundApplication(bundleIdentifier: bundleIdentifier,
+                                                                                 insertBlankString: false,
+                                                                                 treatFirstCharacterAsMarkedText: false,
+                                                                                 showMarkerWhenEmpty: true))
                     }
                 }
             }
@@ -771,8 +777,8 @@ final class SettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $showMarkedTextMarker.dropFirst().sink { showMarkedTextMarker in
-            UserDefaults.app.set(showMarkedTextMarker.rawValue, forKey: UserDefaultsKeys.showMarkedTextMarker)
-            logger.log("▽と▼の表示を\(showMarkedTextMarker.description, privacy: .public)に変更しました")
+            UserDefaults.app.set(showMarkedTextMarker, forKey: UserDefaultsKeys.showsMarkedTextMarker)
+            logger.log("▽と▼の表示を\(showMarkedTextMarker ? "表示" : "非表示", privacy: .public)に変更しました")
             Global.showMarkedTextMarker = showMarkedTextMarker
         }.store(in: &cancellables)
 
@@ -894,7 +900,7 @@ final class SettingsViewModel: ObservableObject {
         period = Punctuation.default.period
         ignoreUserDictInPrivateMode = false
         showInputIconModal = true
-        showMarkedTextMarker = .always
+        showMarkedTextMarker = true
         candidateListDirection = .vertical
         dateYomis = [
             DateConversion.Yomi(yomi: "today", relative: .now),
@@ -1073,18 +1079,20 @@ final class SettingsViewModel: ObservableObject {
     }
 
     /// 互換性設定を追加 or 更新する
-    func upsertWorkaroundApplication(bundleIdentifier: String, insertBlankString: Bool, treatFirstCharacterAsMarkedText: Bool) {
+    func upsertWorkaroundApplication(bundleIdentifier: String, insertBlankString: Bool, treatFirstCharacterAsMarkedText: Bool, showMarkerWhenEmpty: Bool) {
         if let index = workaroundApplications.firstIndex(where: { $0.bundleIdentifier == bundleIdentifier }) {
             let application = workaroundApplications[index]
             workaroundApplications[index] = WorkaroundApplication(bundleIdentifier: application.bundleIdentifier,
                                                                   insertBlankString: insertBlankString,
                                                                   treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                                                  showMarkerWhenEmpty: showMarkerWhenEmpty,
                                                                   icon: application.icon,
                                                                   displayName: application.displayName)
         } else {
             workaroundApplications.append(WorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                                                 insertBlankString: insertBlankString,
-                                                                treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText))
+                                                                treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                                                showMarkerWhenEmpty: showMarkerWhenEmpty))
         }
     }
 

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -58,8 +58,8 @@ struct UserDefaultsKeys {
     static let ignoreUserDictInPrivateMode = "ignoreUserDictInPrivateMode"
     // 入力モードのモーダルを表示するかどうか
     static let showInputModePanel = "showInputModePanel"
-    // ▽と▼の表示
-    static let showMarkedTextMarker = "showMarkedTextMarker"
+    // ▽と▼を表示するか (Bool)
+    static let showsMarkedTextMarker = "showsMarkedTextMarker"
     // 候補リストの表示方向
     static let candidateListDirection = "candidateListDirection"
     // 日時変換の変換後のリスト

--- a/macSKK/Settings/WorkaroundApplicationView.swift
+++ b/macSKK/Settings/WorkaroundApplicationView.swift
@@ -8,6 +8,7 @@ struct WorkaroundApplicationView: View {
     @Binding var bundleIdentifier: String
     @Binding var insertBlankString: Bool
     @Binding var treatFirstCharacterAsMarkedText: Bool
+    @Binding var showMarkerWhenEmpty: Bool
     @Binding var isShowingSheet: Bool
 
     var body: some View {
@@ -17,6 +18,8 @@ struct WorkaroundApplicationView: View {
                 Toggle("Insert Blank String", isOn: $insertBlankString)
                     .toggleStyle(.switch)
                 Toggle("Treat First Character as Marked Text", isOn: $treatFirstCharacterAsMarkedText)
+                    .toggleStyle(.switch)
+                Toggle("Show Marker When Empty", isOn: $showMarkerWhenEmpty)
                     .toggleStyle(.switch)
             } header: {
                 Text("SettingsHeaderWorkaroundApplication")
@@ -32,7 +35,8 @@ struct WorkaroundApplicationView: View {
                     Button {
                         settingsViewModel.upsertWorkaroundApplication(bundleIdentifier: bundleIdentifier,
                                                                       insertBlankString: insertBlankString,
-                                                                      treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText)
+                                                                      treatFirstCharacterAsMarkedText: treatFirstCharacterAsMarkedText,
+                                                                      showMarkerWhenEmpty: showMarkerWhenEmpty)
                         isShowingSheet = false
                     } label: {
                         Text(settingsViewModel.workaroundApplications.contains(where: { $0.bundleIdentifier == bundleIdentifier })  ? "Done" : "Add")
@@ -52,5 +56,6 @@ struct WorkaroundApplicationView: View {
                               bundleIdentifier: .constant("net.mtgto.inputmethod.macSKK"),
                               insertBlankString: .constant(true),
                               treatFirstCharacterAsMarkedText: .constant(true),
+                              showMarkerWhenEmpty: .constant(false),
                               isShowingSheet: .constant(true))
 }

--- a/macSKK/Settings/WorkaroundView.swift
+++ b/macSKK/Settings/WorkaroundView.swift
@@ -10,6 +10,7 @@ struct WorkaroundView: View {
     @State var bundleIdentifier: String = ""
     @State var insertBlankString: Bool = true
     @State var treatFirstCharacterAsMarkedText: Bool = true
+    @State var showMarkerWhenEmpty: Bool = false
 
     var body: some View {
         let applications = settingsViewModel.workaroundApplications
@@ -37,6 +38,7 @@ struct WorkaroundView: View {
                                     Group {
                                         Text("Insert Blank String") + Text(": ") + Text(application.insertBlankString ? "Enabled" : "Disabled")
                                         Text("Treat First Character as Marked Text") + Text(": ") + Text(application.treatFirstCharacterAsMarkedText ? "Enabled" : "Disabled")
+                                        Text("Show Marker When Empty") + Text(": ") + Text(application.showMarkerWhenEmpty ? "Enabled" : "Disabled")
                                     }
                                     .font(.footnote)
                                     .fontWeight(.light)
@@ -54,6 +56,7 @@ struct WorkaroundView: View {
                                     bundleIdentifier = application.bundleIdentifier
                                     insertBlankString = application.insertBlankString
                                     treatFirstCharacterAsMarkedText = application.treatFirstCharacterAsMarkedText
+                                    showMarkerWhenEmpty = application.showMarkerWhenEmpty
                                     isShowingSheet = true
                                 } label: {
                                     Image(systemName: "info.circle")
@@ -78,6 +81,7 @@ struct WorkaroundView: View {
                             bundleIdentifier = ""
                             insertBlankString = false
                             treatFirstCharacterAsMarkedText = false
+                            showMarkerWhenEmpty = false
                             isShowingSheet = true
                         } label: {
                             Text("Add…")
@@ -95,6 +99,7 @@ struct WorkaroundView: View {
                                       bundleIdentifier: $bundleIdentifier,
                                       insertBlankString: $insertBlankString,
                                       treatFirstCharacterAsMarkedText: $treatFirstCharacterAsMarkedText,
+                                      showMarkerWhenEmpty: $showMarkerWhenEmpty,
                                       isShowingSheet: $isShowingSheet)
         }
     }
@@ -105,10 +110,12 @@ struct WorkaroundView: View {
         WorkaroundApplication(bundleIdentifier: "net.mtgto.inputmethod.macSKK",
                               insertBlankString: true,
                               treatFirstCharacterAsMarkedText: true,
+                              showMarkerWhenEmpty: true,
                               icon: NSImage(named: "AppIcon"), displayName: "macSKK"),
         WorkaroundApplication(bundleIdentifier: "net.mtgto.inputmethod.macSKK.not-resolved",
                               insertBlankString: false,
                               treatFirstCharacterAsMarkedText: false,
+                              showMarkerWhenEmpty: false,
                               icon: nil,
                               displayName: nil)
     ]))

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "MenuItemDirectInput" = "Direct input from \"%@\"";
 "MenuItemInsertBlankString" = "Insert Blank String for Workaround";
 "MenuItemTreadFirstCharacterAsMarkedText" = "Treat First Char as Marked for Workaround";
+"MenuItemShowMarkerWhenEmpty" = "Show Marker When Empty for Workaround";
 "MenuItemSKKServ" = "Use SKKServ";
 "SettingsNameGeneral" = "General";
 "SettingsNameDictionaries" = "Dictionaries";
@@ -90,9 +91,6 @@
 "Ignore User Dict in Private Mode" = "Ignore User Dict in Private Mode";
 "Show Input Mode Modal" = "Show Input Mode Modal";
 "Show Marked Text Marker" = "Show ▽ and ▼";
-"ShowMarkedTextMarkerAlways" = "Show";
-"ShowMarkedTextMarkerMinimal" = "Hide as much as possible (prioritize input handling)";
-"ShowMarkedTextMarkerNever" = "Never show";
 "Customize Input Mode Colors…" = "Customize Input Mode Colors…";
 "Register fixed katakana word to dict" = "Register fixed katakana word to dict";
 "Ignore leading spaces when registering a word" = "Ignore leading spaces when registering a word";
@@ -102,6 +100,7 @@
 "Show Candidate for Completion" = "Show Candidate for Completion";
 "Insert Blank String" = "Insert Blank String";
 "Treat First Character as Marked Text" = "Treat First Character as Marked Text";
+"Show Marker When Empty" = "Show Marker When Empty";
 "Enabled" = "Enabled";
 "Disabled" = "Disabled";
 "Add…" = "Add…";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "MenuItemDirectInput" = "\"%@\"では直接入力";
 "MenuItemInsertBlankString" = "空文字挿入 (互換性)";
 "MenuItemTreadFirstCharacterAsMarkedText" = "1文字目を未確定扱い (互換性)";
+"MenuItemShowMarkerWhenEmpty" = "空のときには▽▼を表示 (互換性)";
 "MenuItemSKKServ" = "SKKServを利用する";
 "SettingsNameGeneral" = "一般";
 "SettingsNameDictionaries" = "辞書";
@@ -89,10 +90,7 @@
 "Confirm the first completion by period" = "最初の補完候補をピリオドキーで確定する";
 "Ignore User Dict in Private Mode" = "プライベートモードではユーザー辞書を参照しない";
 "Show Input Mode Modal" = "入力モードアイコンを表示";
-"Show Marked Text Marker" = "▽と▼の表示";
-"ShowMarkedTextMarkerAlways" = "表示する";
-"ShowMarkedTextMarkerMinimal" = "できるだけ表示しない（入力処理を優先）";
-"ShowMarkedTextMarkerNever" = "まったく表示しない";
+"Show Marked Text Marker" = "▽と▼を表示する";
 "Customize Input Mode Colors…" = "入力モードの色をカスタマイズ…";
 "Register fixed katakana word to dict" = "カタカナで確定した単語を辞書に登録する";
 "Ignore leading spaces when registering a word" = "単語登録中に先頭スペースを無視する";
@@ -102,6 +100,7 @@
 "Show Candidate for Completion" = "変換候補を補完候補として表示";
 "Insert Blank String" = "空文字挿入";
 "Treat First Character as Marked Text" = "1文字目を常に未確定扱い";
+"Show Marker When Empty" = "空のときには▽▼を表示";
 "Enabled" = "有効";
 "Disabled" = "無効";
 "Add…" = "追加…";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -14,6 +14,8 @@ let notificationNameToggleDirectMode = Notification.Name("toggleDirectMode")
 let notificationNameToggleInsertBlankString = Notification.Name("toggleInsertBlankString")
 // 1文字目を常に未確定扱いするワークアラウンドの有効無効を切り替えたいときに通知される通知の名前。
 let notificationNameToggleTreatFirstCharacterAsMarkedText = Notification.Name("toggleTreatFirstCharacterAsMarkedText")
+// 空のときには▽▼を表示するワークアラウンドの有効無効を切り替えたいときに通知される通知の名前。
+let notificationNameToggleShowMarkerWhenEmpty = Notification.Name("toggleShowMarkerWhenEmpty")
 // 設定画面を開きたいときに通知される通知の名前
 let notificationNameOpenSettings = Notification.Name("openSettings")
 // インラインで表示する変換候補の数を変更したときに通知される通知の名前
@@ -48,6 +50,7 @@ struct macSKKApp: App {
     init() {
         // 環境設定の初期値をSettingsViewModelより先に行う
         Self.setupUserDefaults()
+        Self.migrateUserDefaults()
         do {
             dictionariesDirectoryUrl = try FileManager.default.url(
                 for: .documentDirectory,
@@ -58,7 +61,7 @@ struct macSKKApp: App {
             let settingsViewModel = try SettingsViewModel(dictionariesDirectoryUrl: dictionariesDirectoryUrl)
             let settingsWindow = SettingsWindow(settingsViewModel: settingsViewModel)
             Global.privateMode.send(UserDefaults.app.bool(forKey: UserDefaultsKeys.privateMode))
-            Global.showMarkedTextMarker = ShowMarkedTextMarker(rawValue: UserDefaults.app.string(forKey: UserDefaultsKeys.showMarkedTextMarker) ?? "") ?? .always
+            Global.showMarkedTextMarker = UserDefaults.app.bool(forKey: UserDefaultsKeys.showsMarkedTextMarker)
 
             // SettingsViewModelの初期化が終わったあとにユーザー辞書を読み込まないと辞書のロード状態が設定されない
             Global.dictionary = try UserDict(dicts: [],
@@ -187,6 +190,14 @@ struct macSKKApp: App {
         }
     }
 
+    private static func migrateUserDefaults() {
+        // v2.13.0 - v2.14.x まであったshowMarkedTextMarkerのマイグレーション
+        if let oldValue = UserDefaults.app.string(forKey: "showMarkedTextMarker") {
+            UserDefaults.app.set(oldValue != "never", forKey: UserDefaultsKeys.showsMarkedTextMarker)
+            UserDefaults.app.removeObject(forKey: "showMarkedTextMarker")
+        }
+    }
+
     private static func setupUserDefaults() {
         UserDefaults.app.register(defaults: [
             UserDefaultsKeys.dictionaries: [],
@@ -196,10 +207,10 @@ struct macSKKApp: App {
             UserDefaultsKeys.inlineCandidateCount: 3,
             UserDefaultsKeys.selectCandidateKeys: "123456789",
             UserDefaultsKeys.workarounds: [
-                ["bundleIdentifier": "net.kovidgoyal.kitty", "insertBlankString": true, "treatFirstCharacterAsMarkedText": false],
-                ["bundleIdentifier": "jp.naver.line.mac", "insertBlankString": true, "treatFirstCharacterAsMarkedText": false],
-                ["bundleIdentifier": "org.alacritty", "insertBlankString": true, "treatFirstCharacterAsMarkedText": false],
-                ["bundleIdentifier": "co.zeit.hyper", "insertBlankString": false, "treatFirstCharacterAsMarkedText": true],
+                ["bundleIdentifier": "net.kovidgoyal.kitty", "insertBlankString": true, "treatFirstCharacterAsMarkedText": false, "showMarkerWhenEmpty": true],
+                ["bundleIdentifier": "jp.naver.line.mac", "insertBlankString": true, "treatFirstCharacterAsMarkedText": false, "showMarkerWhenEmpty": false],
+                ["bundleIdentifier": "org.alacritty", "insertBlankString": true, "treatFirstCharacterAsMarkedText": false, "showMarkerWhenEmpty": true],
+                ["bundleIdentifier": "co.zeit.hyper", "insertBlankString": false, "treatFirstCharacterAsMarkedText": true, "showMarkerWhenEmpty": true],
             ],
             // NSFont.preferredFont(forTextStyle: .body).pointSize と同じサイズ
             UserDefaultsKeys.candidatesFontSize: 13,
@@ -222,7 +233,7 @@ struct macSKKApp: App {
             UserDefaultsKeys.privateMode: false,
             UserDefaultsKeys.ignoreUserDictInPrivateMode: false,
             UserDefaultsKeys.showInputModePanel: true,
-            UserDefaultsKeys.showMarkedTextMarker: ShowMarkedTextMarker.always.rawValue,
+            UserDefaultsKeys.showsMarkedTextMarker: true,
             UserDefaultsKeys.candidateListDirection: CandidateListDirection.vertical.rawValue,
             UserDefaultsKeys.dateConversions: [
                 "yomis": [

--- a/macSKKTests/MarkedTextTests.swift
+++ b/macSKKTests/MarkedTextTests.swift
@@ -5,36 +5,28 @@ import XCTest
 @testable import macSKK
 
 final class MarkedTextTests: XCTestCase {
-    func testAttributedStringAlways() {
-        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(.always).characters), "▽あ")
-        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(.always).characters), "▼阿")
+    func testAttributedStringShow() {
+        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(true).characters), "▽あ")
+        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(true).characters), "▼阿")
         // abbrevなど未確定文字列が空のケース
-        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(.always).characters), "▽")
+        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(true).characters), "▽")
     }
 
-    func testAttributedStringMinimal() {
-        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(.minimal).characters), "あ")
-        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(.minimal).characters), "阿")
-        // abbrevなど未確定文字列が空のときはフォールバックで▽を表示する
-        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(.minimal).characters), "▽")
-        XCTAssertEqual(String(MarkedText([.markerCompose, .plain(""), .cursor]).attributedString(.minimal).characters), "▽")
-    }
-
-    func testAttributedStringNever() {
-        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(.never).characters), "あ")
-        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(.never).characters), "阿")
-        // neverは未確定文字列が空でもマーカーを表示しない
-        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(.never).characters), "")
+    func testAttributedStringHide() {
+        XCTAssertEqual(String(MarkedText([.markerCompose, .plain("あ"), .cursor]).attributedString(false).characters), "あ")
+        XCTAssertEqual(String(MarkedText([.markerSelect, .emphasized("阿"), .cursor]).attributedString(false).characters), "阿")
+        // 非表示時は未確定文字列が空でもマーカーを表示しない
+        XCTAssertEqual(String(MarkedText([.markerCompose, .cursor]).attributedString(false).characters), "")
     }
 
     func testCursorRange() {
         // カーソルがない場合は末尾にカーソルが追加され cursorRange は nil
-        XCTAssertNil(MarkedText([.markerCompose, .plain("あ")]).cursorRange(.always))
+        XCTAssertNil(MarkedText([.markerCompose, .plain("あ")]).cursorRange(true))
         // カーソル位置がマーカーと文字数の合算になっている
-        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor]).cursorRange(.always), NSRange(location: 2, length: 0))
+        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor]).cursorRange(true), NSRange(location: 2, length: 0))
         // マーカー非表示時はカーソル位置にマーカー分が含まれない
-        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor]).cursorRange(.never), NSRange(location: 1, length: 0))
+        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor]).cursorRange(false), NSRange(location: 1, length: 0))
         // カーソルが中間位置にある場合
-        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor, .plain("い")]).cursorRange(.always), NSRange(location: 2, length: 0))
+        XCTAssertEqual(MarkedText([.markerCompose, .plain("あ"), .cursor, .plain("い")]).cursorRange(true), NSRange(location: 2, length: 0))
     }
 }


### PR DESCRIPTION
https://github.com/mtgto/macSKK/pull/457#issuecomment-4363983684
#457 で、Ghostty, Kittyなど一部アプリで問題があることがわかったため、互換性設定に「このアプリでは空文字列のときは▽▼を表示」する設定を追加します。

<img width="279" height="220" alt="image" src="https://github.com/user-attachments/assets/86b8cba4-9c7e-4541-97c0-fa4825751081" />

- WorkaroundApplicationに showMarkerWhenEmpty フラグを追加
- 入力メニューからアプリごとにトグル可能
- UserDefaultsキーをshowMarkedTextMarkerからshowsMarkedTextMarkerに変更
  - 旧キーが存在する場合は起動時にマイグレーション
- Kitty・Alacritty・HyperのshowMarkerWhenEmptyをデフォルトで有効化