### PR TITLE
メニューに直近の辞書登録をキャンセルする機能を追加

### DIFF
--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -311,6 +311,17 @@ enum FileDictType: Equatable {
         return false
     }
 
+    @MainActor func delete(yomi: String, word: Word) -> Bool {
+        if dict.delete(yomi: yomi, word: word) {
+            hasUnsavedChanges = true
+            NotificationCenter.default.post(name: notificationNameDictLoad,
+                                            object: DictLoadEvent(id: self.id,
+                                                                  status: .loaded(success: dict.entryCount, failure: dict.failedEntryCount)))
+            return true
+        }
+        return false
+    }
+
     func findCompletions(prefix: String) -> [String] {
         return dict.findCompletions(prefix: prefix)
     }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -323,19 +323,10 @@ class InputController: IMKInputController {
             recentRegisteredEntriesHeaderItem.isEnabled = false
             preferenceMenu.addItem(recentRegisteredEntriesHeaderItem)
             for (index, entry) in Global.dictionary.recentRegisteredEntries.enumerated() {
-                // item.tagを使ってindexを指定するやり方ではactionが呼ばれないため、
-                // 引数なしselectorにし、indexごとにメソッドを分ける。
-                let action: Selector = switch index {
-                case 0:
-                    #selector(deleteRecentRegisteredEntry0)
-                case 1:
-                    #selector(deleteRecentRegisteredEntry1)
-                default:
-                    #selector(deleteRecentRegisteredEntry2)
-                }
                 let item = NSMenuItem(title: entry.menuTitle,
-                                      action: action,
+                                      action: #selector(deleteRecentRegisteredEntry),
                                       keyEquivalent: "")
+                item.tag = index
                 preferenceMenu.addItem(item)
             }
             preferenceMenu.addItem(.separator())
@@ -427,26 +418,20 @@ class InputController: IMKInputController {
         Global.dictionary.save()
     }
 
-    @objc func deleteRecentRegisteredEntry0() {
-        deleteRecentRegisteredEntry(at: 0)
-    }
+    @objc func deleteRecentRegisteredEntry(_ sender: Any?) {
+        // IMKInputControllerでNSMenuItemにアクセスするにはkIMKCommandMenuItemNameを使う必要がある
+        if let sender = sender as? [String: Any],
+           let menuItem = sender[kIMKCommandMenuItemName] as? NSMenuItem {
+            let index = menuItem.tag
+            guard index < Global.dictionary.recentRegisteredEntries.count else {
+                logger.error("直近登録エントリの削除メニューが選択されましたが、削除対象のindex \(index) が範囲外です")
+                return
+            }
 
-    @objc func deleteRecentRegisteredEntry1() {
-        deleteRecentRegisteredEntry(at: 1)
-    }
-
-    @objc func deleteRecentRegisteredEntry2() {
-        deleteRecentRegisteredEntry(at: 2)
-    }
-
-    private func deleteRecentRegisteredEntry(at index: Int) {
-        guard index < Global.dictionary.recentRegisteredEntries.count else {
-            logger.error("直近登録エントリの削除メニューが選択されましたが、削除対象のindex \(index) が範囲外です")
-            return
-        }
-        let entry = Global.dictionary.recentRegisteredEntries[index]
-        if !Global.dictionary.deleteRecentRegisteredEntry(entry) {
-            logger.error("直近登録エントリ \(entry.yomi, privacy: .public) \(entry.word.word, privacy: .public) を削除できませんでした")
+            let entry = Global.dictionary.recentRegisteredEntries[index]
+            if !Global.dictionary.deleteRecentRegisteredEntry(entry) {
+                logger.error("直近登録エントリ \(entry.yomi, privacy: .public) \(entry.word.word, privacy: .public) を削除できませんでした")
+            }
         }
     }
 

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -315,6 +315,31 @@ class InputController: IMKInputController {
                 withTitle: String(localized: "MenuItemSaveDict", comment: "Save User Dictionary"),
                 action: #selector(saveDict), keyEquivalent: "")
         }
+        if !Global.privateMode.value && !Global.dictionary.recentRegisteredEntries.isEmpty {
+            preferenceMenu.addItem(.separator())
+            let recentRegisteredEntriesHeaderItem = NSMenuItem(title: String(localized: "MenuItemCancelRecentRegisteredEntry"),
+                                                               action: nil,
+                                                               keyEquivalent: "")
+            recentRegisteredEntriesHeaderItem.isEnabled = false
+            preferenceMenu.addItem(recentRegisteredEntriesHeaderItem)
+            for (index, entry) in Global.dictionary.recentRegisteredEntries.enumerated() {
+                // item.tagを使ってindexを指定するやり方ではactionが呼ばれないため、
+                // 引数なしselectorにし、indexごとにメソッドを分ける。
+                let action: Selector = switch index {
+                case 0:
+                    #selector(deleteRecentRegisteredEntry0)
+                case 1:
+                    #selector(deleteRecentRegisteredEntry1)
+                default:
+                    #selector(deleteRecentRegisteredEntry2)
+                }
+                let item = NSMenuItem(title: entry.menuTitle,
+                                      action: action,
+                                      keyEquivalent: "")
+                preferenceMenu.addItem(item)
+            }
+            preferenceMenu.addItem(.separator())
+        }
         let privateModeItem = NSMenuItem(title: String(localized: "MenuItemPrivateMode", comment: "Private mode"),
                                          action: #selector(togglePrivateMode),
                                          keyEquivalent: "")
@@ -400,6 +425,29 @@ class InputController: IMKInputController {
 
     @objc func saveDict() {
         Global.dictionary.save()
+    }
+
+    @objc func deleteRecentRegisteredEntry0() {
+        deleteRecentRegisteredEntry(at: 0)
+    }
+
+    @objc func deleteRecentRegisteredEntry1() {
+        deleteRecentRegisteredEntry(at: 1)
+    }
+
+    @objc func deleteRecentRegisteredEntry2() {
+        deleteRecentRegisteredEntry(at: 2)
+    }
+
+    private func deleteRecentRegisteredEntry(at index: Int) {
+        guard index < Global.dictionary.recentRegisteredEntries.count else {
+            logger.error("直近登録エントリの削除メニューが選択されましたが、削除対象のindex \(index) が範囲外です")
+            return
+        }
+        let entry = Global.dictionary.recentRegisteredEntries[index]
+        if !Global.dictionary.deleteRecentRegisteredEntry(entry) {
+            logger.error("直近登録エントリ \(entry.yomi, privacy: .public) \(entry.word.word, privacy: .public) を削除できませんでした")
+        }
     }
 
     @objc func togglePrivateMode() {

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -220,6 +220,33 @@ struct MemoryDict: DictProtocol, Sendable {
         return false
     }
 
+    /// 辞書から指定された変換候補だけを削除する。
+    ///
+    /// 送り仮名ブロックつきの同じ変換候補がある場合も、okuri が一致する候補だけを削除する。
+    @MainActor mutating func delete(yomi: String, word: Word) -> Bool {
+        if let words = entries[yomi] {
+            let filtered = words.filter { $0.word != word.word || $0.okuri != word.okuri }
+            if words.count != filtered.count {
+                if filtered.isEmpty {
+                    entries.removeValue(forKey: yomi)
+                    if yomi.isOkuriAri {
+                        if let index = okuriAriYomis.firstIndex(of: yomi) {
+                            okuriAriYomis.remove(at: index)
+                        }
+                    } else {
+                        if let index = okuriNashiYomis.firstIndex(of: yomi) {
+                            okuriNashiYomis.remove(at: index)
+                        }
+                    }
+                } else {
+                    entries[yomi] = filtered
+                }
+                return true
+            }
+        }
+        return false
+    }
+
     /**
      * 現在入力中のprefixに続く入力候補を返す。見つからなければ空配列を返す。
      *

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -236,7 +236,11 @@ final class StateMachine {
                         }
                         updateMarkedText()
                     } else {
-                        addWordToUserDict(yomi: registerState.yomi, okuri: registerState.okuri, candidate: Candidate(registerState.text))
+                        addWordToUserDict(
+                            yomi: registerState.yomi,
+                            okuri: registerState.okuri,
+                            candidate: Candidate(registerState.text),
+                            source: .registering)
                         if let last = prev.last {
                             state.specialState = .register(last, prev: prev.dropLast())
                         } else {
@@ -1718,10 +1722,17 @@ final class StateMachine {
      *   - okuri: 送り仮名として確定したひらがな。"A Ru" のように入力した場合 "る" の部分。
      *   - candidate: 追加したい変換候補
      */
-    @MainActor func addWordToUserDict(yomi: String, okuri: String?, candidate: Candidate, annotation: Annotation? = nil) {
+    @MainActor func addWordToUserDict(
+        yomi: String,
+        okuri: String?,
+        candidate: Candidate,
+        annotation: Annotation? = nil,
+        source: UserDictAddSource = .conversion
+    ) {
         if candidate.saveToUserDict {
             Global.dictionary.add(yomi: candidate.toMidashiString(yomi: yomi),
-                                  word: Word(candidate.candidateString, okuri: okuri, annotation: annotation))
+                                  word: Word(candidate.candidateString, okuri: okuri, annotation: annotation),
+                                  source: source)
         }
     }
 

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -14,11 +14,18 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
     }
 }
 
+enum UserDictAddSource {
+    /// 変換候補を選択してユーザー辞書に追加するとき
+    case conversion
+    /// 単語登録からユーザー辞書に追加するとき
+    case registering
+}
+
 /// ユーザー辞書。マイ辞書 (単語登録対象。ファイル名固定) とファイル辞書 をまとめて参照することができる。
 /// v0.22.0以降はskkservサーバーを辞書としても利用することが可能。
 ///
 /// TODO: ファイル辞書にしかない単語を削除しようとしたときにどうやってそれを記録するか。NG登録?
-@MainActor class UserDict: NSObject, DictProtocol {
+@MainActor class UserDict: NSObject {
     nonisolated static let userDictFilename = "skk-jisyo.utf8"
     nonisolated static let ignoredPathExtensions = ["tmp", "bak"]
     let dictionariesDirectoryURL: URL
@@ -41,7 +48,6 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
     /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
     private let ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>
     private var cancellables: Set<AnyCancellable> = []
-    let saveToUserDict = true
     private(set) var recentRegisteredEntries: [RecentRegisteredEntry] = []
     private let maxRecentRegisteredEntryCount = 3
 
@@ -147,7 +153,7 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
         }
         // ユーザー辞書、それ以外の辞書の順に参照する
         candidates.append(contentsOf: refer(yomi, option: option).map { word in
-            return wordToCandidate(word, original: nil, saveToUserDict: saveToUserDict)
+            return wordToCandidate(word, original: nil, saveToUserDict: true)
         })
         if findFromAllDicts {
             dicts.forEach { dict in
@@ -175,7 +181,7 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
                     return Candidate(convertedWord,
                                      annotations: annotations,
                                      original: Candidate.Original(midashi: midashi, word: word.word),
-                                     saveToUserDict: saveToUserDict)
+                                     saveToUserDict: true)
                 })
                 if findFromAllDicts {
                     dicts.forEach { dict in
@@ -300,12 +306,14 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - word: SKK辞書の変換候補。
      */
-    @MainActor func add(yomi: String, word: Word) {
+    @MainActor func add(yomi: String, word: Word, source: UserDictAddSource) {
         logger.log("ユーザー辞書に読み \(yomi, privacy: .public), 変換 \(word.word, privacy: .public) を登録する")
         if !privateMode.value {
             if let dict = userDict as? FileDict {
                 dict.add(yomi: yomi, word: word)
-                addRecentRegisteredEntry(yomi: yomi, word: word)
+                if source == .registering {
+                    addRecentRegisteredEntry(yomi: yomi, word: word)
+                }
                 savePublisher.send(())
             }
         }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -8,6 +8,16 @@ import Foundation
 /// v0.22.0以降はskkservサーバーを辞書としても利用することが可能。
 ///
 /// TODO: ファイル辞書にしかない単語を削除しようとしたときにどうやってそれを記録するか。NG登録?
+struct RecentRegisteredEntry: Hashable, Identifiable {
+    var id: Self { self }
+    let yomi: String
+    let word: Word
+
+    var menuTitle: String {
+        String(format: String(localized: "MenuItemDeleteRecentRegisteredEntry"), Entry(yomi: yomi, candidates: [word]).serialize())
+    }
+}
+
 @MainActor class UserDict: NSObject, DictProtocol {
     nonisolated static let userDictFilename = "skk-jisyo.utf8"
     nonisolated static let ignoredPathExtensions = ["tmp", "bak"]
@@ -32,6 +42,8 @@ import Foundation
     private let ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>
     private var cancellables: Set<AnyCancellable> = []
     let saveToUserDict = true
+    private(set) var recentRegisteredEntries: [RecentRegisteredEntry] = []
+    private let maxRecentRegisteredEntryCount = 3
 
     // MARK: NSFilePresenter
     nonisolated let presentedItemURL: URL?
@@ -293,6 +305,7 @@ import Foundation
         if !privateMode.value {
             if let dict = userDict as? FileDict {
                 dict.add(yomi: yomi, word: word)
+                addRecentRegisteredEntry(yomi: yomi, word: word)
                 savePublisher.send(())
             }
         }
@@ -320,9 +333,32 @@ import Foundation
             return true
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
+                logger.log("ユーザー辞書からエントリ \(Entry(yomi: yomi, candidates: [Word(word)]).serialize(), privacy: .public) を削除しました")
                 savePublisher.send(())
                 return true
             }
+        }
+        return false
+    }
+
+    /** 変換文字列だけでなく okuri も一致する候補だけを削除する。 */
+    @MainActor func delete(yomi: String, word: Word) -> Bool {
+        if privateMode.value {
+            return true
+        } else if let dict = userDict as? FileDict {
+            if dict.delete(yomi: yomi, word: word) {
+                logger.log("ユーザー辞書からエントリ \(Entry(yomi: yomi, candidates: [word]).serialize(), privacy: .public) を削除しました")
+                savePublisher.send(())
+                return true
+            }
+        }
+        return false
+    }
+
+    @MainActor func deleteRecentRegisteredEntry(_ entry: RecentRegisteredEntry) -> Bool {
+        if delete(yomi: entry.yomi, word: entry.word) {
+            removeRecentRegisteredEntry(entry)
+            return true
         }
         return false
     }
@@ -424,6 +460,19 @@ import Foundation
         } else {
             return false
         }
+    }
+
+    private func addRecentRegisteredEntry(yomi: String, word: Word) {
+        let entry = RecentRegisteredEntry(yomi: yomi, word: word)
+        recentRegisteredEntries.removeAll { $0 == entry }
+        recentRegisteredEntries.insert(entry, at: 0)
+        if recentRegisteredEntries.count > maxRecentRegisteredEntryCount {
+            recentRegisteredEntries.removeLast(recentRegisteredEntries.count - maxRecentRegisteredEntryCount)
+        }
+    }
+
+    private func removeRecentRegisteredEntry(_ entry: RecentRegisteredEntry) {
+        recentRegisteredEntries.removeAll { $0 == entry }
     }
 
     private func wordToCandidate(_ word: Word, original: Candidate.Original?, saveToUserDict: Bool) -> Candidate {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -4,10 +4,6 @@
 import Combine
 import Foundation
 
-/// ユーザー辞書。マイ辞書 (単語登録対象。ファイル名固定) とファイル辞書 をまとめて参照することができる。
-/// v0.22.0以降はskkservサーバーを辞書としても利用することが可能。
-///
-/// TODO: ファイル辞書にしかない単語を削除しようとしたときにどうやってそれを記録するか。NG登録?
 struct RecentRegisteredEntry: Hashable, Identifiable {
     var id: Self { self }
     let yomi: String
@@ -18,6 +14,10 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
     }
 }
 
+/// ユーザー辞書。マイ辞書 (単語登録対象。ファイル名固定) とファイル辞書 をまとめて参照することができる。
+/// v0.22.0以降はskkservサーバーを辞書としても利用することが可能。
+///
+/// TODO: ファイル辞書にしかない単語を削除しようとしたときにどうやってそれを記録するか。NG登録?
 @MainActor class UserDict: NSObject, DictProtocol {
     nonisolated static let userDictFilename = "skk-jisyo.utf8"
     nonisolated static let ignoredPathExtensions = ["tmp", "bak"]

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -181,6 +181,8 @@
 "Follow Romaji-Kana Rule" = "Follow Romaji-Kana Rule";
 "EnterKey" = "Enter \"%@\"";
 "DuplicatedKeyBindingName" = "Copy of %@";
+"MenuItemCancelRecentRegisteredEntry" = "Cancel Recent Dictionary Registrations";
+"MenuItemDeleteRecentRegisteredEntry" = "Delete %@";
 
 "LocaleJa_Jp" = "Japan";
 "LocaleEn_Us" = "US";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -6,6 +6,8 @@
 "MenuItemTreadFirstCharacterAsMarkedText" = "Treat First Char as Marked for Workaround";
 "MenuItemShowMarkerWhenEmpty" = "Show Marker When Empty for Workaround";
 "MenuItemSKKServ" = "Use SKKServ";
+"MenuItemCancelRecentRegisteredEntry" = "Cancel Recent Dictionary Registrations";
+"MenuItemDeleteRecentRegisteredEntry" = "Delete %@";
 "SettingsNameGeneral" = "General";
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameCandidateWindow" = "Candidates Panel";
@@ -181,8 +183,6 @@
 "Follow Romaji-Kana Rule" = "Follow Romaji-Kana Rule";
 "EnterKey" = "Enter \"%@\"";
 "DuplicatedKeyBindingName" = "Copy of %@";
-"MenuItemCancelRecentRegisteredEntry" = "Cancel Recent Dictionary Registrations";
-"MenuItemDeleteRecentRegisteredEntry" = "Delete %@";
 
 "LocaleJa_Jp" = "Japan";
 "LocaleEn_Us" = "US";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -6,6 +6,8 @@
 "MenuItemTreadFirstCharacterAsMarkedText" = "1文字目を未確定扱い (互換性)";
 "MenuItemShowMarkerWhenEmpty" = "空のときには▽▼を表示 (互換性)";
 "MenuItemSKKServ" = "SKKServを利用する";
+"MenuItemCancelRecentRegisteredEntry" = "直近の辞書登録をキャンセルする";
+"MenuItemDeleteRecentRegisteredEntry" = "%@ を削除する";
 "SettingsNameGeneral" = "一般";
 "SettingsNameDictionaries" = "辞書";
 "SettingsNameCandidateWindow" = "変換候補パネル";
@@ -181,8 +183,6 @@
 "Follow Romaji-Kana Rule" = "ローマ字かな変換ルールに従う";
 "EnterKey" = "\"%@\" を入力";
 "DuplicatedKeyBindingName" = "%@ のコピー";
-"MenuItemCancelRecentRegisteredEntry" = "直近の辞書登録をキャンセルする";
-"MenuItemDeleteRecentRegisteredEntry" = "%@ を削除する";
 
 "LocaleJa_Jp" = "日本";
 "LocaleEn_Us" = "アメリカ合衆国";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -181,6 +181,8 @@
 "Follow Romaji-Kana Rule" = "ローマ字かな変換ルールに従う";
 "EnterKey" = "\"%@\" を入力";
 "DuplicatedKeyBindingName" = "%@ のコピー";
+"MenuItemCancelRecentRegisteredEntry" = "直近の辞書登録をキャンセルする";
+"MenuItemDeleteRecentRegisteredEntry" = "%@ を削除する";
 
 "LocaleJa_Jp" = "日本";
 "LocaleEn_Us" = "アメリカ合衆国";

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -190,6 +190,22 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.okuriAriYomis, [])
     }
 
+    @MainActor func testDeleteExactCandidate() throws {
+        var dict = MemoryDict(entries: ["あr": [Word("有", okuri: "る"), Word("有", okuri: "り"), Word("有")]], readonly: false)
+        XCTAssertTrue(dict.delete(yomi: "あr", word: Word("有", okuri: "る")))
+        XCTAssertEqual(dict.refer("あr", option: nil), [Word("有", okuri: "り"), Word("有")])
+        XCTAssertEqual(dict.okuriAriYomis, ["あr"])
+        XCTAssertFalse(dict.delete(yomi: "あr", word: Word("有", okuri: "る")), "削除済")
+
+        XCTAssertTrue(dict.delete(yomi: "あr", word: Word("有")))
+        XCTAssertEqual(dict.refer("あr", option: nil), [Word("有", okuri: "り")])
+        XCTAssertEqual(dict.okuriAriYomis, ["あr"])
+
+        XCTAssertTrue(dict.delete(yomi: "あr", word: Word("有", okuri: "り")))
+        XCTAssertEqual(dict.refer("あr", option: nil), [])
+        XCTAssertEqual(dict.okuriAriYomis, [])
+    }
+
     @MainActor func testFindCompletions() {
         var dict = MemoryDict(entries: [:], readonly: false)
         XCTAssertEqual(dict.findCompletions(prefix: ""), [], "辞書が空だと空")

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -4248,6 +4248,18 @@ final class StateMachineTests: XCTestCase {
         XCTAssertEqual(Global.dictionary.refer("いt"), [Word("言", okuri: "った", annotation: nil)])
     }
 
+    @MainActor func testAddWordToUserDictRecentRegisteredEntry() {
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let recentRegisteredEntryCount = Global.dictionary.recentRegisteredEntries.count
+
+        stateMachine.addWordToUserDict(yomi: "あ", okuri: nil, candidate: Candidate("亜"))
+        XCTAssertEqual(Global.dictionary.recentRegisteredEntries.count, recentRegisteredEntryCount)
+
+        stateMachine.addWordToUserDict(yomi: "い", okuri: nil, candidate: Candidate("伊"), source: .registering)
+        XCTAssertEqual(Global.dictionary.recentRegisteredEntries.count, recentRegisteredEntryCount + 1)
+        XCTAssertEqual(Global.dictionary.recentRegisteredEntries.first, RecentRegisteredEntry(yomi: "い", word: Word("伊")))
+    }
+
     // Ctrl-jを押した
     var hiraganaAction: Action {
         Action(keyBind: .hiragana, event: generateNSEvent(character: "j", characterIgnoringModifiers: "j", modifierFlags: .control))

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -69,7 +69,7 @@ import Combine
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["位"])
         privateMode.send(true)
         // addのテスト
-        userDict.add(yomi: "い", word: word)
+        userDict.add(yomi: "い", word: word, source: .conversion)
         // referは変化しない
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["位"])
         // deleteのテスト


### PR DESCRIPTION
入力中に打ち間違いなどで想定外の辞書登録に入ってしまって、そのまま勢いで適当な文字とリターンを押してしまい、意図しない辞書登録を行ってしまうことがあります。
これ自体は完全に私の操作ミスなのですが、辞書からゴミエントリを削除するために一度ファイルへの保存とエディタでの手動削除をしていて、これを楽に出来ないかということでメニューに直近の辞書登録をキャンセルする項目を追加するPRとなります。
（もちろん、辞書登録中にエントリ削除は出来るのですが、上記のような勢いで辞書登録した場合はどのwordで登録されているのかも分からなくてですね……）

<img width="273" height="564" alt="Screenshot 2026-05-31 at 23 33 33" src="https://github.com/user-attachments/assets/f356645a-9bd6-4b3c-a3aa-cdb43a07738b" />
