### PR TITLE
GitHub Actions環境をXcode 26.6に変更 (before 26.5) 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -47,7 +47,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
       - id: deployment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
     steps:
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode
     - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_26.5.app/Contents/Developer'
-    - uses: actions/checkout@v6
+      run: sudo xcode-select -s '/Applications/Xcode_26.6.app/Contents/Developer'
+    - uses: actions/checkout@v7
     - name: test
       run: |
         xcodebuild -target macSKKTests -scheme macSKK DEVELOPMENT_TEAM= test | xcbeautify


### PR DESCRIPTION
ついでに気付いたところも更新

- actions/checkout をv7に更新
- ドキュメントサイトのデプロイ用runnerをubuntu-slimに変更