### PR TITLE
送り仮名入力中に遅延した補完候補検索結果でパネルが表示されるバグを修正

### DIFF
--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -212,7 +212,8 @@ class InputController: IMKInputController {
                 guard let self else { return }
                 // 補完候補の検索を別スレッドで実行しているため、その間に読みが変更されたり変換を開始したり確定している可能性がある。
                 // 現在のStateMachineの読みが異なる場合は補完候補検索結果を捨てて何もしない
-                if case .composing(let composing) = self.stateMachine.state.inputMethod {
+                // okuri == nilのチェックはupdateMarkedTextの補完条件と合わせるため (送り仮名入力中は補完しない)
+                if case .composing(let composing) = self.stateMachine.state.inputMethod, composing.okuri == nil {
                     if yomi != composing.yomi(for: .hiragana, kanaRule: Global.kanaRule) {
                         logger.info("補完候補を検索しましたが現在の読みが補完候補検索時と変わっているため補完候補は表示しません")
                         return


### PR DESCRIPTION
#486 補完候補の検索中に送り仮名が入力されると、補完候補が表示されたままになってしまうバグを修正。

補完候補の検索はDispatchQueue.globalで非同期実行されるため、検索開始後に
送り仮名入力 (大文字キー) が行われた場合、遅れて届いた検索結果のsinkで
composing.okuri != nilの状態でもguardを通過して補完パネルを表示してしまい、 変換候補パネルと共存するバグがあった。

updateMarkedTextの補完候補通知条件 (composing.okuri == nil) と sinkのguard条件を一致させることで送り仮名が入力されたら補完候補を表示しないように修正する。