### PR TITLE
skkserv自動無効化通知に実際の連続エラー回数を表示する

### DIFF
--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -578,11 +578,12 @@ final class SettingsViewModel: ObservableObject {
 
         NotificationCenter.default.publisher(for: notificationNameSKKServAutoDisabled)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] notification in
                 guard let self else { return }
                 self.skkservDictSetting.enabled = false
                 self.skkservDictSetting = self.skkservDictSetting
-                UNNotifier.sendNotificationForSKKServAutoDisabled()
+                let consecutiveErrorCount = notification.object as? Int ?? Global.skkservAutoDisableThreshold
+                UNNotifier.sendNotificationForSKKServAutoDisabled(consecutiveErrorCount: consecutiveErrorCount)
             }
             .store(in: &cancellables)
 

--- a/macSKK/UNNotifier.swift
+++ b/macSKK/UNNotifier.swift
@@ -31,10 +31,10 @@ struct UNNotifier {
         sendUserNotification(request: request)
     }
 
-    static func sendNotificationForSKKServAutoDisabled() {
+    static func sendNotificationForSKKServAutoDisabled(consecutiveErrorCount: Int) {
         let content = UNMutableNotificationContent()
         content.title = String(localized: "UNSKKServAutoDisabledTitle", comment: "SKKServの自動無効化")
-        content.body = String(localized: "UNSKKServAutoDisabledBody", comment: "SKKServへの接続エラーが連続して発生したため無効化されました")
+        content.body = String(format: String(localized: "UNSKKServAutoDisabledBody", comment: "SKKServへの接続エラーが連続して発生したため無効化されました"), consecutiveErrorCount)
 
         let request = UNNotificationRequest(identifier: Self.userNotificationSKKServAutoDisabledIdentifier, content: content, trigger: nil)
         sendUserNotification(request: request)

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -518,7 +518,7 @@ enum UserDictAddSource {
             if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {
                 logger.log("skkservへの接続エラーが\(Global.skkservConsecutiveErrorCount)回連続したため無効化します")
                 Global.skkservDict = nil
-                NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: nil)
+                NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: Global.skkservConsecutiveErrorCount)
             }
         }
     }

--- a/macSKK/en.lproj/Localizable.strings
+++ b/macSKK/en.lproj/Localizable.strings
@@ -60,7 +60,7 @@
 "UNUserDictWriteErrorTitle" = "Error";
 "UNUserDictWriteErrorBody" = "Failed to save the user dictionary";
 "UNSKKServAutoDisabledTitle" = "SKKServ Disabled";
-"UNSKKServAutoDisabledBody" = "SKKServ was automatically disabled after 3 consecutive connection errors.";
+"UNSKKServAutoDisabledBody" = "SKKServ was automatically disabled after %d consecutive connection errors.";
 "User Dictionary" = "User Dictionary";
 "Delete" = "Delete";
 "Unregistered" = "Unregistered";

--- a/macSKK/ja.lproj/Localizable.strings
+++ b/macSKK/ja.lproj/Localizable.strings
@@ -60,7 +60,7 @@
 "UNUserDictWriteErrorTitle" = "エラー";
 "UNUserDictWriteErrorBody" = "ユーザー辞書の永続化に失敗しました";
 "UNSKKServAutoDisabledTitle" = "SKKServを無効化しました";
-"UNSKKServAutoDisabledBody" = "skkservへの接続エラーが3回連続したため自動で無効化しました。";
+"UNSKKServAutoDisabledBody" = "skkservへの接続エラーが%d回連続したため自動で無効化しました。";
 "User Dictionary" = "ユーザー辞書";
 "Delete" = "削除";
 "Unregistered" = "未登録です";


### PR DESCRIPTION
skkserv の自動無効化通知の本文が「3回連続」と固定文字列になっており、設定した「無効化に必要な連続エラーの回数」を反映していませんでした。無効化の判定自体は設定値どおり行われていますが、通知の `Localizable.strings` だけが `3` をハードコードしていたためです。

`UNSKKServAutoDisabledBody` を `%d` 形式にし、通知に実際の連続エラー回数を渡すようにします。