### PR TITLE
補完候補検索時のskkserv問い合わせ回数とcandidate総数に上限を設ける

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -198,8 +198,9 @@ class InputController: IMKInputController {
             .receive(on: DispatchQueue.global())
             .compactMap { (yomi, cursorPosition) -> (String, Completion, NSRect)? in
                 let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
+                let skkservOption = skkservDict.map { CompletionSKKServOption(dict: $0, candidateLimit: Global.displayCandidateCount) }
                 if Global.showCandidateForCompletion {
-                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts, skkservCandidateLimit: Global.displayCandidateCount)
+                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservOption: skkservOption, findFromAllDicts: Global.findCompletionFromAllDicts)
                     return (yomi, .candidates(candidates), cursorPosition)
                 } else {
                     let completions = Global.dictionary.findCompletionsDicts(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts)

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -199,7 +199,7 @@ class InputController: IMKInputController {
             .compactMap { (yomi, cursorPosition) -> (String, Completion, NSRect)? in
                 let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
                 if Global.showCandidateForCompletion {
-                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts)
+                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts, skkservCandidateLimit: Global.displayCandidateCount)
                     return (yomi, .candidates(candidates), cursorPosition)
                 } else {
                     let completions = Global.dictionary.findCompletionsDicts(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts)

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -198,7 +198,7 @@ class InputController: IMKInputController {
             .receive(on: DispatchQueue.global())
             .compactMap { (yomi, cursorPosition) -> (String, Completion, NSRect)? in
                 let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
-                let skkservOption = skkservDict.map { CompletionSKKServOption(dict: $0, candidateLimit: Global.displayCandidateCount) }
+                let skkservOption = skkservDict.map { CompletionSKKServOption(dict: $0, referLimit: Global.displayCandidateCount) }
                 if Global.showCandidateForCompletion {
                     let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservOption: skkservOption, findFromAllDicts: Global.findCompletionFromAllDicts)
                     return (yomi, .candidates(candidates), cursorPosition)

--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -9,6 +9,13 @@ protocol SKKServDictProtocol {
     func findCompletions(prefix: String) -> [String]
 }
 
+/// 補完候補検索でのskkserv検索オプション
+struct CompletionSKKServOption {
+    let dict: any SKKServDictProtocol
+    /// skkservへのreferの問い合わせの上限回数
+    let candidateLimit: Int
+}
+
 /**
  * skkservを辞書として使う辞書定義
  *

--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -13,7 +13,7 @@ protocol SKKServDictProtocol {
 struct CompletionSKKServOption {
     let dict: any SKKServDictProtocol
     /// skkservへのreferの問い合わせの上限回数
-    let candidateLimit: Int
+    let referLimit: Int
 }
 
 /**

--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -3,13 +3,19 @@
 
 import Foundation
 
+protocol SKKServDictProtocol {
+    var saveToUserDict: Bool { get }
+    func refer(_ yomi: String, option: DictReferringOption?) -> [Word]
+    func findCompletions(prefix: String) -> [String]
+}
+
 /**
  * skkservを辞書として使う辞書定義
  *
  * 複数のskkservを想定してSKKServDict(サーバー数)とSKKServService(1つ)と分けているけど、
  * 当面はサーバー数を1に固定してSKKServDictにXPCとの通信処理をもってきたほうがシンプルかも?
  */
-final class SKKServDict {
+final class SKKServDict: SKKServDictProtocol {
     private let destination: SKKServDestination
     private let service: any SKKServServiceProtocol
     /// 変換履歴をユーザー辞書に保存するかどうか

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -400,14 +400,14 @@ enum UserDictAddSource {
      *
      * - Parameters:
      *   - prefix: SKK辞書の見出しの一部。
-     *   - skkservDict: SKKServを検索対象とする場合に渡す
+     *   - skkservOption: SKKServを検索対象とする場合に渡す。nilのときはskkservを引かない
      *   - findFromAllDicts: ユーザー辞書以外を検索対象とするか
-     *   - skkservCandidateLimit: skkservへの変換候補の問い合わせの上限回数
      *
      * NOTE: asyncにするかも? (skkservとかで便利そう)
      * AsyncStreamにするかも?
      */
-    func candidatesForCompletion(prefix: String, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool, skkservCandidateLimit: Int) -> [Candidate] {
+    func candidatesForCompletion(prefix: String, skkservOption: CompletionSKKServOption?, findFromAllDicts: Bool) -> [Candidate] {
+        let skkservDict = skkservOption?.dict
         // 1文字のときは全探索するとめちゃくちゃ量が多いので完全一致だけ探す
         if prefix.count == 1 {
             return referDicts(prefix, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
@@ -420,7 +420,7 @@ enum UserDictAddSource {
         var skkservReferCount = 0
         for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
             if results.count >= 100 { break }
-            let currentSkkservDict = skkservReferCount < skkservCandidateLimit ? skkservDict : nil
+            let currentSkkservDict: (any SKKServDictProtocol)? = skkservOption.map { skkservReferCount < $0.candidateLimit ? $0.dict : nil } ?? nil
             if currentSkkservDict != nil { skkservReferCount += 1 }
             let candidates = referDicts(midashi, option: nil, skkservDict: currentSkkservDict, findFromAllDicts: findFromAllDicts)
                 .prefix(100 - results.count)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -420,7 +420,7 @@ enum UserDictAddSource {
         var skkservReferCount = 0
         for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
             if results.count >= 100 { break }
-            let currentSkkservDict: (any SKKServDictProtocol)? = skkservOption.map { skkservReferCount < $0.candidateLimit ? $0.dict : nil } ?? nil
+            let currentSkkservDict: (any SKKServDictProtocol)? = skkservOption.map { skkservReferCount < $0.referLimit ? $0.dict : nil } ?? nil
             if currentSkkservDict != nil { skkservReferCount += 1 }
             let candidates = referDicts(midashi, option: nil, skkservDict: currentSkkservDict, findFromAllDicts: findFromAllDicts)
                 .prefix(100 - results.count)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -420,8 +420,13 @@ enum UserDictAddSource {
         var skkservReferCount = 0
         for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
             if results.count >= 100 { break }
-            let currentSkkservDict: (any SKKServDictProtocol)? = skkservOption.map { skkservReferCount < $0.referLimit ? $0.dict : nil } ?? nil
-            if currentSkkservDict != nil { skkservReferCount += 1 }
+            let currentSkkservDict: (any SKKServDictProtocol)?
+            if let option = skkservOption, skkservReferCount < option.referLimit {
+                 currentSkkservDict = option.dict
+                 skkservReferCount += 1
+             } else {
+                 currentSkkservDict = nil
+             }
             let candidates = referDicts(midashi, option: nil, skkservDict: currentSkkservDict, findFromAllDicts: findFromAllDicts)
                 .prefix(100 - results.count)
                 .map { candidate in

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -391,11 +391,23 @@ enum UserDictAddSource {
 
     /**
      * 現在入力中のprefixに続く変換候補を返す。
+     * prefixが1文字しかないときは完全一致だけを返す。
+     * 2文字以上あるときは見つかったものから最大100件まで返す。
      *
-     * asyncにするかも? (skkservとかで便利そう)
+     * skkservへの変換候補問い合わせはファイル辞書に比べて引くのにコストがかかるため、別に上限を設ける。
+     * ``Global.displayCandidateCount`` 回数引いたらそれ以上は引かない。
+     * 将来AsyncStreamにできたら遅延しながら引くのはありかも。
+     *
+     * - Parameters:
+     *   - prefix: SKK辞書の見出しの一部。
+     *   - skkservDict: SKKServを検索対象とする場合に渡す
+     *   - findFromAllDicts: ユーザー辞書以外を検索対象とするか
+     *   - skkservCandidateLimit: skkservへの変換候補の問い合わせの上限回数
+     *
+     * NOTE: asyncにするかも? (skkservとかで便利そう)
      * AsyncStreamにするかも?
      */
-    func candidatesForCompletion(prefix: String, skkservDict: SKKServDict?, findFromAllDicts: Bool) -> [Candidate] {
+    func candidatesForCompletion(prefix: String, skkservDict: SKKServDict?, findFromAllDicts: Bool, skkservCandidateLimit: Int) -> [Candidate] {
         // 1文字のときは全探索するとめちゃくちゃ量が多いので完全一致だけ探す
         if prefix.count == 1 {
             return referDicts(prefix, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
@@ -403,17 +415,21 @@ enum UserDictAddSource {
                     candidate.withOriginal(Candidate.Original(midashi: prefix, word: candidate.word))
                 }
         }
-        // あとでいろいろ拡張するけどひとまずfindCompletionsの結果を[Candidate]にするだけ
-        // 別スレッドから実行したいのでひとまずskkserv以外を検索する
-        return findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts).flatMap { midashi in
-            // NOTE: 多すぎても役に立たないだろうと思うのでひとまず先頭100件に制限。設定項目にしてもよさそう
-            // FIXME: Candidateの配列じゃなくて、(String, Candidate) のように見出し語と変換候補のタプルの配列を返すほうがよさそう
-            referDicts(midashi, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
-                .prefix(100)
+        // FIXME: Candidateの配列じゃなくて、(String, Candidate) のように見出し語と変換候補のタプルの配列を返すほうがよさそう
+        var results: [Candidate] = []
+        var skkservReferCount = 0
+        for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
+            if results.count >= 100 { break }
+            let currentSkkservDict: SKKServDict? = skkservReferCount < skkservCandidateLimit ? skkservDict : nil
+            if currentSkkservDict != nil { skkservReferCount += 1 }
+            let candidates = referDicts(midashi, option: nil, skkservDict: currentSkkservDict, findFromAllDicts: findFromAllDicts)
+                .prefix(100 - results.count)
                 .map { candidate in
                     candidate.withOriginal(Candidate.Original(midashi: midashi, word: candidate.word))
                 }
+            results.append(contentsOf: candidates)
         }
+        return results
     }
 
     /// ユーザー辞書を永続化する

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -138,7 +138,7 @@ enum UserDictAddSource {
      *   - skkservDict: SKKServ辞書。nilのときはskkservを引かない
      *   - findFromAllDicts: ユーザー辞書以外を検索するか。trueにするのは補完候補検索時のみ。
      */
-    func referDicts(_ yomi: String, option: DictReferringOption?, skkservDict: SKKServDict?, findFromAllDicts: Bool) -> [Candidate] {
+    func referDicts(_ yomi: String, option: DictReferringOption?, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool) -> [Candidate] {
         var result: [Candidate] = []
         var candidates = refer(yomi, option: option).map { word in
             let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
@@ -241,7 +241,7 @@ enum UserDictAddSource {
      *   - skkservDict: SKKServ辞書。nilのときはskkservを引かない
      *   - findFromAllDicts: ユーザー辞書以外を検索するか
      */
-    func findCompletionsDicts(prefix: String, skkservDict: SKKServDict?, findFromAllDicts: Bool) -> [String] {
+    func findCompletionsDicts(prefix: String, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool) -> [String] {
         if prefix.isEmpty {
             return []
         }
@@ -407,7 +407,7 @@ enum UserDictAddSource {
      * NOTE: asyncにするかも? (skkservとかで便利そう)
      * AsyncStreamにするかも?
      */
-    func candidatesForCompletion(prefix: String, skkservDict: SKKServDict?, findFromAllDicts: Bool, skkservCandidateLimit: Int) -> [Candidate] {
+    func candidatesForCompletion(prefix: String, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool, skkservCandidateLimit: Int) -> [Candidate] {
         // 1文字のときは全探索するとめちゃくちゃ量が多いので完全一致だけ探す
         if prefix.count == 1 {
             return referDicts(prefix, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
@@ -420,7 +420,7 @@ enum UserDictAddSource {
         var skkservReferCount = 0
         for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
             if results.count >= 100 { break }
-            let currentSkkservDict: SKKServDict? = skkservReferCount < skkservCandidateLimit ? skkservDict : nil
+            let currentSkkservDict = skkservReferCount < skkservCandidateLimit ? skkservDict : nil
             if currentSkkservDict != nil { skkservReferCount += 1 }
             let candidates = referDicts(midashi, option: nil, skkservDict: currentSkkservDict, findFromAllDicts: findFromAllDicts)
                 .prefix(100 - results.count)

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -192,20 +192,20 @@ import Combine
             dateYomis: [],
             dateConversions: [])
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: false, skkservCandidateLimit: 9),
+            userDict.candidatesForCompletion(prefix: "にほ", skkservOption: nil, findFromAllDicts: false),
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本"))
             ])
         // 全辞書を対象
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9),
+            userDict.candidatesForCompletion(prefix: "にほ", skkservOption: nil, findFromAllDicts: true),
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本")),
                 Candidate("二本", annotations: [], original: .init(midashi: "にほん", word: "二本")),
                 Candidate("日本語", annotations: [annotation2], original: .init(midashi: "にほんご", word: "日本語")),
             ])
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "に", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9),
+            userDict.candidatesForCompletion(prefix: "に", skkservOption: nil, findFromAllDicts: true),
             [Candidate("似", original: .init(midashi: "に", word: "似"))],
         )
     }
@@ -225,7 +225,7 @@ import Combine
             ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
             dateYomis: [],
             dateConversions: [])
-        let results = userDict.candidatesForCompletion(prefix: "あい", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9)
+        let results = userDict.candidatesForCompletion(prefix: "あい", skkservOption: nil, findFromAllDicts: true)
         XCTAssertEqual(results.count, 100)
     }
 
@@ -250,7 +250,7 @@ import Combine
             dateYomis: [],
             dateConversions: [])
         let limit = 9
-        _ = userDict.candidatesForCompletion(prefix: "あい", skkservDict: mock, findFromAllDicts: true, skkservCandidateLimit: limit)
+        _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, candidateLimit: limit), findFromAllDicts: true)
         XCTAssertEqual(mock.referCallCount, limit)
     }
 }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -7,6 +7,25 @@ import Combine
 @testable import macSKK
 
 @MainActor final class UserDictTests: XCTestCase {
+    class MockSKKServDict: SKKServDictProtocol {
+        let saveToUserDict = false
+        let wordsPerYomi: [String: [Word]]
+        private(set) var referCallCount = 0
+
+        init(wordsPerYomi: [String: [Word]]) {
+            self.wordsPerYomi = wordsPerYomi
+        }
+
+        func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
+            referCallCount += 1
+            return wordsPerYomi[yomi] ?? []
+        }
+
+        func findCompletions(prefix: String) -> [String] {
+            return wordsPerYomi.keys.filter { $0.hasPrefix(prefix) && $0 != prefix }.sorted()
+        }
+    }
+
     @MainActor func testRefer() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊"), Word("位")]], readonly: true, saveToUserDict: false)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true, saveToUserDict: true)
@@ -189,5 +208,49 @@ import Combine
             userDict.candidatesForCompletion(prefix: "に", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9),
             [Candidate("似", original: .init(midashi: "に", word: "似"))],
         )
+    }
+
+    func testCandidatesForCompletionTotalLimit() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
+        // 50見出し語×3候補=150件になるが返値は100件に絞られる
+        let entries = Dictionary(uniqueKeysWithValues: (1...50).map { i in
+            (String(format: "あい%02d", i), [Word("候補A\(i)"), Word("候補B\(i)"), Word("候補C\(i)")])
+        })
+        let dict = MemoryDict(entries: entries, readonly: false)
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: privateMode,
+            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+            dateYomis: [],
+            dateConversions: [])
+        let results = userDict.candidatesForCompletion(prefix: "あい", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9)
+        XCTAssertEqual(results.count, 100)
+    }
+
+    func testCandidatesForCompletionSkkservLimit() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
+        // skkservへのreferの問い合わせがskkservCandidateLimit回で打ち切られることを確認
+        let yomis = (1...20).map { String(format: "あい%02d", $0) }
+        let dictEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
+            (yomi, [Word("漢字\(i + 1)")])
+        })
+        let skkservEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
+            (yomi, [Word("SKK\(i + 1)")])
+        })
+        let dict = MemoryDict(entries: dictEntries, readonly: false)
+        let mock = MockSKKServDict(wordsPerYomi: skkservEntries)
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: privateMode,
+            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+            dateYomis: [],
+            dateConversions: [])
+        let limit = 9
+        _ = userDict.candidatesForCompletion(prefix: "あい", skkservDict: mock, findFromAllDicts: true, skkservCandidateLimit: limit)
+        XCTAssertEqual(mock.referCallCount, limit)
     }
 }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -173,20 +173,20 @@ import Combine
             dateYomis: [],
             dateConversions: [])
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: false),
+            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: false, skkservCandidateLimit: 9),
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本"))
             ])
         // 全辞書を対象
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: true),
+            userDict.candidatesForCompletion(prefix: "にほ", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9),
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本")),
                 Candidate("二本", annotations: [], original: .init(midashi: "にほん", word: "二本")),
                 Candidate("日本語", annotations: [annotation2], original: .init(midashi: "にほんご", word: "日本語")),
             ])
         XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "に", skkservDict: nil, findFromAllDicts: true),
+            userDict.candidatesForCompletion(prefix: "に", skkservDict: nil, findFromAllDicts: true, skkservCandidateLimit: 9),
             [Candidate("似", original: .init(midashi: "に", word: "似"))],
         )
     }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -250,7 +250,7 @@ import Combine
             dateYomis: [],
             dateConversions: [])
         let limit = 9
-        _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, candidateLimit: limit), findFromAllDicts: true)
+        _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, referLimit: limit), findFromAllDicts: true)
         XCTAssertEqual(mock.referCallCount, limit)
     }
 }


### PR DESCRIPTION
#480 いまの補完変換候補の検索処理の次の問題を修正します。

- 見つかったものを全部返している → 100件まで返すようにする
- 見つかった補完見出し候補を全部SKKServで引いている → 表示する変換候補個数 (1 - 9) に制限する (#484)

#484 をPRでいただいたのですが、

- #480 も片付けたい
- SKKServDictを含むテストができるようにSKKServDictにプロトコル定義を追加

も入れたかったので別PRにしました。