### PR TITLE
変換候補・補完候補の数を設定可能にする

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -51,6 +51,8 @@ import Combine
     static var punctuation: Punctuation = .default
     /// ▽と▼を表示するか
     static var showMarkedTextMarker: Bool = true
+    /// 変換候補パネルに一度に表示する変換候補の数
+    static var displayCandidateCount: Int = 9
     /// 変換候補パネルの表示方向
     static var candidateListDirection = CurrentValueSubject<CandidateListDirection, Never>(.vertical)
     /// ピリオドで補完候補の最初の要素で確定するか

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -237,7 +237,7 @@ class InputController: IMKInputController {
                         self.stateMachine.completion = nil
                     } else {
                         // 先頭1ページ分だけ変換候補パネルに表示する。
-                        Global.completionPanel.viewModel.completion = .candidates(Array(candidates.prefix(9)))
+                        Global.completionPanel.viewModel.completion = .candidates(Array(candidates.prefix(Global.displayCandidateCount)))
                         if cursorPosition != .zero {
                             Global.completionPanel.show(at: cursorPosition, windowLevel: windowLevel(for: textInput))
                         }

--- a/macSKK/Settings/GeneralView.swift
+++ b/macSKK/Settings/GeneralView.swift
@@ -23,6 +23,11 @@ struct GeneralView: View {
                         Text(listDirection.description).tag(listDirection)
                     }
                 }
+                Picker("Number of candidates in panel", selection: $settingsViewModel.displayCandidateCount) {
+                    ForEach(1..<10) { count in
+                        Text("\(count)").tag(count)
+                    }
+                }
                 Toggle(isOn: $settingsViewModel.showAnnotation, label: {
                     Text("Show Annotation")
                 })

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -187,6 +187,8 @@ final class SettingsViewModel: ObservableObject {
     @Published var showAnnotation: Bool
     /// インラインで表示する変換候補の数。
     @Published var inlineCandidateCount: Int
+    /// 変換候補パネルに一度に表示する変換候補の数
+    @Published var displayCandidateCount: Int
     /// 変換候補のフォントサイズ
     @Published var candidatesFontSize: Int
     /// 変換候補のフォントファミリー名。空文字列のときはSystem Font
@@ -276,6 +278,7 @@ final class SettingsViewModel: ObservableObject {
         }
         showAnnotation = UserDefaults.app.bool(forKey: UserDefaultsKeys.showAnnotation)
         inlineCandidateCount = UserDefaults.app.integer(forKey: UserDefaultsKeys.inlineCandidateCount)
+        displayCandidateCount = UserDefaults.app.integer(forKey: UserDefaultsKeys.displayCandidateCount)
         candidatesFontSize = UserDefaults.app.integer(forKey: UserDefaultsKeys.candidatesFontSize)
         candidatesFontFamily = UserDefaults.app.string(forKey: UserDefaultsKeys.candidatesFontFamily) ?? ""
         overridesCandidatesBackgroundColor = UserDefaults.app.bool(forKey: UserDefaultsKeys.overridesCandidatesBackgroundColor)
@@ -407,6 +410,7 @@ final class SettingsViewModel: ObservableObject {
         Global.ignoreLeadingSpacesWhenRegistering = ignoreLeadingSpacesWhenRegistering
         Global.backToSelectingFromRegistering = backToSelectingFromRegistering
         Global.yomiCompletionByTabInRegistering = yomiCompletionByTabInRegistering
+        Global.displayCandidateCount = displayCandidateCount
         Global.inputModePanel.updateColorSets(inputModeColorSets)
         Global.showMarkedTextMarker = showMarkedTextMarker
 
@@ -599,6 +603,12 @@ final class SettingsViewModel: ObservableObject {
             UserDefaults.app.set(inlineCandidateCount, forKey: UserDefaultsKeys.inlineCandidateCount)
             NotificationCenter.default.post(name: notificationNameInlineCandidateCount, object: inlineCandidateCount)
             logger.log("インラインで表示する変換候補の数を\(inlineCandidateCount)個に変更しました")
+        }.store(in: &cancellables)
+
+        $displayCandidateCount.dropFirst().sink { displayCandidateCount in
+            UserDefaults.app.set(displayCandidateCount, forKey: UserDefaultsKeys.displayCandidateCount)
+            Global.displayCandidateCount = displayCandidateCount
+            logger.log("変換候補パネルに一度に表示する変換候補の数を\(displayCandidateCount)個に変更しました")
         }.store(in: &cancellables)
 
         $candidatesFontFamily.dropFirst().sink { candidatesFontFamily in
@@ -891,6 +901,7 @@ final class SettingsViewModel: ObservableObject {
         selectedInputSourceId = InputSource.defaultInputSourceId
         showAnnotation = true
         inlineCandidateCount = 3
+        displayCandidateCount = 9
         workaroundApplications = []
         candidatesFontSize = 13
         candidatesFontFamily = ""

--- a/macSKK/Settings/UserDefaultsKeys.swift
+++ b/macSKK/Settings/UserDefaultsKeys.swift
@@ -80,4 +80,6 @@ struct UserDefaultsKeys {
     static let skkservAutoDisableThreshold = "skkservAutoDisableThreshold"
     // 単語登録中にタブキーで読みを補完する
     static let yomiCompletionByTabInRegistering = "yomiCompletionByTabInRegistering"
+    // 変換候補パネルに一度に表示する変換候補の数
+    static let displayCandidateCount = "displayCandidateCount"
 }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1599,7 +1599,7 @@ final class StateMachine {
     ///     - 空文字列で確定する
     ///   - 状態がUnregister (ユーザー辞書から削除するか質問中)
     ///     - 空文字列で確定する
-    func commitComposition() {
+    @MainActor func commitComposition() {
         if state.specialState != nil {
             state.inputMethod = .normal
             state.specialState = nil
@@ -1664,7 +1664,7 @@ final class StateMachine {
     }
 
     /// 現在の変換候補選択状態をcandidateEventSubject.sendする
-    private func updateCandidates(selecting: SelectingState?) {
+    @MainActor private func updateCandidates(selecting: SelectingState?) {
         if let selecting {
             if selecting.candidateIndex < inlineCandidateCount {
                 candidateEventSubject.send(

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -52,11 +52,8 @@ final class StateMachine {
     var completionSetAt: Date? = nil
     let completionConfirmationTimeLimit: TimeInterval = 0.5
 
-    // TODO: displayCandidateCountを環境設定にするかも
     /// 変換候補パネルを表示するまで表示する変換候補の数
     var inlineCandidateCount: Int
-    /// 変換候補パネルに一度に表示する変換候補の数
-    let displayCandidateCount = 9
     /// 1文字で確定するローマ字やq/lなどのモード変更などで未確定文字列を一度表示するワークグラウンドが有効かどうか
     /// xterm.jsを利用しているVSCodeのターミナルやHyperなどaiueoで直接入力されてしまう環境向け
     var enableMarkedTextWorkaround: Bool
@@ -1340,7 +1337,7 @@ final class StateMachine {
                 if selecting.candidateIndex >= inlineCandidateCount {
                     // 前ページの先頭
                     diff =
-                        -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
+                        -((selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount) - Global.displayCandidateCount
                 } else {
                     diff = -1
                 }
@@ -1349,7 +1346,7 @@ final class StateMachine {
                 if selecting.candidateIndex >= inlineCandidateCount {
                     // 前ページの先頭
                     let diff =
-                        -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
+                        -((selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount) - Global.displayCandidateCount
                     return handleSelectingPrevious(diff: diff, selecting: selecting)
                 } else {
                     // インライン選択中は変換候補の末尾を一字消して確定
@@ -1420,7 +1417,7 @@ final class StateMachine {
             }
         case .startOfLine:
             // 現ページの先頭
-            let diff = -(selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
+            let diff = -(selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount
             if diff < 0 {
                 let newSelectingState = selecting.addCandidateIndex(diff: diff)
                 state.inputMethod = .selecting(newSelectingState)
@@ -1431,7 +1428,7 @@ final class StateMachine {
         case .endOfLine:
             // 現ページの末尾
             let diff = min(
-                displayCandidateCount - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount,
+                Global.displayCandidateCount - (selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount,
                 selecting.candidates.count - selecting.candidateIndex - 1
             )
             if diff > 0 {
@@ -1479,8 +1476,8 @@ final class StateMachine {
 
         if let input = action.event.charactersIgnoringModifiers {
             if selecting.candidateIndex >= inlineCandidateCount {
-                if let first = input.lowercased().first, let index = Global.selectCandidateKeys.firstIndex(of: first), index < displayCandidateCount {
-                    let diff = index - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
+                if let first = input.lowercased().first, let index = Global.selectCandidateKeys.firstIndex(of: first), index < Global.displayCandidateCount {
+                    let diff = index - (selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount
                     if selecting.candidateIndex + diff < selecting.candidates.count {
                         let newSelecting = selecting.addCandidateIndex(diff: diff)
                         fixCurrentSelect(selecting: newSelecting)
@@ -1562,7 +1559,7 @@ final class StateMachine {
     @MainActor private func handleSelectingPreviousPage(selecting: SelectingState) -> Bool {
         if selecting.candidateIndex >= inlineCandidateCount {
             // 前ページの先頭
-            let diff = -((selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount) - displayCandidateCount
+            let diff = -((selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount) - Global.displayCandidateCount
             return handleSelectingPrevious(diff: diff, selecting: selecting)
         } else {
             return handleSelectingPrevious(diff: -1, selecting: selecting)
@@ -1575,7 +1572,7 @@ final class StateMachine {
      */
     @MainActor private func handleSelectingNextPage(_ action: Action, selecting: SelectingState, specialState: SpecialState?) -> Bool {
         if selecting.candidateIndex >= inlineCandidateCount {
-            let diff = displayCandidateCount - (selecting.candidateIndex - inlineCandidateCount) % displayCandidateCount
+            let diff = Global.displayCandidateCount - (selecting.candidateIndex - inlineCandidateCount) % Global.displayCandidateCount
             return handleSelectingNext(action, diff: diff, selecting: selecting, specialState: specialState)
         } else {
             return handleSelectingNext(action, diff: 1, selecting: selecting, specialState: specialState)
@@ -1675,10 +1672,10 @@ final class StateMachine {
                                selected: selecting.candidates[selecting.candidateIndex]))
             } else {
                 var start = selecting.candidateIndex - inlineCandidateCount
-                let currentPage = start / displayCandidateCount
-                let totalPageCount = (selecting.candidates.count - inlineCandidateCount - 1) / displayCandidateCount + 1
-                start = start - start % displayCandidateCount + inlineCandidateCount
-                let candidates = selecting.candidates[start..<min(start + displayCandidateCount, selecting.candidates.count)]
+                let currentPage = start / Global.displayCandidateCount
+                let totalPageCount = (selecting.candidates.count - inlineCandidateCount - 1) / Global.displayCandidateCount + 1
+                start = start - start % Global.displayCandidateCount + inlineCandidateCount
+                let candidates = selecting.candidates[start..<min(start + Global.displayCandidateCount, selecting.candidates.count)]
                 candidateEventSubject.send(
                     Candidates(page: Candidates.Page(words: Array(candidates), current: currentPage, total: totalPageCount),
                                selected: selecting.candidates[selecting.candidateIndex]))

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -75,6 +75,7 @@
 "Keys of selecting candidates" = "Keys of selecting candidates";
 "Copy" = "Copy";
 "Number of inline candidates" = "Number of inline candidates";
+"Number of candidates in panel" = "Number of candidates in panel";
 "Backspace in selecting candidates" = "Backspace in selecting candidates";
 "Behavior of Comma" = "Behavior of Comma";
 "Behavior of Period" = "Behavior of Period";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -75,6 +75,7 @@
 "Keys of selecting candidates" = "変換候補の決定に使用するキー";
 "Copy" = "コピー";
 "Number of inline candidates" = "インラインで表示する変換候補の数";
+"Number of candidates in panel" = "変換候補パネルに表示する変換候補の数";
 "Backspace in selecting candidates" = "変換候補選択中のバックスペース";
 "Behavior of Comma" = "カンマの挙動";
 "Behavior of Period" = "ピリオドの挙動";

--- a/macSKK/macSKKApp.swift
+++ b/macSKK/macSKKApp.swift
@@ -270,6 +270,7 @@ struct macSKKApp: App {
                 }
             ),
             UserDefaultsKeys.skkservAutoDisableThreshold: 3,
+            UserDefaultsKeys.displayCandidateCount: 9,
         ])
     }
 

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -25,6 +25,7 @@ final class StateMachineTests: XCTestCase {
         Global.ignoreLeadingSpacesWhenRegistering = true
         Global.backToSelectingFromRegistering = false
         Global.yomiCompletionByTabInRegistering = false
+        Global.displayCandidateCount = 9
     }
 
     @MainActor func testHandleNormalSimple() {
@@ -3724,6 +3725,38 @@ final class StateMachineTests: XCTestCase {
         XCTAssertTrue(stateMachine.handle(leftKeyAction)) // 前ページ移動
         Global.selectingBackspace = .dropLastInlineOnly
         XCTAssertTrue(stateMachine.handle(backspaceAction)) // selectingBackspaceがdropLastAlwaysじゃないときは前ページ遷移として機能する
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor func testHandleSelectingDisplayCandidateCount() {
+        Global.dictionary.setEntries(["あ": "123456789".map { Word(String($0)) }])
+        Global.displayCandidateCount = 3
+
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.candidateEvent.collect(5).sink { events in
+            // インライン表示中 (page == nil)
+            XCTAssertNil(events[0]?.page)
+            XCTAssertNil(events[1]?.page)
+            XCTAssertNil(events[2]?.page)
+            // パネル表示 page 0: "4","5","6"
+            XCTAssertEqual(events[3]?.selected.word, "4")
+            XCTAssertEqual(events[3]?.page?.words.map(\.word), ["4", "5", "6"])
+            XCTAssertEqual(events[3]?.page?.current, 0)
+            XCTAssertEqual(events[3]?.page?.total, 2)
+            // スペースで次ページ: page 1: "7","8","9"
+            XCTAssertEqual(events[4]?.selected.word, "7")
+            XCTAssertEqual(events[4]?.page?.words.map(\.word), ["7", "8", "9"])
+            XCTAssertEqual(events[4]?.page?.current, 1)
+            XCTAssertEqual(events[4]?.page?.total, 2)
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "a", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
         wait(for: [expectation], timeout: 1.0)
     }
 


### PR DESCRIPTION
#471 「設定」→「一般」→「変換候補パネルに表示する変換候補の数」から変換候補・補完候補の数を選択可能にします。(1〜9)

https://github.com/user-attachments/assets/f79442a9-30e2-420e-a15f-f6a381fc9747

