### PR TITLE
補完候補から直接キーで確定できる

### DIFF
--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -43,7 +43,14 @@ final class StateMachine {
     let yomiEvent: AnyPublisher<YomiEvent, Never>
     private let yomiEventSubject = PassthroughSubject<YomiEvent, Never>()
     /// 読みの一部と補完結果(読み)のペア
-    var completion: Completion? = nil
+    var completion: Completion? = nil {
+        didSet {
+            completionSetAt = completion == nil ? nil : Date()
+        }
+    }
+    /// completionがセットされた日時。一定時間経過後に確定キーが押されたら確定とみなすために使用する
+    var completionSetAt: Date? = nil
+    let completionConfirmationTimeLimit: TimeInterval = 0.5
 
     // TODO: displayCandidateCountを環境設定にするかも
     /// 変換候補パネルを表示するまで表示する変換候補の数
@@ -582,10 +589,24 @@ final class StateMachine {
         if action.keyBind == nil && (event.modifierFlags.contains(.control) || event.modifierFlags.contains(.command)) {
             return true
         } else if let input, !event.modifierFlags.contains(.control) {
-            // 補完候補が変換候補であり、fixedCompletionByPeriodが有効で、ピリオドキーが入力された場合先頭の補完候補で確定する
-            if input == "." && !event.modifierFlags.contains(.shift) && Global.fixedCompletionByPeriod {
-                if case .candidates(let candidates) = completion, let candidate = candidates.first, let original = candidate.original {
+            if case .candidates(let candidateWords) = completion, let candidate = candidateWords.first, let original = candidate.original {
+                // 補完候補が変換候補であり、fixedCompletionByPeriodが有効で、ピリオドキーが入力された場合先頭の補完候補で確定する
+                if input == "." && !event.modifierFlags.contains(.shift) && Global.fixedCompletionByPeriod {
                     addWordToUserDict(yomi: original.midashi,  okuri: nil, candidate: candidate)
+                    state.inputMethod = .normal
+                    addFixedText(candidate.word)
+                    return true
+                }
+                // 補完候補が表示されてから一定時間経過後に確定キーが押された場合は補完候補で確定する
+                if let displayedAt = completionSetAt,
+                   displayedAt.timeIntervalSinceNow <= -completionConfirmationTimeLimit,
+                   let first = input.lowercased().first,
+                   let index = Global.selectCandidateKeys.firstIndex(of: first), index < candidateWords.count {
+                    let candidate = candidateWords[index]
+                    if let original = candidate.original {
+                        addWordToUserDict(yomi: original.midashi, okuri: nil, candidate: candidate)
+                    }
+                    completion = nil
                     state.inputMethod = .normal
                     addFixedText(candidate.word)
                     return true

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -2415,6 +2415,45 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    @MainActor func testHandleComposingSelectCompletionByKey() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(5).sink { events in
+            // "a" → ▽あ
+            XCTAssertEqual(events[0], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            // "1" → completionSetAt が 0.3 秒以内のため読みとして入力
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose, .plain("あ1")])))
+            // ESC → ▽あ1 を破棄
+            XCTAssertEqual(events[2], .markedText(MarkedText([])))
+            // shift+a → ▽あ
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerCompose, .plain("あ")])))
+            // "1" → completionSetAt が 0.3 秒以上前のため補完候補 "朝" で確定
+            XCTAssertEqual(events[4], .fixedText("朝"))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+
+        let candidates: Completion = .candidates([
+            Candidate("朝", original: Candidate.Original(midashi: "あさ", word: "朝")),
+            Candidate("麻", original: Candidate.Original(midashi: "あさ", word: "麻")),
+        ])
+
+        // 表示から規定時間以内に数字キーを押すと読みとして入力される
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        stateMachine.completion = candidates
+        stateMachine.completionSetAt = Date()
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "1")))
+        XCTAssertTrue(stateMachine.handle(cancelAction))
+
+        // completionSetAt が 規定時間以上前なら補完候補で確定する
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        stateMachine.completion = candidates
+        stateMachine.completionSetAt = Date(timeIntervalSinceNow: -(stateMachine.completionConfirmationTimeLimit + 0.1))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "1")))
+        XCTAssertEqual(Global.dictionary.refer("あさ"), [Word("朝")])
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     @MainActor func testHandleComposingPeriod() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
         Global.fixedCompletionByPeriod = true


### PR DESCRIPTION
#466 補完候補が表示されてから一定秒数経過したら選択キーで確定できるようにします。

自分の入力速度では0.5秒くらいかなと思ったので決め打ちで設定してみます。
もし人によってそれだと遅い・早いなどあれば設定可能にしてみようと思いますのでご意見いただければ幸いです。