### PR TITLE
背景色設定と横表示でカスタムフォントが反映されない問題を修正

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -637,8 +637,6 @@ final class SettingsViewModel: ObservableObject {
 
         $overridesCandidatesBackgroundColor.dropFirst().sink { overridesCandidatesBackgroundColor in
             UserDefaults.app.set(overridesCandidatesBackgroundColor, forKey: UserDefaultsKeys.overridesCandidatesBackgroundColor)
-            Global.candidatesPanel.viewModel.candidatesBackgroundColor = nil
-            Global.completionPanel.viewModel.candidatesViewModel.candidatesBackgroundColor = nil
             logger.log("変換候補の背景色を上書きするかの設定を\(overridesCandidatesBackgroundColor ? "有効" : "無効", privacy: .public)にしました")
         }.store(in: &cancellables)
 
@@ -647,8 +645,6 @@ final class SettingsViewModel: ObservableObject {
                 UserDefaults.app.set(serialized, forKey: UserDefaultsKeys.candidatesBackgroundColor)
                 logger.log("変換候補の背景色を\(serialized, privacy: .public)に変更しました")
             }
-            Global.candidatesPanel.viewModel.candidatesBackgroundColor = candidatesBackgroundColor
-            Global.completionPanel.viewModel.candidatesViewModel.candidatesBackgroundColor = candidatesBackgroundColor
         }.store(in: &cancellables)
 
         $overridesCandidatesBackgroundColor.combineLatest($candidatesBackgroundColor).sink { (overridesCandidatesBackgroundColor, candidatesBackgroundColor) in
@@ -690,8 +686,6 @@ final class SettingsViewModel: ObservableObject {
 
         $overridesAnnotationBackgroundColor.dropFirst().sink { overridesAnnotationBackgroundColor in
             UserDefaults.app.set(overridesAnnotationBackgroundColor, forKey: UserDefaultsKeys.overridesAnnotationBackgroundColor)
-            Global.candidatesPanel.viewModel.annotationBackgroundColor = nil
-            Global.completionPanel.viewModel.candidatesViewModel.annotationBackgroundColor = nil
             logger.log("注釈の背景色を上書きするかの設定を\(overridesAnnotationBackgroundColor ? "有効" : "無効", privacy: .public)にしました")
         }.store(in: &cancellables)
 
@@ -700,8 +694,6 @@ final class SettingsViewModel: ObservableObject {
                 UserDefaults.app.set(serialized, forKey: UserDefaultsKeys.annotationBackgroundColor)
                 logger.log("注釈の背景色を\(serialized, privacy: .public)に変更しました")
             }
-            Global.candidatesPanel.viewModel.annotationBackgroundColor = annotationBackgroundColor
-            Global.completionPanel.viewModel.candidatesViewModel.annotationBackgroundColor = annotationBackgroundColor
         }.store(in: &cancellables)
 
         $overridesAnnotationBackgroundColor.combineLatest($annotationBackgroundColor).sink { (overridesAnnotationBackgroundColor, annotationBackgroundColor) in

--- a/macSKK/View/HorizontalCandidatesView.swift
+++ b/macSKK/View/HorizontalCandidatesView.swift
@@ -35,14 +35,13 @@ struct HorizontalCandidatesView: View {
                 ForEach(Array(words.enumerated()), id: \.element) { index, candidate in
                     HStack(alignment: .firstTextBaseline, spacing: 0) {
                         Text(String(Global.selectCandidateKeys[index]).uppercased())
-                            // 変換候補の90%のフォントサイズ
-                            .font(.system(size: candidates.candidatesFontSize * 0.9))
+                            .font(candidates.candidatesMarkerFont)
                             // 目立たないようにする
                             .foregroundStyle(candidates.selected == candidate ? Color(NSColor.selectedMenuItemTextColor.withAlphaComponent(0.8)) : Color(NSColor.secondaryLabelColor))
                             .frame(width: 16, alignment: .trailing)
                             .padding(.trailing, 4)
                         Text(candidate.word)
-                            .font(.system(size: candidates.candidatesFontSize))
+                            .font(candidates.candidatesFont)
                             .foregroundStyle(candidates.selected == candidate ? Color(NSColor.selectedMenuItemTextColor) : Color(NSColor.textColor))
                             .fixedSize(horizontal: true, vertical: false)
                             .padding(.trailing, 8)


### PR DESCRIPTION
#424 で導入した変換候補・注釈表示のフォント・背景色の設定が反映されないバグを修正します。

- 変換候補を横表示にしているとき、フォントの変更が反映されない
- 変換候補・注釈の背景色設定が反映されない