### PR TITLE
SKKServDictをSendable化

### DIFF
--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -13,6 +13,10 @@ import Combine
     static var dictionary: UserDict!
     /// skkserv辞書
     static var skkservDict: SKKServDict? = nil
+    /// skkservへの接続エラーの連続回数
+    static var skkservConsecutiveErrorCount: Int = 0
+    /// 接続エラーが何回連続したら自動無効化するか
+    static var skkservAutoDisableThreshold: Int = 3
     static let privateMode = CurrentValueSubject<Bool, Never>(false)
     /// プライベートモード時に変換候補にユーザー辞書を無視するかどうか
     static var ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
@@ -99,5 +103,14 @@ import Combine
 
     static var candidatesPanel: CandidatesPanel {
         shared.candidatesPanel
+    }
+
+    static func handleSKKServError() {
+        skkservConsecutiveErrorCount += 1
+        if skkservConsecutiveErrorCount >= skkservAutoDisableThreshold {
+            logger.log("skkservへの接続エラーが\(skkservConsecutiveErrorCount)回連続したため無効化します")
+            skkservDict = nil
+            NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
+        }
     }
 }

--- a/macSKK/Global.swift
+++ b/macSKK/Global.swift
@@ -12,7 +12,7 @@ import Combine
     /// 利用可能な辞書の集合
     static var dictionary: UserDict!
     /// skkserv辞書
-    static var skkservDict: SKKServDict? = nil
+    static var skkservDict: (any SKKServDictProtocol)? = nil
     /// skkservへの接続エラーの連続回数
     static var skkservConsecutiveErrorCount: Int = 0
     /// 接続エラーが何回連続したら自動無効化するか
@@ -103,14 +103,5 @@ import Combine
 
     static var candidatesPanel: CandidatesPanel {
         shared.candidatesPanel
-    }
-
-    static func handleSKKServError() {
-        skkservConsecutiveErrorCount += 1
-        if skkservConsecutiveErrorCount >= skkservAutoDisableThreshold {
-            logger.log("skkservへの接続エラーが\(skkservConsecutiveErrorCount)回連続したため無効化します")
-            skkservDict = nil
-            NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
-        }
     }
 }

--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -5,8 +5,8 @@ import Foundation
 
 protocol SKKServDictProtocol {
     var saveToUserDict: Bool { get }
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word]
-    func findCompletions(prefix: String) -> [String]
+    func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error>
+    func findCompletions(prefix: String) -> Result<[String], any Error>
 }
 
 /// 補完候補検索でのskkserv検索オプション
@@ -22,115 +22,82 @@ struct CompletionSKKServOption {
  * 複数のskkservを想定してSKKServDict(サーバー数)とSKKServService(1つ)と分けているけど、
  * 当面はサーバー数を1に固定してSKKServDictにXPCとの通信処理をもってきたほうがシンプルかも?
  */
-final class SKKServDict: SKKServDictProtocol {
+final class SKKServDict: SKKServDictProtocol, Sendable {
     private let destination: SKKServDestination
     private let service: any SKKServServiceProtocol
     /// 変換履歴をユーザー辞書に保存するかどうか
     let saveToUserDict: Bool
-    /// 接続エラーが何回連続したら自動無効化するか
-    var autoDisableThreshold: Int
-    /// 接続エラーの連続回数
-    private var consecutiveErrorCount: Int = 0
-    /// 自動無効化されたかどうか
-    private var isAutoDisabled: Bool = false
 
-    init(destination: SKKServDestination, service: any SKKServServiceProtocol = SKKServService(), saveToUserDict: Bool, autoDisableThreshold: Int) {
+    init(destination: SKKServDestination, service: any SKKServServiceProtocol = SKKServService(), saveToUserDict: Bool) {
         self.destination = destination
         self.service = service
         self.saveToUserDict = saveToUserDict
-        self.autoDisableThreshold = autoDisableThreshold
     }
 
     /**
      * skkservに変換候補の問い合わせを行い変換候補を返す。
      *
-     * TCP接続が切れたり接続タイムアウトや応答のタイムアウトした場合はログだけ出力して空配列を返す。
+     * TCP接続が切れたり接続タイムアウトや応答のタイムアウトした場合はログだけ出力して .failure を返す。
      */
-    func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
-        if isAutoDisabled { return [] }
+    func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error> {
         do {
             let result = try service.refer(yomi: yomi, destination: destination, timeout: 1.0)
-            consecutiveErrorCount = 0
             // 変換候補が見つかった場合は "1/変換/返還/" のように 1が先頭でスラッシュで区切られた文字列
             // 見つからなかった場合は "4へんかん" のように4が先頭の文字列
             guard result.hasPrefix("1/") else {
                 logger.debug("skkservから変換候補が見つからなかったレスポンスが返りました")
-                return []
+                return .success([])
             }
             // Entry.parseWordsは先頭のスラッシュがない形を受け取る
             guard let candidates = Entry.parseWords(result.dropFirst(2), dictId: "skkserv") else {
                 logger.error("skkservの返した変換候補を正常にパースできませんでした")
-                return []
+                return .success([])
             }
-            return candidates
+            return .success(candidates)
         } catch {
-            if let error = error as? SKKServClientError {
-                switch error {
-                case .connectionRefused:
-                    logger.log("skkservが応答しません")
-                case .connectionTimeout:
-                    logger.log("skkservとの接続がタイムアウトしました")
-                case .invalidResponse:
-                    logger.warning("skkservから想定しない応答が返りました")
-                case .timeout:
-                    logger.log("skkservから応答が一定時間返りませんでした")
-                default:
-                    logger.error("skkservから不明なエラーが返りました")
-                }
-            } else {
-                logger.error("skkserv辞書の検索でエラーが発生しました: \(error, privacy: .public)")
-            }
-            handleConnectionError()
-            return []
+            logSKKServError(error)
+            return .failure(error)
         }
     }
 
-    func findCompletions(prefix: String) -> [String] {
-        if isAutoDisabled { return [] }
+    func findCompletions(prefix: String) -> Result<[String], any Error> {
         do {
             let result = try service.completion(yomi: prefix, destination: destination, timeout: 1.0)
-            consecutiveErrorCount = 0
             // 補完結果が見つかった場合は "1/ほかん/ほかんこうほ/" のように 1が先頭でスラッシュで区切られた文字列
             // 見つからなかた場合は "4ほかん" のように4が先頭の文字列
             guard result.hasPrefix("1/") else {
                 logger.debug("skkservから補完候補が見つからなかったレスポンスが返りました")
-                return []
+                return .success([])
             }
             let completions = result.dropFirst(2).split(separator: "/").map { String($0) }
             // 重複した候補、読みと同じ候補、読みを接頭辞としてもたない候補は除去
-            return completions.reduce(into: []) { acc, item in
+            return .success(completions.reduce(into: []) { acc, item in
                 if !acc.contains(item) && item.hasPrefix(prefix) && item != prefix {
                     acc.append(item)
                 }
-            }
+            })
         } catch {
-            if let error = error as? SKKServClientError {
-                switch error {
-                case .connectionRefused:
-                    logger.log("skkservが応答しません")
-                case .connectionTimeout:
-                    logger.log("skkservとの接続がタイムアウトしました")
-                case .invalidResponse:
-                    logger.warning("skkservから想定しない応答が返りました")
-                case .timeout:
-                    logger.log("skkservから応答が一定時間返りませんでした")
-                default:
-                    logger.error("skkservから不明なエラーが返りました")
-                }
-            } else {
-                logger.error("skkserv辞書の検索でエラーが発生しました: \(error, privacy: .public)")
-            }
-            handleConnectionError()
-            return []
+            logSKKServError(error)
+            return .failure(error)
         }
     }
 
-    private func handleConnectionError() {
-        consecutiveErrorCount += 1
-        if consecutiveErrorCount >= autoDisableThreshold {
-            logger.log("skkservへの接続エラーが\(self.consecutiveErrorCount)回連続したため無効化します")
-            isAutoDisabled = true
-            NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
+    private func logSKKServError(_ error: any Error) {
+        if let error = error as? SKKServClientError {
+            switch error {
+            case .connectionRefused:
+                logger.log("skkservが応答しません")
+            case .connectionTimeout:
+                logger.log("skkservとの接続がタイムアウトしました")
+            case .invalidResponse:
+                logger.warning("skkservから想定しない応答が返りました")
+            case .timeout:
+                logger.log("skkservから応答が一定時間返りませんでした")
+            default:
+                logger.error("skkservから不明なエラーが返りました")
+            }
+        } else {
+            logger.error("skkserv辞書の検索でエラーが発生しました: \(error, privacy: .public)")
         }
     }
 

--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-protocol SKKServDictProtocol {
+protocol SKKServDictProtocol: Sendable {
     var saveToUserDict: Bool { get }
     func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error>
     func findCompletions(prefix: String) -> Result<[String], any Error>

--- a/macSKK/SKKServService.swift
+++ b/macSKK/SKKServService.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-protocol SKKServServiceProtocol {
+protocol SKKServServiceProtocol: Sendable {
     func refer(yomi: String, destination: SKKServDestination, timeout: TimeInterval) throws -> String
     func completion(yomi: String, destination: SKKServDestination, timeout: TimeInterval) throws -> String
     func disconnect() throws
@@ -14,8 +14,11 @@ protocol SKKServServiceProtocol {
  *
  * macSKKのプロセスはネットワーク (接続しにいく) 権限をSandboxで絞っており、
  * 実際にskkservにTCP接続するのはSKKServClientターゲットで定義しているXPCです。
+ *
+ * - NOTE: NSXPCConnectionはSendable非準拠だが、serviceはletで差し替え不可であり、
+ *         activate()やremoteObjectProxyはApple内部でスレッドセーフに実装されているとみなして@unchecked Sendableを付与している。
  */
-struct SKKServService: SKKServServiceProtocol {
+struct SKKServService: SKKServServiceProtocol, @unchecked Sendable {
     private let service: NSXPCConnection
 
     init() {

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -417,6 +417,7 @@ final class SettingsViewModel: ObservableObject {
         Global.inputModePanel.updateColorSets(inputModeColorSets)
         Global.showMarkedTextMarker = showMarkedTextMarker
         Global.completionConfirmationTimeLimit = Double(completionConfirmationTimeLimit) / 1000
+        Global.skkservAutoDisableThreshold = skkservAutoDisableThreshold
 
         // SKK-JISYO.Lのようなファイルの読み込みが遅いのでバックグラウンドで処理
         Task {
@@ -460,7 +461,8 @@ final class SettingsViewModel: ObservableObject {
             if setting.enabled {
                 let destination = SKKServDestination(host: setting.address, port: setting.port, requestEncoding: setting.requestEncoding, responseEncoding: setting.responseEncoding)
                 logger.log("skkserv辞書を設定します")
-                Global.skkservDict = SKKServDict(destination: destination, saveToUserDict: setting.saveToUserDict, autoDisableThreshold: self.skkservAutoDisableThreshold)
+                Global.skkservConsecutiveErrorCount = 0
+                Global.skkservDict = SKKServDict(destination: destination, saveToUserDict: setting.saveToUserDict)
             } else {
                 logger.log("skkserv辞書は無効化されています")
                 Global.skkservDict = nil
@@ -470,7 +472,7 @@ final class SettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $skkservAutoDisableThreshold.dropFirst().removeDuplicates().sink { threshold in
-            Global.skkservDict?.autoDisableThreshold = threshold
+            Global.skkservAutoDisableThreshold = threshold
             UserDefaults.app.set(threshold, forKey: UserDefaultsKeys.skkservAutoDisableThreshold)
             logger.log("SKKServの接続エラーによる自動無効化の閾値が\(threshold)回に設定されました。")
         }.store(in: &cancellables)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -165,11 +165,16 @@ enum UserDictAddSource {
         }
         // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
         if let skkservDict {
-            let skkservCandidates: [Candidate] = skkservDict.refer(yomi, option: option).map { word in
-                let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
+            switch skkservDict.refer(yomi, option: option) {
+            case .success(let words):
+                Global.skkservConsecutiveErrorCount = 0
+                candidates.append(contentsOf: words.map { word in
+                    let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                    return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
+                })
+            case .failure:
+                Global.handleSKKServError()
             }
-            candidates.append(contentsOf: skkservCandidates)
         }
         if candidates.isEmpty {
             // yomiが数値を含む場合は "#" に置換して辞書を引く
@@ -198,16 +203,21 @@ enum UserDictAddSource {
                     }
                 }
                 if let skkservDict {
-                    let skkservCandidates: [Candidate] = skkservDict.refer(midashi, option: option).compactMap { word in
-                        guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
-                        guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
-                        let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                        return Candidate(convertedWord,
-                                         annotations: annotations,
-                                         original: Candidate.Original(midashi: midashi, word: word.word),
-                                         saveToUserDict: skkservDict.saveToUserDict)
+                    switch skkservDict.refer(midashi, option: option) {
+                    case .success(let words):
+                        Global.skkservConsecutiveErrorCount = 0
+                        candidates.append(contentsOf: words.compactMap { word in
+                            guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
+                            guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
+                            let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                            return Candidate(convertedWord,
+                                             annotations: annotations,
+                                             original: Candidate.Original(midashi: midashi, word: word.word),
+                                             saveToUserDict: skkservDict.saveToUserDict)
+                        })
+                    case .failure:
+                        Global.handleSKKServError()
                     }
-                    candidates.append(contentsOf: skkservCandidates)
                 }
             }
         }
@@ -258,10 +268,16 @@ enum UserDictAddSource {
             }
         }
         if let skkservDict {
-            for yomi in skkservDict.findCompletions(prefix: prefix) {
-                if seen.insert(yomi).inserted {
-                    results.append(yomi)
+            switch skkservDict.findCompletions(prefix: prefix) {
+            case .success(let completions):
+                Global.skkservConsecutiveErrorCount = 0
+                for yomi in completions {
+                    if seen.insert(yomi).inserted {
+                        results.append(yomi)
+                    }
                 }
+            case .failure:
+                Global.handleSKKServError()
             }
         }
         return results

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -167,15 +167,11 @@ enum UserDictAddSource {
         // NOTE: Global.skkservDictは接続エラーが連続するとnilに変わるが、それを呼び出し側でチェックできてない。
         // Swift Concurrency対応で呼び出し元で修正予定。
         if let skkservDict, Global.skkservDict != nil {
-            switch skkservDict.refer(yomi, option: option) {
-            case .success(let words):
-                Global.skkservConsecutiveErrorCount = 0
+            handleSKKServResult(skkservDict.refer(yomi, option: option)) { words in
                 candidates.append(contentsOf: words.map { word in
                     let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
                     return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
                 })
-            case .failure:
-                handleSKKServError()
             }
         }
         if candidates.isEmpty {
@@ -207,9 +203,7 @@ enum UserDictAddSource {
                 // NOTE: Global.skkservDictは接続エラーが連続するとnilに変わるが、それを呼び出し側でチェックできてない。
                 // Swift Concurrency対応で呼び出し元で修正予定。
                 if let skkservDict, Global.skkservDict != nil {
-                    switch skkservDict.refer(midashi, option: option) {
-                    case .success(let words):
-                        Global.skkservConsecutiveErrorCount = 0
+                    handleSKKServResult(skkservDict.refer(midashi, option: option)) { words in
                         candidates.append(contentsOf: words.compactMap { word in
                             guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
                             guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
@@ -219,8 +213,6 @@ enum UserDictAddSource {
                                              original: Candidate.Original(midashi: midashi, word: word.word),
                                              saveToUserDict: skkservDict.saveToUserDict)
                         })
-                    case .failure:
-                        handleSKKServError()
                     }
                 }
             }
@@ -272,16 +264,12 @@ enum UserDictAddSource {
             }
         }
         if let skkservDict {
-            switch skkservDict.findCompletions(prefix: prefix) {
-            case .success(let completions):
-                Global.skkservConsecutiveErrorCount = 0
+            handleSKKServResult(skkservDict.findCompletions(prefix: prefix)) { completions in
                 for yomi in completions {
                     if seen.insert(yomi).inserted {
                         results.append(yomi)
                     }
                 }
-            case .failure:
-                handleSKKServError()
             }
         }
         return results
@@ -510,17 +498,28 @@ enum UserDictAddSource {
         return Candidate(word.word, annotations: annotations, original: original, saveToUserDict: saveToUserDict)
     }
 
-    // TODO: このメソッドは@MainActor指定されているが、呼び出し元のInputControllerの補完検索を
-    // .receive(on: DispatchQueue.global())以降で同期的に呼んでいるため実際にはメインスレッド以外から
-    // 実行されることがあり、SettingsViewModel (実際にメインスレッドで実行) からのGlobal.skkservDict等への
-    // 書き込みとデータ競合する可能性がある。referDicts/findCompletionsDictsをnonisolated async化し、
-    // このメソッドの呼び出しをMainActor.run経由にすることで解消する予定。
-    @MainActor private func handleSKKServError() {
-        Global.skkservConsecutiveErrorCount += 1
-        if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {
-            logger.log("skkservへの接続エラーが\(Global.skkservConsecutiveErrorCount)回連続したため無効化します")
-            Global.skkservDict = nil
-            NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
+    /**
+     * skkservへの問い合わせ結果を処理する。成功時はエラーカウントをリセットしてonSuccessに結果を渡す。
+     * 失敗時はエラーカウントを増やし、連続エラー数が閾値に達していればskkservを無効化する。
+     *
+     * - TODO: このメソッドは@MainActor指定されているが、呼び出し元のInputControllerの補完検索を
+     * .receive(on: DispatchQueue.global())以降で同期的に呼んでいるため実際にはメインスレッド以外から
+     * 実行されることがあり、SettingsViewModel (実際にメインスレッドで実行) からのGlobal.skkservDict等への
+     * 書き込みとデータ競合する可能性がある。referDicts/findCompletionsDictsをnonisolated async化し、
+     * このメソッドの呼び出しをMainActor.run経由にすることで解消する予定。
+     */
+    @MainActor private func handleSKKServResult<T>(_ result: Result<T, any Error>, onSuccess: (T) -> Void) {
+        switch result {
+        case .success(let value):
+            Global.skkservConsecutiveErrorCount = 0
+            onSuccess(value)
+        case .failure:
+            Global.skkservConsecutiveErrorCount += 1
+            if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {
+                logger.log("skkservへの接続エラーが\(Global.skkservConsecutiveErrorCount)回連続したため無効化します")
+                Global.skkservDict = nil
+                NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
+            }
         }
     }
 }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -164,7 +164,9 @@ enum UserDictAddSource {
             }
         }
         // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
-        if let skkservDict {
+        // NOTE: Global.skkservDictは接続エラーが連続するとnilに変わるが、それを呼び出し側でチェックできてない。
+        // Swift Concurrency対応で呼び出し元で修正予定。
+        if let skkservDict, Global.skkservDict != nil {
             switch skkservDict.refer(yomi, option: option) {
             case .success(let words):
                 Global.skkservConsecutiveErrorCount = 0
@@ -202,7 +204,9 @@ enum UserDictAddSource {
                         })
                     }
                 }
-                if let skkservDict {
+                // NOTE: Global.skkservDictは接続エラーが連続するとnilに変わるが、それを呼び出し側でチェックできてない。
+                // Swift Concurrency対応で呼び出し元で修正予定。
+                if let skkservDict, Global.skkservDict != nil {
                     switch skkservDict.refer(midashi, option: option) {
                     case .success(let words):
                         Global.skkservConsecutiveErrorCount = 0

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -510,6 +510,11 @@ enum UserDictAddSource {
         return Candidate(word.word, annotations: annotations, original: original, saveToUserDict: saveToUserDict)
     }
 
+    // TODO: このメソッドは@MainActor指定されているが、呼び出し元のInputControllerの補完検索を
+    // .receive(on: DispatchQueue.global())以降で同期的に呼んでいるため実際にはメインスレッド以外から
+    // 実行されることがあり、SettingsViewModel (実際にメインスレッドで実行) からのGlobal.skkservDict等への
+    // 書き込みとデータ競合する可能性がある。referDicts/findCompletionsDictsをnonisolated async化し、
+    // このメソッドの呼び出しをMainActor.run経由にすることで解消する予定。
     @MainActor private func handleSKKServError() {
         Global.skkservConsecutiveErrorCount += 1
         if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -173,7 +173,7 @@ enum UserDictAddSource {
                     return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
                 })
             case .failure:
-                Global.handleSKKServError()
+                handleSKKServError()
             }
         }
         if candidates.isEmpty {
@@ -216,7 +216,7 @@ enum UserDictAddSource {
                                              saveToUserDict: skkservDict.saveToUserDict)
                         })
                     case .failure:
-                        Global.handleSKKServError()
+                        handleSKKServError()
                     }
                 }
             }
@@ -277,7 +277,7 @@ enum UserDictAddSource {
                     }
                 }
             case .failure:
-                Global.handleSKKServError()
+                handleSKKServError()
             }
         }
         return results
@@ -504,6 +504,15 @@ enum UserDictAddSource {
     private func wordToCandidate(_ word: Word, original: Candidate.Original?, saveToUserDict: Bool) -> Candidate {
         let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
         return Candidate(word.word, annotations: annotations, original: original, saveToUserDict: saveToUserDict)
+    }
+
+    @MainActor private func handleSKKServError() {
+        Global.skkservConsecutiveErrorCount += 1
+        if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {
+            logger.log("skkservへの接続エラーが\(Global.skkservConsecutiveErrorCount)回連続したため無効化します")
+            Global.skkservDict = nil
+            NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
+        }
     }
 }
 

--- a/macSKKTests/SKKServDictTests.swift
+++ b/macSKKTests/SKKServDictTests.swift
@@ -23,31 +23,30 @@ final class SKKServDictTests: XCTestCase {
 
     func testRefer() async throws {
         let service = MockedSKKServService(response: "1/変換/返還/")
-        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false, autoDisableThreshold: 1)
-        XCTAssertEqual(dict.refer("へんかん", option: nil).map { $0.word }, ["変換", "返還"])
+        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false)
+        XCTAssertEqual(try dict.refer("へんかん", option: nil).get().map { $0.word }, ["変換", "返還"])
     }
 
     func testReferNotFound() async throws {
         let service = MockedSKKServService(response: "4へんかん")
-        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false, autoDisableThreshold: 1)
-        XCTAssertEqual(dict.refer("へんかん", option: nil).map { $0.word }, [])
+        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false)
+        XCTAssertEqual(try dict.refer("へんかん", option: nil).get().map { $0.word }, [])
     }
 
     func testFindCompletion() async throws {
         let service = MockedSKKServService(response: "1/ほかん/ほかく/")
-        var dict = SKKServDict(destination: destination, service: service, saveToUserDict: false, autoDisableThreshold: 1)
-        XCTAssertEqual(dict.findCompletions(prefix: "ほか"), ["ほかん", "ほかく"])
+        var dict = SKKServDict(destination: destination, service: service, saveToUserDict: false)
+        XCTAssertEqual(try dict.findCompletions(prefix: "ほか").get(), ["ほかん", "ほかく"])
         // 重複した補完候補、読みと同じ候補、読みを接頭辞としてもたない候補は除外する
         dict = SKKServDict(destination: destination,
                            service: MockedSKKServService(response: "1/ほかん/ほかん/ほか/ほげ/"),
-                           saveToUserDict: false,
-                           autoDisableThreshold: 1)
-        XCTAssertEqual(dict.findCompletions(prefix: "ほか"), ["ほかん"])
+                           saveToUserDict: false)
+        XCTAssertEqual(try dict.findCompletions(prefix: "ほか").get(), ["ほかん"])
     }
 
     func testFindCompletionNotFound() async throws {
         let service = MockedSKKServService(response: "4ほかん")
-        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false, autoDisableThreshold: 1)
-        XCTAssertEqual(dict.findCompletions(prefix: "ほかん"), [])
+        let dict = SKKServDict(destination: destination, service: service, saveToUserDict: false)
+        XCTAssertEqual(try dict.findCompletions(prefix: "ほかん").get(), [])
     }
 }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -16,13 +16,13 @@ import Combine
             self.wordsPerYomi = wordsPerYomi
         }
 
-        func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
+        func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error> {
             referCallCount += 1
-            return wordsPerYomi[yomi] ?? []
+            return .success(wordsPerYomi[yomi] ?? [])
         }
 
-        func findCompletions(prefix: String) -> [String] {
-            return wordsPerYomi.keys.filter { $0.hasPrefix(prefix) && $0 != prefix }.sorted()
+        func findCompletions(prefix: String) -> Result<[String], any Error> {
+            return .success(wordsPerYomi.keys.filter { $0.hasPrefix(prefix) && $0 != prefix }.sorted())
         }
     }
 

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -25,11 +25,16 @@ final class UserDictTests: XCTestCase {
         super.tearDown()
     }
 
-    class MockSKKServDict: SKKServDictProtocol {
+    /**
+     * `referCallCount` は `@MainActor` に隔離した可変状態としているため、クラス自体は素直にSendableにできる。
+     * `refer(_:option:)` はプロトコル要件でnonisolatedな同期メソッドだが、
+     * 実際の呼び出しは常にMainActor経由であることが保証されているためassumeIsolatedで安全にアクセスする。
+     */
+    final class MockSKKServDict: SKKServDictProtocol, Sendable {
         let saveToUserDict = false
         let wordsPerYomi: [String: [Word]]
         let shouldFail: Bool
-        private(set) var referCallCount = 0
+        @MainActor private(set) var referCallCount = 0
 
         init(wordsPerYomi: [String: [Word]], shouldFail: Bool = false) {
             self.wordsPerYomi = wordsPerYomi
@@ -37,7 +42,7 @@ final class UserDictTests: XCTestCase {
         }
 
         func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error> {
-            referCallCount += 1
+            MainActor.assumeIsolated { referCallCount += 1 }
             if shouldFail {
                 return .failure(NSError(domain: "MockSKKServDict", code: 0))
             }
@@ -45,6 +50,9 @@ final class UserDictTests: XCTestCase {
         }
 
         func findCompletions(prefix: String) -> Result<[String], any Error> {
+            if shouldFail {
+                return .failure(NSError(domain: "MockSKKServDict", code: 0))
+            }
             return .success(wordsPerYomi.keys.filter { $0.hasPrefix(prefix) && $0 != prefix }.sorted())
         }
     }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -6,18 +6,41 @@ import Combine
 
 @testable import macSKK
 
-@MainActor final class UserDictTests: XCTestCase {
+final class UserDictTests: XCTestCase {
+    private var originalSkkservDict: (any SKKServDictProtocol)?
+    private var originalSkkservConsecutiveErrorCount = 0
+    private var originalSkkservAutoDisableThreshold = 0
+
+    @MainActor override func setUp() {
+        super.setUp()
+        originalSkkservDict = Global.skkservDict
+        originalSkkservConsecutiveErrorCount = Global.skkservConsecutiveErrorCount
+        originalSkkservAutoDisableThreshold = Global.skkservAutoDisableThreshold
+    }
+
+    @MainActor override func tearDown() {
+        Global.skkservDict = originalSkkservDict
+        Global.skkservConsecutiveErrorCount = originalSkkservConsecutiveErrorCount
+        Global.skkservAutoDisableThreshold = originalSkkservAutoDisableThreshold
+        super.tearDown()
+    }
+
     class MockSKKServDict: SKKServDictProtocol {
         let saveToUserDict = false
         let wordsPerYomi: [String: [Word]]
+        let shouldFail: Bool
         private(set) var referCallCount = 0
 
-        init(wordsPerYomi: [String: [Word]]) {
+        init(wordsPerYomi: [String: [Word]], shouldFail: Bool = false) {
             self.wordsPerYomi = wordsPerYomi
+            self.shouldFail = shouldFail
         }
 
         func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error> {
             referCallCount += 1
+            if shouldFail {
+                return .failure(NSError(domain: "MockSKKServDict", code: 0))
+            }
             return .success(wordsPerYomi[yomi] ?? [])
         }
 
@@ -76,7 +99,7 @@ import Combine
         XCTAssertEqual(userDict.referDicts("し", option: .prefix), [])
     }
 
-    func testPrivateMode() throws {
+    @MainActor func testPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let userDict = try UserDict(dicts: [],
                                     userDictEntries: ["い": [Word("位")]],
@@ -134,7 +157,7 @@ import Combine
         XCTAssertEqual(candidatesKyou.first?.word, "今日") // ユーザー辞書の方が日付変換より前
     }
 
-    func testFindCompletionsPrivateMode() throws {
+    @MainActor func testFindCompletionsPrivateMode() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(true)
         let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
@@ -155,7 +178,7 @@ import Combine
         XCTAssertEqual(userDict.findCompletions(prefix: "に"), ["にふ"])
     }
 
-    func testFindCompletionsDateYomi() throws {
+    @MainActor func testFindCompletionsDateYomi() throws {
         let userDict = try UserDict(dicts: [],
                                     userDictEntries: ["tower": [Word("塔")]],
                                     privateMode: CurrentValueSubject<Bool, Never>(false),
@@ -173,7 +196,8 @@ import Combine
         XCTAssertEqual(userDict.findCompletions(prefix: "y"), ["yesterday"])
     }
 
-    func testCandidatesForCompletion() throws {
+    // TODO: UserDict自体から `@MainActor` を外したらここの `@MainActor` を外す
+    @MainActor func testCandidatesForCompletion() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         let annotation1 = Annotation(dictId: UserDict.userDictFilename, text: "日本の注釈")
@@ -210,7 +234,8 @@ import Combine
         )
     }
 
-    func testCandidatesForCompletionTotalLimit() throws {
+    // TODO: UserDict自体から `@MainActor` を外したらここの `@MainActor` を外す
+    @MainActor func testCandidatesForCompletionTotalLimit() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         // 50見出し語×3候補=150件になるが返値は100件に絞られる
@@ -229,7 +254,8 @@ import Combine
         XCTAssertEqual(results.count, 100)
     }
 
-    func testCandidatesForCompletionSkkservLimit() throws {
+    // TODO: UserDict自体から `@MainActor` を外したらここの `@MainActor` を外す
+    @MainActor func testCandidatesForCompletionSkkservLimit() throws {
         let privateMode = CurrentValueSubject<Bool, Never>(false)
         let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
         // skkservへのreferの問い合わせがskkservCandidateLimit回で打ち切られることを確認
@@ -242,6 +268,7 @@ import Combine
         })
         let dict = MemoryDict(entries: dictEntries, readonly: false)
         let mock = MockSKKServDict(wordsPerYomi: skkservEntries)
+        Global.skkservDict = mock
         let userDict = try UserDict(
             dicts: [dict],
             userDictEntries: [:],
@@ -252,5 +279,20 @@ import Combine
         let limit = 9
         _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, referLimit: limit), findFromAllDicts: true)
         XCTAssertEqual(mock.referCallCount, limit)
+    }
+
+    @MainActor func testHandleSKKServErrorDisablesSkkservDict() throws {
+        let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
+        Global.skkservDict = mock
+        Global.skkservConsecutiveErrorCount = 0
+        Global.skkservAutoDisableThreshold = 1
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: [:],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        _ = userDict.referDicts("あい")
+        XCTAssertNil(Global.skkservDict)
     }
 }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -291,4 +291,31 @@ final class UserDictTests: XCTestCase {
         _ = userDict.referDicts("あい")
         XCTAssertNil(Global.skkservDict)
     }
+
+    // candidatesForCompletionの1回の呼び出し中にskkservが自動無効化された場合、
+    // それ以降のskkservへの問い合わせを打ち切ることを確認する
+    @MainActor func testCandidatesForCompletionStopsRequeryingAfterAutoDisabled() throws {
+        let yomis = (1...20).map { String(format: "あい%02d", $0) }
+        let dictEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
+            (yomi, [Word("漢字\(i + 1)")])
+        })
+        let dict = MemoryDict(entries: dictEntries, readonly: false)
+        let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
+        Global.skkservDict = mock
+        Global.skkservConsecutiveErrorCount = 0
+        // findCompletionsDicts内のmock.findCompletions()呼び出しで1回分エラーカウントが消費されるため、
+        // 残り2回のmock.refer()失敗で無効化されるように3を指定する
+        Global.skkservAutoDisableThreshold = 3
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: CurrentValueSubject<Bool, Never>(false),
+            ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+            dateYomis: [],
+            dateConversions: [])
+        _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, referLimit: 9), findFromAllDicts: true)
+        // referLimitの9回まで問い合わせを続けず、無効化された時点で打ち切られる
+        XCTAssertEqual(mock.referCallCount, 2)
+        XCTAssertNil(Global.skkservDict)
+    }
 }

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -7,22 +7,10 @@ import Combine
 @testable import macSKK
 
 final class UserDictTests: XCTestCase {
-    private var originalSkkservDict: (any SKKServDictProtocol)?
-    private var originalSkkservConsecutiveErrorCount = 0
-    private var originalSkkservAutoDisableThreshold = 0
-
     @MainActor override func setUp() {
-        super.setUp()
-        originalSkkservDict = Global.skkservDict
-        originalSkkservConsecutiveErrorCount = Global.skkservConsecutiveErrorCount
-        originalSkkservAutoDisableThreshold = Global.skkservAutoDisableThreshold
-    }
-
-    @MainActor override func tearDown() {
-        Global.skkservDict = originalSkkservDict
-        Global.skkservConsecutiveErrorCount = originalSkkservConsecutiveErrorCount
-        Global.skkservAutoDisableThreshold = originalSkkservAutoDisableThreshold
-        super.tearDown()
+        Global.skkservDict = nil
+        Global.skkservConsecutiveErrorCount = 0
+        Global.skkservAutoDisableThreshold = 3
     }
 
     /**


### PR DESCRIPTION
#489 Swift 6対応のため、SKKServDictをSendableに準拠させる。

変更可能なメンバー変数 `consecutiveErrorCount`, `isAutoDisabled` を `@MainActor` な Globalに移動。
SKKServDictのrefer/findCompletionsを `Result<..., any Error>` を返す形式に変更。