### PR TITLE
キーボード操作での削除時に入力メニューに残る問題などを修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -315,16 +315,16 @@ class InputController: IMKInputController {
                 withTitle: String(localized: "MenuItemSaveDict", comment: "Save User Dictionary"),
                 action: #selector(saveDict), keyEquivalent: "")
         }
-        if !Global.privateMode.value && !Global.dictionary.recentRegisteredEntries.isEmpty {
+        if !Global.privateMode.value && !Global.dictionary.recentRegisteredCandidates.isEmpty {
             preferenceMenu.addItem(.separator())
-            let recentRegisteredEntriesHeaderItem = NSMenuItem(title: String(localized: "MenuItemUndoRecentRegisteredEntry"),
-                                                               action: nil,
-                                                               keyEquivalent: "")
-            recentRegisteredEntriesHeaderItem.isEnabled = false
-            preferenceMenu.addItem(recentRegisteredEntriesHeaderItem)
-            for (index, entry) in Global.dictionary.recentRegisteredEntries.enumerated() {
+            let recentRegisteredCandidatesHeaderItem = NSMenuItem(title: String(localized: "MenuItemUndoRecentRegisteredCandidate"),
+                                                                   action: nil,
+                                                                   keyEquivalent: "")
+            recentRegisteredCandidatesHeaderItem.isEnabled = false
+            preferenceMenu.addItem(recentRegisteredCandidatesHeaderItem)
+            for (index, entry) in Global.dictionary.recentRegisteredCandidates.enumerated() {
                 let item = NSMenuItem(title: entry.menuTitle,
-                                      action: #selector(deleteRecentRegisteredEntry),
+                                      action: #selector(deleteRecentRegisteredCandidate),
                                       keyEquivalent: "")
                 item.tag = index
                 preferenceMenu.addItem(item)
@@ -418,17 +418,17 @@ class InputController: IMKInputController {
         Global.dictionary.save()
     }
 
-    @objc func deleteRecentRegisteredEntry(_ sender: Any?) {
+    @objc func deleteRecentRegisteredCandidate(_ sender: Any?) {
         // IMKInputControllerでNSMenuItemにアクセスするにはkIMKCommandMenuItemNameを使う必要がある
         if let sender = sender as? [String: Any],
            let menuItem = sender[kIMKCommandMenuItemName] as? NSMenuItem {
             let index = menuItem.tag
-            guard index < Global.dictionary.recentRegisteredEntries.count else {
+            guard index < Global.dictionary.recentRegisteredCandidates.count else {
                 logger.error("直近登録エントリの削除メニューが選択されましたが、削除対象のindex \(index) が範囲外です")
                 return
             }
 
-            let entry = Global.dictionary.recentRegisteredEntries[index]
+            let entry = Global.dictionary.recentRegisteredCandidates[index]
             if !Global.dictionary.delete(yomi: entry.yomi, word: entry.word) {
                 logger.error("直近登録エントリ \(entry.yomi, privacy: .public) \(entry.word.word, privacy: .public) を削除できませんでした")
             }

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -317,7 +317,7 @@ class InputController: IMKInputController {
         }
         if !Global.privateMode.value && !Global.dictionary.recentRegisteredEntries.isEmpty {
             preferenceMenu.addItem(.separator())
-            let recentRegisteredEntriesHeaderItem = NSMenuItem(title: String(localized: "MenuItemCancelRecentRegisteredEntry"),
+            let recentRegisteredEntriesHeaderItem = NSMenuItem(title: String(localized: "MenuItemUndoRecentRegisteredEntry"),
                                                                action: nil,
                                                                keyEquivalent: "")
             recentRegisteredEntriesHeaderItem.isEnabled = false
@@ -429,7 +429,7 @@ class InputController: IMKInputController {
             }
 
             let entry = Global.dictionary.recentRegisteredEntries[index]
-            if !Global.dictionary.deleteRecentRegisteredEntry(entry) {
+            if !Global.dictionary.delete(yomi: entry.yomi, word: entry.word) {
                 logger.error("直近登録エントリ \(entry.yomi, privacy: .public) \(entry.word.word, privacy: .public) を削除できませんでした")
             }
         }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -10,7 +10,7 @@ struct RecentRegisteredEntry: Hashable, Identifiable {
     let word: Word
 
     var menuTitle: String {
-        String(format: String(localized: "MenuItemDeleteRecentRegisteredEntry"), Entry(yomi: yomi, candidates: [word]).serialize())
+        Entry(yomi: yomi, candidates: [word]).serialize()
     }
 }
 
@@ -305,6 +305,7 @@ enum UserDictAddSource {
      * - Parameters:
      *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
      *   - word: SKK辞書の変換候補。
+     *   - source: 追加の呼び元。単語登録からの追加の場合のみ直近の辞書登録履歴に記録する。
      */
     @MainActor func add(yomi: String, word: Word, source: UserDictAddSource) {
         logger.log("ユーザー辞書に読み \(yomi, privacy: .public), 変換 \(word.word, privacy: .public) を登録する")
@@ -342,6 +343,7 @@ enum UserDictAddSource {
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 logger.log("ユーザー辞書からエントリ \(Entry(yomi: yomi, candidates: [Word(word)]).serialize(), privacy: .public) を削除しました")
+                recentRegisteredEntries.removeAll { $0.yomi == yomi && $0.word.word == word }
                 savePublisher.send(())
                 return true
             }
@@ -356,17 +358,10 @@ enum UserDictAddSource {
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 logger.log("ユーザー辞書からエントリ \(Entry(yomi: yomi, candidates: [word]).serialize(), privacy: .public) を削除しました")
+                recentRegisteredEntries.removeAll { $0.yomi == yomi && $0.word == word }
                 savePublisher.send(())
                 return true
             }
-        }
-        return false
-    }
-
-    @MainActor func deleteRecentRegisteredEntry(_ entry: RecentRegisteredEntry) -> Bool {
-        if delete(yomi: entry.yomi, word: entry.word) {
-            removeRecentRegisteredEntry(entry)
-            return true
         }
         return false
     }
@@ -477,10 +472,6 @@ enum UserDictAddSource {
         if recentRegisteredEntries.count > maxRecentRegisteredEntryCount {
             recentRegisteredEntries.removeLast(recentRegisteredEntries.count - maxRecentRegisteredEntryCount)
         }
-    }
-
-    private func removeRecentRegisteredEntry(_ entry: RecentRegisteredEntry) {
-        recentRegisteredEntries.removeAll { $0 == entry }
     }
 
     private func wordToCandidate(_ word: Word, original: Candidate.Original?, saveToUserDict: Bool) -> Candidate {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -4,7 +4,8 @@
 import Combine
 import Foundation
 
-struct RecentRegisteredEntry: Hashable, Identifiable {
+/// 最近登録した変換候補
+struct RecentRegisteredCandidate: Hashable, Identifiable {
     var id: Self { self }
     let yomi: String
     let word: Word
@@ -48,8 +49,8 @@ enum UserDictAddSource {
     /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
     private let ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>
     private var cancellables: Set<AnyCancellable> = []
-    private(set) var recentRegisteredEntries: [RecentRegisteredEntry] = []
-    private let maxRecentRegisteredEntryCount = 3
+    private(set) var recentRegisteredCandidates: [RecentRegisteredCandidate] = []
+    private let maxRecentRegisteredCandidateCount = 3
 
     // MARK: NSFilePresenter
     nonisolated let presentedItemURL: URL?
@@ -313,7 +314,7 @@ enum UserDictAddSource {
             if let dict = userDict as? FileDict {
                 dict.add(yomi: yomi, word: word)
                 if source == .registering {
-                    addRecentRegisteredEntry(yomi: yomi, word: word)
+                    addRecentRegisteredCandidate(yomi: yomi, word: word)
                 }
                 savePublisher.send(())
             }
@@ -343,7 +344,7 @@ enum UserDictAddSource {
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 logger.log("ユーザー辞書からエントリ \(Entry(yomi: yomi, candidates: [Word(word)]).serialize(), privacy: .public) を削除しました")
-                recentRegisteredEntries.removeAll { $0.yomi == yomi && $0.word.word == word }
+                recentRegisteredCandidates.removeAll { $0.yomi == yomi && $0.word.word == word }
                 savePublisher.send(())
                 return true
             }
@@ -358,7 +359,7 @@ enum UserDictAddSource {
         } else if let dict = userDict as? FileDict {
             if dict.delete(yomi: yomi, word: word) {
                 logger.log("ユーザー辞書からエントリ \(Entry(yomi: yomi, candidates: [word]).serialize(), privacy: .public) を削除しました")
-                recentRegisteredEntries.removeAll { $0.yomi == yomi && $0.word == word }
+                recentRegisteredCandidates.removeAll { $0.yomi == yomi && $0.word == word }
                 savePublisher.send(())
                 return true
             }
@@ -465,12 +466,12 @@ enum UserDictAddSource {
         }
     }
 
-    private func addRecentRegisteredEntry(yomi: String, word: Word) {
-        let entry = RecentRegisteredEntry(yomi: yomi, word: word)
-        recentRegisteredEntries.removeAll { $0 == entry }
-        recentRegisteredEntries.insert(entry, at: 0)
-        if recentRegisteredEntries.count > maxRecentRegisteredEntryCount {
-            recentRegisteredEntries.removeLast(recentRegisteredEntries.count - maxRecentRegisteredEntryCount)
+    private func addRecentRegisteredCandidate(yomi: String, word: Word) {
+        let entry = RecentRegisteredCandidate(yomi: yomi, word: word)
+        recentRegisteredCandidates.removeAll { $0 == entry }
+        recentRegisteredCandidates.insert(entry, at: 0)
+        if recentRegisteredCandidates.count > maxRecentRegisteredCandidateCount {
+            recentRegisteredCandidates.removeLast(recentRegisteredCandidates.count - maxRecentRegisteredCandidateCount)
         }
     }
 

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 "MenuItemTreadFirstCharacterAsMarkedText" = "Treat First Char as Marked for Workaround";
 "MenuItemShowMarkerWhenEmpty" = "Show Marker When Empty for Workaround";
 "MenuItemSKKServ" = "Use SKKServ";
-"MenuItemUndoRecentRegisteredEntry" = "Undo Recent Dictionary Registrations";
+"MenuItemUndoRecentRegisteredCandidate" = "Undo Recent Dictionary Registrations";
 "SettingsNameGeneral" = "General";
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameCandidateWindow" = "Candidates Panel";

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -6,8 +6,7 @@
 "MenuItemTreadFirstCharacterAsMarkedText" = "Treat First Char as Marked for Workaround";
 "MenuItemShowMarkerWhenEmpty" = "Show Marker When Empty for Workaround";
 "MenuItemSKKServ" = "Use SKKServ";
-"MenuItemCancelRecentRegisteredEntry" = "Cancel Recent Dictionary Registrations";
-"MenuItemDeleteRecentRegisteredEntry" = "Delete %@";
+"MenuItemUndoRecentRegisteredEntry" = "Undo Recent Dictionary Registrations";
 "SettingsNameGeneral" = "General";
 "SettingsNameDictionaries" = "Dictionaries";
 "SettingsNameCandidateWindow" = "Candidates Panel";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 "MenuItemTreadFirstCharacterAsMarkedText" = "1文字目を未確定扱い (互換性)";
 "MenuItemShowMarkerWhenEmpty" = "空のときには▽▼を表示 (互換性)";
 "MenuItemSKKServ" = "SKKServを利用する";
-"MenuItemUndoRecentRegisteredEntry" = "直近の辞書登録を取り消す";
+"MenuItemUndoRecentRegisteredCandidate" = "直近の辞書登録を取り消す";
 "SettingsNameGeneral" = "一般";
 "SettingsNameDictionaries" = "辞書";
 "SettingsNameCandidateWindow" = "変換候補パネル";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -6,8 +6,7 @@
 "MenuItemTreadFirstCharacterAsMarkedText" = "1文字目を未確定扱い (互換性)";
 "MenuItemShowMarkerWhenEmpty" = "空のときには▽▼を表示 (互換性)";
 "MenuItemSKKServ" = "SKKServを利用する";
-"MenuItemCancelRecentRegisteredEntry" = "直近の辞書登録をキャンセルする";
-"MenuItemDeleteRecentRegisteredEntry" = "%@ を削除する";
+"MenuItemUndoRecentRegisteredEntry" = "直近の辞書登録を取り消す";
 "SettingsNameGeneral" = "一般";
 "SettingsNameDictionaries" = "辞書";
 "SettingsNameCandidateWindow" = "変換候補パネル";

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -4248,16 +4248,16 @@ final class StateMachineTests: XCTestCase {
         XCTAssertEqual(Global.dictionary.refer("いt"), [Word("言", okuri: "った", annotation: nil)])
     }
 
-    @MainActor func testAddWordToUserDictRecentRegisteredEntry() {
+    @MainActor func testAddWordToUserDictRecentRegisteredCandidate() {
         let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
-        let recentRegisteredEntryCount = Global.dictionary.recentRegisteredEntries.count
+        let recentRegisteredCandidateCount = Global.dictionary.recentRegisteredCandidates.count
 
         stateMachine.addWordToUserDict(yomi: "あ", okuri: nil, candidate: Candidate("亜"))
-        XCTAssertEqual(Global.dictionary.recentRegisteredEntries.count, recentRegisteredEntryCount)
+        XCTAssertEqual(Global.dictionary.recentRegisteredCandidates.count, recentRegisteredCandidateCount)
 
         stateMachine.addWordToUserDict(yomi: "い", okuri: nil, candidate: Candidate("伊"), source: .registering)
-        XCTAssertEqual(Global.dictionary.recentRegisteredEntries.count, recentRegisteredEntryCount + 1)
-        XCTAssertEqual(Global.dictionary.recentRegisteredEntries.first, RecentRegisteredEntry(yomi: "い", word: Word("伊")))
+        XCTAssertEqual(Global.dictionary.recentRegisteredCandidates.count, recentRegisteredCandidateCount + 1)
+        XCTAssertEqual(Global.dictionary.recentRegisteredCandidates.first, RecentRegisteredCandidate(yomi: "い", word: Word("伊")))
     }
 
     // Ctrl-jを押した


### PR DESCRIPTION
#472 直近の辞書登録されたエントリの簡単削除機能にいくつか細かい修正。

<img width="270" height="301" alt="image" src="https://github.com/user-attachments/assets/a3a8bdff-33f5-4a28-916f-cbbf759515fa" />

- キーボード操作で単語削除したとき入力メニューにに残ってしまう問題を修正 (delete メソッドで常に直近登録からの削除も実行するように変更)
- メニューのヘッダー「直近の辞書登録をキャンセルする」を「直近の辞書登録を取り消す」に変更
- 各エントリのメニュータイトルから「を削除する」を削除して単に辞書エントリを表示するだけにする
- `UserDict#add` の`source`にコメントを追加
- RecentRegisteredEntry -> RecentRegisteredCandidateにリネーム
  - Entryが読みと複数の変換候補の組、今回対象としてるのは読みと1つの変換候補の組。