### PR TITLE
補完候補の検索が該当読み数に対してO(n^2)になっているのを修正

### DIFF
--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -246,10 +246,12 @@ enum UserDictAddSource {
             return []
         }
         var results: [String] = findCompletions(prefix: prefix)
+        // 重複排除は順序を保ちつつSetでメンバーシップ判定する (Array.containsだと該当読み数Mに対しO(M^2)になる)
+        var seen = Set(results)
         if findFromAllDicts {
             for dict in dicts {
                 for yomi in dict.findCompletions(prefix: prefix) {
-                    if !results.contains(yomi) {
+                    if seen.insert(yomi).inserted {
                         results.append(yomi)
                     }
                 }
@@ -257,7 +259,7 @@ enum UserDictAddSource {
         }
         if let skkservDict {
             for yomi in skkservDict.findCompletions(prefix: prefix) {
-                if !results.contains(yomi) {
+                if seen.insert(yomi).inserted {
                     results.append(yomi)
                 }
             }
@@ -368,17 +370,19 @@ enum UserDictAddSource {
             return []
         }
         var results: [String] = []
+        // 重複排除は順序を保ちつつSetでメンバーシップ判定する (Array.containsだと読み数に対しO(n^2)になる)
+        var seen = Set<String>()
         if !privateMode.value || !ignoreUserDictInPrivateMode.value {
             if let userDict {
                 for yomi in userDict.findCompletions(prefix: prefix) {
-                    if !results.contains(yomi) {
+                    if seen.insert(yomi).inserted {
                         results.append(yomi)
                     }
                 }
             }
         }
         dateYomis.forEach { dateYomi in
-            if dateYomi.yomi.hasPrefix(prefix) && !results.contains(dateYomi.yomi) {
+            if dateYomi.yomi.hasPrefix(prefix) && seen.insert(dateYomi.yomi).inserted {
                 results.append(dateYomi.yomi)
             }
         }


### PR DESCRIPTION
「すべての辞書から補完を探す」が有効なとき、該当する読みが多い接頭辞を入力すると補完候補の表示が遅延します。入力途中の短い接頭辞ほど該当読みが多く、遅延が顕著になります。

原因は `UserDict.findCompletionsDicts` / `findCompletions` の重複排除が `Array.contains` による線形探索で、該当読み数に対して O(n^2) になっていたためです。順序を保持したまま `Set` でメンバーシップ判定するようにして O(n) にしました。出力順は変わらず、既存テストも pass しています。

標準辞書 SKK-JISYO.L 単体でも、例えば「こう」(該当 2763 件) の補完表示が約 370ms から約 13ms になります。辞書を追加するほど該当読みが増え、修正前は二乗で悪化します。