### PR TITLE
skkserv で補完候補を検索する場合に表示が遅くなる問題を修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -199,7 +199,7 @@ class InputController: IMKInputController {
             .compactMap { (yomi, cursorPosition) -> (String, Completion, NSRect)? in
                 let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
                 if Global.showCandidateForCompletion {
-                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts)
+                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts, skkservReferLimit: Global.displayCandidateCount)
                     return (yomi, .candidates(candidates), cursorPosition)
                 } else {
                     let completions = Global.dictionary.findCompletionsDicts(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -392,10 +392,21 @@ enum UserDictAddSource {
     /**
      * 現在入力中のprefixに続く変換候補を返す。
      *
+     * 見出しごとにskkservへ問い合わせる (TCP往復) コストが見出し数に比例するため、補完にskkservを
+     * 使うと該当読みが多い接頭辞で表示が遅延する。そこでskkservへ問い合わせるのは先頭 ``skkservReferLimit``
+     * 件の見出しまでとし、それ以降の見出しはローカル辞書 (ユーザー辞書・ファイル辞書) のみ引く。
+     * ローカル辞書の参照は安価なので全見出しを実体化でき、表示順や2ページ目以降の候補は従来どおり保たれる。
+     *
      * asyncにするかも? (skkservとかで便利そう)
      * AsyncStreamにするかも?
+     *
+     * - Parameters:
+     *   - prefix: SKK辞書の見出しの接頭辞
+     *   - skkservDict: SKKServ辞書。nilのときはskkservを引かない
+     *   - findFromAllDicts: ユーザー辞書以外を検索するか
+     *   - skkservReferLimit: skkservへ変換候補を問い合わせる見出しの最大数。先頭からこの数の見出しだけskkservも引く
      */
-    func candidatesForCompletion(prefix: String, skkservDict: SKKServDict?, findFromAllDicts: Bool) -> [Candidate] {
+    func candidatesForCompletion(prefix: String, skkservDict: SKKServDict?, findFromAllDicts: Bool, skkservReferLimit: Int) -> [Candidate] {
         // 1文字のときは全探索するとめちゃくちゃ量が多いので完全一致だけ探す
         if prefix.count == 1 {
             return referDicts(prefix, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
@@ -403,17 +414,25 @@ enum UserDictAddSource {
                     candidate.withOriginal(Candidate.Original(midashi: prefix, word: candidate.word))
                 }
         }
-        // あとでいろいろ拡張するけどひとまずfindCompletionsの結果を[Candidate]にするだけ
-        // 別スレッドから実行したいのでひとまずskkserv以外を検索する
-        return findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts).flatMap { midashi in
+        // FIXME: Candidateの配列じゃなくて、(String, Candidate) のように見出し語と変換候補のタプルの配列を返すほうがよさそう
+        var candidates: [Candidate] = []
+        var skkservReferCount = 0
+        for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
+            // skkservを引くのは先頭skkservReferLimit件の見出しまで。残りはローカル辞書のみ引く。
+            let skkservDictForMidashi = skkservReferCount < skkservReferLimit ? skkservDict : nil
             // NOTE: 多すぎても役に立たないだろうと思うのでひとまず先頭100件に制限。設定項目にしてもよさそう
-            // FIXME: Candidateの配列じゃなくて、(String, Candidate) のように見出し語と変換候補のタプルの配列を返すほうがよさそう
-            referDicts(midashi, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
-                .prefix(100)
-                .map { candidate in
-                    candidate.withOriginal(Candidate.Original(midashi: midashi, word: candidate.word))
-                }
+            candidates.append(contentsOf:
+                referDicts(midashi, option: nil, skkservDict: skkservDictForMidashi, findFromAllDicts: findFromAllDicts)
+                    .prefix(100)
+                    .map { candidate in
+                        candidate.withOriginal(Candidate.Original(midashi: midashi, word: candidate.word))
+                    }
+            )
+            if skkservDictForMidashi != nil {
+                skkservReferCount += 1
+            }
         }
+        return candidates
     }
 
     /// ユーザー辞書を永続化する

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -173,21 +173,92 @@ import Combine
             dateYomis: [],
             dateConversions: [])
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: false),
+            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: false, skkservReferLimit: 100),
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本"))
             ])
         // 全辞書を対象
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: true),
+            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: true, skkservReferLimit: 100),
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本")),
                 Candidate("二本", annotations: [], original: .init(midashi: "にほん", word: "二本")),
                 Candidate("日本語", annotations: [annotation2], original: .init(midashi: "にほんご", word: "日本語")),
             ])
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "に", skkservDict: nil, findFromAllDicts: true),
+            userDict.candidatesForCompletion(prefix: "に", skkservDict: nil, findFromAllDicts: true, skkservReferLimit: 100),
             [Candidate("似", original: .init(midashi: "に", word: "似"))],
         )
+    }
+
+    /// skkservReferLimitに関わらず、ローカル辞書の候補は全見出しぶん実体化される (2ページ目以降も保たれる) ことを確認する。
+    func testCandidatesForCompletionMaterializesAllLocalCandidates() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
+        // 「あい」で始まる見出しを多数用意し、各見出しは1候補 (prefixは2文字以上にする)
+        var entries: [String: [Word]] = [:]
+        for i in 0..<50 {
+            entries[String(format: "あい%03d", i)] = [Word("亜\(i)")]
+        }
+        let dict = MemoryDict(entries: entries, readonly: false, saveToUserDict: false)
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: privateMode,
+            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+            dateYomis: [],
+            dateConversions: [])
+        // skkservを引かない場合、skkservReferLimitが小さくてもローカル候補は打ち切られず全件返る
+        XCTAssertEqual(userDict.candidatesForCompletion(prefix: "あい", skkservDict: nil, findFromAllDicts: true, skkservReferLimit: 9).count, 50)
+        XCTAssertEqual(userDict.candidatesForCompletion(prefix: "あい", skkservDict: nil, findFromAllDicts: true, skkservReferLimit: 0).count, 50)
+    }
+
+    /// skkservへの問い合わせ(refer)は先頭skkservReferLimit件の見出しに限られる一方、
+    /// ローカル辞書の候補は全見出しぶん実体化されることを確認する。
+    /// (補完表示の遅延の主因がskkserv refer回数なので、回数が抑えられることが速度改善の根拠になる)
+    final class CountingSKKServService: SKKServServiceProtocol, @unchecked Sendable {
+        private(set) var referCount = 0
+        init() {}
+        func refer(yomi: String, destination: SKKServDestination, timeout: TimeInterval) throws -> String {
+            referCount += 1
+            return "1/\(yomi)変換/"
+        }
+        func completion(yomi: String, destination: SKKServDestination, timeout: TimeInterval) throws -> String {
+            // 見出しはユーザー辞書側で用意するので、skkserv側の補完見出しは無し (見つからない応答)
+            return "4\(yomi)"
+        }
+        func disconnect() throws {}
+    }
+
+    func testCandidatesForCompletionLimitsSKKServRefer() throws {
+        let destination = SKKServDestination(host: "localhost", port: 1178, encoding: .utf8)
+        // ユーザー辞書に「あい…」見出しを50件用意 (各1候補)。skkserv側の補完見出しは無し。
+        func makeUserDict() throws -> UserDict {
+            var entries: [String: [Word]] = [:]
+            for i in 0..<50 {
+                entries[String(format: "あい%03d", i)] = [Word("亜\(i)")]
+            }
+            let dict = MemoryDict(entries: entries, readonly: false, saveToUserDict: false)
+            return try UserDict(
+                dicts: [dict],
+                userDictEntries: [:],
+                privateMode: CurrentValueSubject<Bool, Never>(false),
+                ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                dateYomis: [],
+                dateConversions: [])
+        }
+        // skkservReferLimit=9 -> 先頭9見出しだけskkservを引く。残り41件はローカルのみ。
+        let svc9 = CountingSKKServService()
+        let dict9 = SKKServDict(destination: destination, service: svc9, saveToUserDict: false, autoDisableThreshold: 1000)
+        let got9 = try makeUserDict().candidatesForCompletion(prefix: "あい", skkservDict: dict9, findFromAllDicts: true, skkservReferLimit: 9)
+        XCTAssertEqual(svc9.referCount, 9, "skkserv referは先頭9見出しに限られる")
+        // 先頭9見出し: ローカル1 + skkserv1 = 2候補、残り41見出し: ローカル1候補 => 9*2 + 41 = 59
+        XCTAssertEqual(got9.count, 59, "ローカル候補は全見出しぶん実体化される (2ページ目以降も保たれる)")
+        // skkservReferLimitを十分大きくすると全50見出しでskkservを引く
+        let svcAll = CountingSKKServService()
+        let dictAll = SKKServDict(destination: destination, service: svcAll, saveToUserDict: false, autoDisableThreshold: 1000)
+        let gotAll = try makeUserDict().candidatesForCompletion(prefix: "あい", skkservDict: dictAll, findFromAllDicts: true, skkservReferLimit: 1000)
+        XCTAssertEqual(svcAll.referCount, 50)
+        XCTAssertEqual(gotAll.count, 100, "全50見出しでローカル1+skkserv1 = 100候補")
     }
 }


### PR DESCRIPTION
skkserv で「補完候補を検索する」がオンの時、見付かった見出し全てについて skkserv に問い合わせるため表示にかなり時間が掛かります。僕の環境では「こう」という入力で見出しが 230 件程度ヒットし、その回数だけ skkserv が呼ばれることで候補の表示が 2000ms 掛かっていました。

これを修正し、skkserv の呼び出し回数を `displayCandidateCount` に制限することにしました。これでログを取った所、「こう」で候補が表示される時間が **2000ms → 48ms** まで短縮しました。

`displayCandidateCount` を使ったのはこれで十分な候補が得られると考えた上ですが、それほど根拠のある数字ではありません。これを越えた分の見出しは skkserv を呼ばず、他のソース（ユーザー辞書とローカルの辞書）からの候補は変わらず表示されます。
