### PR TITLE
変換候補選択中のバックスペースに「前候補に戻す」を追加

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -103,6 +103,8 @@ enum SelectingBackspace: Int, CaseIterable, Identifiable {
     /// インライン時、変換候補リスト表示時を問わず変換候補の末尾一字を削除して確定する。
     /// skkeletonのデフォルトの挙動。
     case dropLastAlways = 2
+    /// 前候補キーと同じ動きをする。
+    case backwardCandidate = 3
 
     // v1.2.0までの挙動
     static let `default` = cancel
@@ -115,6 +117,8 @@ enum SelectingBackspace: Int, CaseIterable, Identifiable {
             return String(localized: "SelectingBackspaceDropLastInlineOnly")
         case .dropLastAlways:
             return String(localized: "SelectingBackspaceDropLastAlways")
+        case .backwardCandidate:
+            return String(localized: "SelectingBackspaceBackwardCandidate")
         }
     }
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1314,6 +1314,9 @@ final class StateMachine {
                 // 変換候補の末尾を一字消して確定
                 fixCurrentSelect(dropLast: true)
                 return true
+            case .backwardCandidate:
+                // 前候補キーと同じ動き
+                return handleSelectingPrevious(diff: -1, selecting: selecting)
             }
         case .up:
             if case .vertical = Global.candidateListDirection.value {

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "SelectingBackspaceCancel" = "Go back one step";
 "SelectingBackspaceDropLastInlineOnly" = "Delete a last character & commit in Inline";
 "SelectingBackspaceDropLastAlways" = "Delete a last character & commit always";
+"SelectingBackspaceBackwardCandidate" = "Same as previous candidate key";
 "Follow Romaji-Kana Rule" = "Follow Romaji-Kana Rule";
 "EnterKey" = "Enter \"%@\"";
 "DuplicatedKeyBindingName" = "Copy of %@";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -176,7 +176,7 @@
 "SelectingBackspaceCancel" = "Go back one step";
 "SelectingBackspaceDropLastInlineOnly" = "Delete a last character & commit in Inline";
 "SelectingBackspaceDropLastAlways" = "Delete a last character & commit always";
-"SelectingBackspaceBackwardCandidate" = "Same as previous candidate key";
+"SelectingBackspaceBackwardCandidate" = "Select backward candidate";
 "Follow Romaji-Kana Rule" = "Follow Romaji-Kana Rule";
 "EnterKey" = "Enter \"%@\"";
 "DuplicatedKeyBindingName" = "Copy of %@";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "SelectingBackspaceCancel" = "一つ前の状態に戻す";
 "SelectingBackspaceDropLastInlineOnly" = "インライン時は一文字削除して確定";
 "SelectingBackspaceDropLastAlways" = "常に一文字削除して確定";
+"SelectingBackspaceBackwardCandidate" = "前候補に戻す";
 "Follow Romaji-Kana Rule" = "ローマ字かな変換ルールに従う";
 "EnterKey" = "\"%@\" を入力";
 "DuplicatedKeyBindingName" = "%@ のコピー";

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -3330,6 +3330,31 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleSelectingBackspaceBackwardCandidate() throws {
+        Global.selectingBackspace = .backwardCandidate
+        let dict = MemoryDict(entries: ["あu": [Word("会"), Word("合")]], readonly: true)
+        Global.dictionary = try UserDict(dicts: [dict],
+                                         privateMode: CurrentValueSubject<Bool, Never>(false),
+                                         ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                         dateYomis: [],
+                                         dateConversions: [])
+        Global.dictionary.setEntries([:])
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(4).sink { events in
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerSelect, .emphasized("会う")])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerSelect, .emphasized("合う")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("会う")])))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "u", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(backspaceAction))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleSelectingTab() {
         Global.dictionary.setEntries(["お": [Word("尾")]])
 


### PR DESCRIPTION
変換候補選択中のバックスペースで「一つ前に戻す」が前候補キーとほぼ同じ動きかと思っていたのですが、リスト表示になった直後の挙動が異なっていたので「前候補に戻す」設定を追加しました。

<img width="711" height="532" alt="Screenshot 2026-05-17 at 9 24 45" src="https://github.com/user-attachments/assets/e71eb8a8-acfc-4c16-930a-a53fdb9b8222" />
