### PR TITLE
メインのビルドターゲット以外でSWIFT_VERSION=6に変更

### DIFF
--- a/SKKServClient/SKKServClient.swift
+++ b/SKKServClient/SKKServClient.swift
@@ -10,11 +10,11 @@ let logger: Logger = Logger(subsystem: "net.mtgto.inputmethod.macSKK", category:
 /**
  * skkservに接続するクライアント。同時に1サーバーへの接続のみ可能
  */
-class SKKServClient: NSObject, SKKServClientProtocol {
+class SKKServClient: NSObject, SKKServClientProtocol, @unchecked Sendable {
     var connection: NWConnection? = nil
     static let queue = DispatchQueue(label: "net.mtgto.inputmethod.macSKK.SKKServClient", qos: .default)
 
-    @objc func serverVersion(destination: SKKServDestination, with reply: @escaping (String?, (any Error)?) -> Void) {
+    @objc func serverVersion(destination: SKKServDestination, with reply: @escaping @Sendable (String?, (any Error)?) -> Void) {
         connect(destination: destination) { result in
             switch result {
             case .success(let connection):
@@ -51,7 +51,7 @@ class SKKServClient: NSObject, SKKServClientProtocol {
         }
     }
 
-    @objc func refer(destination: SKKServDestination, yomi: String, with reply: @escaping (String?, (any Error)?) -> Void) {
+    @objc func refer(destination: SKKServDestination, yomi: String, with reply: @escaping @Sendable (String?, (any Error)?) -> Void) {
         connect(destination: destination) { result in
             switch result {
             case .success(let connection):
@@ -98,7 +98,7 @@ class SKKServClient: NSObject, SKKServClientProtocol {
         }
     }
 
-    @objc func completion(destination: SKKServDestination, yomi: String, with reply: @escaping (String?, (any Error)?) -> Void) {
+    @objc func completion(destination: SKKServDestination, yomi: String, with reply: @escaping @Sendable (String?, (any Error)?) -> Void) {
         connect(destination: destination) { result in
             switch result {
             case .success(let connection):
@@ -149,7 +149,7 @@ class SKKServClient: NSObject, SKKServClientProtocol {
         connection?.forceCancel()
     }
 
-    private func connect(destination: SKKServDestination, callback: @escaping (Result<NWConnection?, any Error>) -> Void) {
+    private func connect(destination: SKKServDestination, callback: @escaping @Sendable (Result<NWConnection?, any Error>) -> Void) {
         // NOTE: connectionの読み取りはXPCスレッドから、書き込みはSelf.queue上のstateUpdateHandlerから行われるため
         // 厳密にはread-write raceが残る。実害としては古い値を見て余分な接続を試みる程度。
         if let connection, case .ready = connection.state, connection.endpoint == destination.endpoint {
@@ -160,7 +160,9 @@ class SKKServClient: NSObject, SKKServClientProtocol {
         connection?.forceCancel()
 
         let connection = NWConnection(to: destination.endpoint, using: .skkserv)
-        var callbackCalled = false
+        // NOTE: stateUpdateHandlerはstart(queue:)で指定したqueue上で直列に呼ばれることが保証されているため、
+        // 実質的には並行アクセスは発生しない
+        nonisolated(unsafe) var callbackCalled = false
         connection.stateUpdateHandler = { state in
             switch state {
             case .ready:
@@ -223,12 +225,12 @@ class SKKServClient: NSObject, SKKServClientProtocol {
 }
 
 extension NWConnection {
-    func send(message: NWProtocolFramer.Message, callback: @escaping (NWError?) -> Void) {
+    func send(message: NWProtocolFramer.Message, callback: @escaping @Sendable (NWError?) -> Void) {
         let context = NWConnection.ContentContext(identifier: "SKKServRequest", metadata: [message])
         send(content: nil, contentContext: context, isComplete: true, completion: .contentProcessed(callback))
     }
 
-    func receive(callback: @escaping (Result<Data?, NWError>) -> Void) {
+    func receive(callback: @escaping @Sendable (Result<Data?, NWError>) -> Void) {
         receiveMessage { content, contentContext, isComplete, error in
             if let error {
                 callback(.failure(error))

--- a/SKKServClient/SKKServClientProtocol.swift
+++ b/SKKServClient/SKKServClientProtocol.swift
@@ -99,8 +99,8 @@ public enum SKKServClientError: Error, CaseIterable {
 }
 
 @objc protocol SKKServClientProtocol {
-    func serverVersion(destination: SKKServDestination, with reply: @escaping (String?, (any Error)?) -> Void)
-    func refer(destination: SKKServDestination, yomi: String, with reply: @escaping (String?, (any Error)?) -> Void)
-    func completion(destination: SKKServDestination, yomi: String, with reply: @escaping (String?, (any Error)?) -> Void)
+    func serverVersion(destination: SKKServDestination, with reply: @escaping @Sendable (String?, (any Error)?) -> Void)
+    func refer(destination: SKKServDestination, yomi: String, with reply: @escaping @Sendable (String?, (any Error)?) -> Void)
+    func completion(destination: SKKServDestination, yomi: String, with reply: @escaping @Sendable (String?, (any Error)?) -> Void)
     func disconnect()
 }

--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -1284,7 +1284,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.mtgto.inputmethod.macSKKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/macSKK.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/macSKK";
 			};
 			name = Debug;
@@ -1301,7 +1301,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.mtgto.inputmethod.macSKKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/macSKK.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/macSKK";
 			};
 			name = Release;
@@ -1322,7 +1322,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -1342,7 +1342,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -1363,7 +1363,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -1383,7 +1383,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};

--- a/macSKK/SKKServService.swift
+++ b/macSKK/SKKServService.swift
@@ -46,13 +46,14 @@ struct SKKServService: SKKServServiceProtocol, @unchecked Sendable {
             throw SKKServClientError.unexpected
         }
         let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<String, any Error> = .failure(SKKServClientError.unexpected)
-        // NOTE: XPCからのコールバックはメインスレッドとは別のスレッドから返ってくる
+        // NOTE: XPCからのコールバックはメインスレッドとは別のスレッドから返ってくるが、
+        // semaphore.wait(_:)で同期を取っているため並行アクセスは発生しない
+        nonisolated(unsafe) var result: Result<String, any Error> = .failure(SKKServClientError.unexpected)
         proxy.serverVersion(destination: destination) { version, error in
             if let version {
                 result = .success(version)
             } else if let error {
-                result = .failure(recastSKKServClientError(error))
+                result = .failure(Self.recastSKKServClientError(error))
             } else {
                 fatalError("SKKServClientから不正な応答が返りました")
             }
@@ -91,13 +92,14 @@ struct SKKServService: SKKServServiceProtocol, @unchecked Sendable {
             throw SKKServClientError.unexpected
         }
         let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<String, any Error> = .failure(SKKServClientError.unexpected)
-        // NOTE: XPCからのコールバックはメインスレッドとは別のスレッドから返ってくる
+        // NOTE: XPCからのコールバックはメインスレッドとは別のスレッドから返ってくるが、
+        // semaphore.wait(_:)で同期を取っているため並行アクセスは発生しない
+        nonisolated(unsafe) var result: Result<String, any Error> = .failure(SKKServClientError.unexpected)
         proxy.refer(destination: destination, yomi: yomi) { line, error in
             if let line {
                 result = .success(line)
             } else if let error {
-                result = .failure(recastSKKServClientError(error))
+                result = .failure(Self.recastSKKServClientError(error))
             } else {
                 fatalError("SKKServClientから不正な応答が返りました")
             }
@@ -124,13 +126,14 @@ struct SKKServService: SKKServServiceProtocol, @unchecked Sendable {
             throw SKKServClientError.unexpected
         }
         let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<String, any Error> = .failure(SKKServClientError.unexpected)
-        // NOTE: XPCからのコールバックはメインスレッドとは別のスレッドから返ってくる
+        // NOTE: XPCからのコールバックはメインスレッドとは別のスレッドから返ってくるが、
+        // semaphore.wait(_:)で同期を取っているため並行アクセスは発生しない
+        nonisolated(unsafe) var result: Result<String, any Error> = .failure(SKKServClientError.unexpected)
         proxy.completion(destination: destination, yomi: yomi) { line, error in
             if let line {
                 result = .success(line)
             } else if let error {
-                result = .failure(recastSKKServClientError(error))
+                result = .failure(Self.recastSKKServClientError(error))
             } else {
                 fatalError("SKKServClientから不正な応答が返りました")
             }
@@ -169,7 +172,7 @@ struct SKKServService: SKKServServiceProtocol, @unchecked Sendable {
      * しかたないのでNSError#domainとNSError#codeからSKKServClientErrorに変換する
      * @see https://zenn.dev/mtgto/articles/swift-macos-odd-problems-using-xpc
      */
-    private func recastSKKServClientError(_ error: any Error) -> any Error {
+    private static func recastSKKServClientError(_ error: any Error) -> any Error {
         // Task.checkCancellationでエラーが発生 == XPCでタイムアウトした
         if error is CancellationError {
             return SKKServClientError.timeout

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -9,23 +9,25 @@ import XCTest
 final class StateMachineTests: XCTestCase {
     var cancellables: Set<AnyCancellable> = []
 
-    @MainActor override func setUpWithError() throws {
-        Global.dictionary.setEntries([:])
-        Global.privateMode.send(false)
-        Global.skkservDict = nil
+    override func setUp() async throws {
         cancellables = []
-        // テストごとにローマ字かな変換ルールをデフォルトに戻す
-        // こうしないとテストの中でGlobal.kanaRuleを書き換えるテストと一緒に走らせると違うかな変換ルールのままに実行されてしまう
-        Global.kanaRule = Romaji.defaultKanaRule
-        Global.selectCandidateKeys = "123456789".map { $0 }
-        Global.enterNewLine = false
-        Global.selectingBackspace = SelectingBackspace.default
-        Global.candidateListDirection.send(.vertical)
-        Global.keyBinding = KeyBindingSet.defaultKeyBindingSet
-        Global.ignoreLeadingSpacesWhenRegistering = true
-        Global.backToSelectingFromRegistering = false
-        Global.yomiCompletionByTabInRegistering = false
-        Global.displayCandidateCount = 9
+        await MainActor.run {
+            Global.dictionary.setEntries([:])
+            Global.privateMode.send(false)
+            Global.skkservDict = nil
+            // テストごとにローマ字かな変換ルールをデフォルトに戻す
+            // こうしないとテストの中でGlobal.kanaRuleを書き換えるテストと一緒に走らせると違うかな変換ルールのままに実行されてしまう
+            Global.kanaRule = Romaji.defaultKanaRule
+            Global.selectCandidateKeys = "123456789".map { $0 }
+            Global.enterNewLine = false
+            Global.selectingBackspace = SelectingBackspace.default
+            Global.candidateListDirection.send(.vertical)
+            Global.keyBinding = KeyBindingSet.defaultKeyBindingSet
+            Global.ignoreLeadingSpacesWhenRegistering = true
+            Global.backToSelectingFromRegistering = false
+            Global.yomiCompletionByTabInRegistering = false
+            Global.displayCandidateCount = 9
+        }
     }
 
     @MainActor func testHandleNormalSimple() {

--- a/macSKKTests/StateTests.swift
+++ b/macSKKTests/StateTests.swift
@@ -6,8 +6,10 @@ import XCTest
 @testable import macSKK
 
 final class StateTests: XCTestCase {
-    @MainActor override func setUp() {
-        Global.kanaRule = Romaji.defaultKanaRule
+    override func setUp() async throws {
+        await MainActor.run {
+            Global.kanaRule = Romaji.defaultKanaRule
+        }
     }
 
     func testComposingStateAppendText() throws {

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -7,10 +7,12 @@ import Combine
 @testable import macSKK
 
 final class UserDictTests: XCTestCase {
-    @MainActor override func setUp() {
-        Global.skkservDict = nil
-        Global.skkservConsecutiveErrorCount = 0
-        Global.skkservAutoDisableThreshold = 3
+    override func setUp() async throws {
+        await MainActor.run {
+            Global.skkservDict = nil
+            Global.skkservConsecutiveErrorCount = 0
+            Global.skkservAutoDisableThreshold = 3
+        }
     }
 
     /**


### PR DESCRIPTION
#489 Swift 6対応のため、Xcodeprojのメインターゲット以外のSWIFT_VERSIONを5から6に変更。
コンパイルエラー、警告を修正。

macSKKターゲットはInputMethodKit frameworkのIMKInputControllerが対応されないと完全には解消されないけど、overrideしているメソッド内をすべて `MainActor.assumeIsolated { ... }` で囲んであげればSWIFT_VERSION=6にもいけそうな気がする。