### PR TITLE
補完候補検索処理をCompletionPresenterへ切り出しユニットテストを追加

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		94DB63242D329CBF005250B8 /* HorizontalCandidatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB63222D329CBF005250B8 /* HorizontalCandidatesView.swift */; };
 		94DB63252D329CBF005250B8 /* VerticalCandidatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB63232D329CBF005250B8 /* VerticalCandidatesView.swift */; };
 		B3C350D6E32E35775AE1FF56 /* DateConversionYomiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073E79CEC2123C051D8BB83B /* DateConversionYomiTests.swift */; };
+		CE00C0DE0000000000000001 /* CompletionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE00C0DE0000000000000002 /* CompletionPresenter.swift */; };
+		CE00C0DE0000000000000003 /* CompletionPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE00C0DE0000000000000004 /* CompletionPresenterTests.swift */; };
 		CE0326A02C5D1DD6000FF691 /* SKK-JISYO.test.json in Resources */ = {isa = PBXBuildFile; fileRef = CE03269F2C5D1DD6000FF691 /* SKK-JISYO.test.json */; };
 		CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE06CA292AAC171B00E80E5E /* FileDictTests.swift */; };
 		CE06CA2D2AAC172F00E80E5E /* empty.txt in Resources */ = {isa = PBXBuildFile; fileRef = CE06CA2C2AAC172F00E80E5E /* empty.txt */; };
@@ -215,6 +217,8 @@
 		4B8E87D72CE0689D004E7461 /* CurrentInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentInputTests.swift; sourceTree = "<group>"; };
 		94DB63222D329CBF005250B8 /* HorizontalCandidatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCandidatesView.swift; sourceTree = "<group>"; };
 		94DB63232D329CBF005250B8 /* VerticalCandidatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCandidatesView.swift; sourceTree = "<group>"; };
+		CE00C0DE0000000000000002 /* CompletionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPresenter.swift; sourceTree = "<group>"; };
+		CE00C0DE0000000000000004 /* CompletionPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPresenterTests.swift; sourceTree = "<group>"; };
 		CE03269F2C5D1DD6000FF691 /* SKK-JISYO.test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "SKK-JISYO.test.json"; sourceTree = "<group>"; };
 		CE06CA292AAC171B00E80E5E /* FileDictTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDictTests.swift; sourceTree = "<group>"; };
 		CE06CA2C2AAC172F00E80E5E /* empty.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
@@ -474,6 +478,7 @@
 				CE7F9AD82AADEBF9001B1877 /* AppDelegate.swift */,
 				CE11C7B42BDD461C00A35F3D /* Global.swift */,
 				CE84A3B829570C37009394C4 /* InputController.swift */,
+				CE00C0DE0000000000000002 /* CompletionPresenter.swift */,
 				CE84A3DD29571797009394C4 /* Action.swift */,
 				CE39DB202A8DFD8F00BC619F /* MarkedText.swift */,
 				CE84A3DB2957174D009394C4 /* State.swift */,
@@ -559,6 +564,7 @@
 				CE84A3EC295DA818009394C4 /* MemoryDictTests.swift */,
 				CE06CA292AAC171B00E80E5E /* FileDictTests.swift */,
 				CEA78FB129646CA100B67E25 /* UserDictTests.swift */,
+				CE00C0DE0000000000000004 /* CompletionPresenterTests.swift */,
 				CED1CA1D2BAFBE0600C32AE3 /* SKKServDictTests.swift */,
 				CEADA44C2B025A8A0026E2BD /* EntryTests.swift */,
 				CE84A3E8295DA504009394C4 /* RomajiTests.swift */,
@@ -916,6 +922,7 @@
 				CED7F51F2AB5F4A7007FC6BD /* Character+Additions.swift in Sources */,
 				CE2157662B2EA985006E4C41 /* UserDefaultsKeys.swift in Sources */,
 				CE84A3B929570C37009394C4 /* InputController.swift in Sources */,
+				CE00C0DE0000000000000001 /* CompletionPresenter.swift in Sources */,
 				CE6599DC2ADBF2630052F8C0 /* SettingsWindow.swift in Sources */,
 				CE3E44AD2B5391DB00105798 /* SettingsWatcher.swift in Sources */,
 				CE39FA972BF0813E00E293F0 /* KeyBindingSet.swift in Sources */,
@@ -1018,6 +1025,7 @@
 				CE8DFE092CBEAA2900A24230 /* Character+AdditionsTests.swift in Sources */,
 				CE2F3B132C030C9A00CE342B /* KeyBindingTests.swift in Sources */,
 				CEA78FB229646CA100B67E25 /* UserDictTests.swift in Sources */,
+				CE00C0DE0000000000000003 /* CompletionPresenterTests.swift in Sources */,
 				CE06CA2B2AAC171B00E80E5E /* FileDictTests.swift in Sources */,
 				CED1CA1E2BAFBE0600C32AE3 /* SKKServDictTests.swift in Sources */,
 				CE6DBA912A846C1700F5A227 /* ReleaseVersionTests.swift in Sources */,

--- a/macSKK/CompletionPresenter.swift
+++ b/macSKK/CompletionPresenter.swift
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+import Combine
+
+/// 補完候補パネルの表示を抽象化するプロトコル。
+/// InputControllerからは具象の`CompletionPanel`を注入し、テストではモックを注入する。
+@MainActor protocol CompletionPanelProtocol: AnyObject {
+    /// 表示する補完候補を設定する。
+    func setCompletion(_ completion: CurrentCompletion)
+    /// 補完候補パネルをカーソル位置に表示する。
+    func show(at cursorPosition: NSRect, windowLevel: NSWindow.Level)
+    /// 補完候補パネルを非表示にする。
+    func orderOut(_ sender: Any?)
+}
+
+/// 補完のレース判定に必要なStateMachineの状態を抽象化するプロトコル。
+@MainActor protocol CompletionStateProtocol: AnyObject {
+    /// 読み入力中(送り仮名なし)ならその読み文字列。それ以外(変換中・送り仮名入力中・未入力)はnil。
+    var currentComposingYomi: String? { get }
+    /// 現在の補完候補。
+    var completion: Completion? { get set }
+}
+
+/// 読みの更新イベントを購読して補完候補を検索し、補完候補パネルへ反映(提示)する。
+///
+/// 検索はDispatchQueue.global()で実行し、結果の反映(`apply`)はMainActorで行う。
+/// UIと状態はプロトコルで注入するため、XCTestからモックを使って補完ロジックを検証できる。
+@MainActor final class CompletionPresenter {
+    private let panel: any CompletionPanelProtocol
+    private var cancellable: AnyCancellable?
+
+    init(panel: any CompletionPanelProtocol) {
+        self.panel = panel
+    }
+
+    /// `yomiEvent`を購読して補完候補の検索・表示を行うパイプラインを構築する。
+    ///
+    /// 補完候補の検索はDispatchQueue.global()で行い、検索結果の反映はMainActorで行う。
+    /// `cursorPosition`/`windowLevel`はtextInput依存のためクロージャで受け取り、
+    /// 検索が必要(=読みが空でない)なときだけ評価する。
+    func subscribe(to yomiEvent: AnyPublisher<YomiEvent, Never>,
+                   state: any CompletionStateProtocol,
+                   cursorPosition: @escaping () -> NSRect,
+                   windowLevel: @escaping () -> NSWindow.Level) {
+        cancellable = yomiEvent
+            .compactMap { [weak self] event -> (String, NSRect)? in
+                guard let self else { return nil }
+                if Global.showCompletion {
+                    if case .other(let yomi) = event {
+                        // 変換開始時などもyomiが空になるので、そのときは
+                        // すでにCandidatesPanelによる補完候補が表示されていることがあるのでCompletionPanelを閉じる。
+                        // YomiEvent.otherじゃないときは補完されたときなので何もしない。
+                        if yomi.isEmpty {
+                            self.panel.orderOut(nil)
+                            state.completion = nil
+                        } else {
+                            return (yomi, cursorPosition())
+                        }
+                    }
+                }
+                return nil
+            }
+            .receive(on: DispatchQueue.global())
+            .map { (yomi, cursor) -> (String, Completion, NSRect) in
+                (yomi, Self.search(prefix: yomi), cursor)
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (yomi, completion, cursor) in
+                self?.apply(completion,
+                            yomi: yomi,
+                            cursorPosition: cursor,
+                            windowLevel: windowLevel(),
+                            displayCandidateCount: Global.displayCandidateCount,
+                            state: state)
+            }
+    }
+
+    /// 補完候補を辞書から検索する。
+    static func search(prefix yomi: String) -> Completion {
+        let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
+        if Global.showCandidateForCompletion {
+            let skkservOption = skkservDict.map { CompletionSKKServOption(dict: $0, referLimit: Global.displayCandidateCount) }
+            let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi,
+                                                                       skkservOption: skkservOption,
+                                                                       findFromAllDicts: Global.findCompletionFromAllDicts)
+            return .candidates(candidates)
+        } else {
+            let completions = Global.dictionary.findCompletionsDicts(prefix: yomi,
+                                                                     skkservDict: skkservDict,
+                                                                     findFromAllDicts: Global.findCompletionFromAllDicts)
+            return .yomi(completions, 0)
+        }
+    }
+
+    /// 補完候補の検索結果を補完候補パネルと状態へ反映する。
+    func apply(_ completion: Completion,
+               yomi: String,
+               cursorPosition: NSRect,
+               windowLevel: NSWindow.Level,
+               displayCandidateCount: Int,
+               state: any CompletionStateProtocol) {
+        // 補完候補の検索を別スレッドで実行しているため、その間に読みが変更されたり変換を開始したり確定している可能性がある。
+        // 現在の読みが検索時と異なる場合(送り仮名入力中や読み入力中でない場合も含む)は補完候補検索結果を捨てて何もしない。
+        guard state.currentComposingYomi == yomi else {
+            logger.info("補完候補を検索しましたが現在の読みが検索時と変わっているため補完候補は表示しません")
+            return
+        }
+        state.completion = completion
+        switch completion {
+        case .yomi(let yomis, let index):
+            if yomis.isEmpty {
+                panel.orderOut(nil)
+                state.completion = nil
+            } else {
+                panel.setCompletion(.yomi(yomis[index]))
+                showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
+            }
+        case .candidates(let candidates):
+            if candidates.isEmpty {
+                panel.orderOut(nil)
+                state.completion = nil
+            } else {
+                // 先頭1ページ分だけ補完候補パネルに表示する。
+                panel.setCompletion(.candidates(Array(candidates.prefix(displayCandidateCount))))
+                showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
+            }
+        }
+    }
+
+    /// カーソル位置が取得できているときだけ補完候補パネルを表示する。
+    private func showIfPositioned(at cursorPosition: NSRect, windowLevel: NSWindow.Level) {
+        if cursorPosition != .zero {
+            panel.show(at: cursorPosition, windowLevel: windowLevel)
+        }
+    }
+}

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -21,6 +21,7 @@ class InputController: IMKInputController {
     private let stateMachine = StateMachine()
     private var targetApp: TargetApplication! = nil
     private var cancellables: Set<AnyCancellable> = []
+    private let completionPresenter = CompletionPresenter(panel: Global.completionPanel)
     private static let notFoundRange = NSRange(location: NSNotFound, length: NSNotFound)
     /// 変換候補として選択されている単語を流すストリーム
     private let selectedWord = PassthroughSubject<Word.Word?, Never>()
@@ -173,79 +174,13 @@ class InputController: IMKInputController {
                 self?.showMarkerWhenEmpty = bundleIdentifiers.contains(bundleIdentifier)
             }
         }.store(in: &cancellables)
-        // 読みが更新されたときに補完候補の検索を行う処理
-        stateMachine.yomiEvent
-            .compactMap { [weak self] yomi -> (String, NSRect)? in
-                guard let self else { return nil }
-                if Global.showCompletion {
-                    if case .other(let yomi) = yomi {
-                        // 変換開始時などもyomiが空になるのでそのときは
-                        // すでにCandidatesPanelによる補完候補が表示されていることがあるのでCompletionPanelを閉じる
-                        // YomiEvent.otherじゃないときは補完されたときなのでそのときは何もしない
-                        if yomi.isEmpty {
-                            if Global.showCompletion {
-                                Global.completionPanel.orderOut(nil)
-                                self.stateMachine.completion = nil
-                            }
-                        } else {
-                            let cursorPosition = self.cursorPosition(for: textInput)
-                            return (yomi, cursorPosition)
-                        }
-                    }
-                }
-                return nil
-            }
-            .receive(on: DispatchQueue.global())
-            .compactMap { (yomi, cursorPosition) -> (String, Completion, NSRect)? in
-                let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
-                let skkservOption = skkservDict.map { CompletionSKKServOption(dict: $0, referLimit: Global.displayCandidateCount) }
-                if Global.showCandidateForCompletion {
-                    let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi, skkservOption: skkservOption, findFromAllDicts: Global.findCompletionFromAllDicts)
-                    return (yomi, .candidates(candidates), cursorPosition)
-                } else {
-                    let completions = Global.dictionary.findCompletionsDicts(prefix: yomi, skkservDict: skkservDict, findFromAllDicts: Global.findCompletionFromAllDicts)
-                    return (yomi, .yomi(completions, 0), cursorPosition)
-                }
-            }
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] (yomi, completion, cursorPosition) in
-                guard let self else { return }
-                // 補完候補の検索を別スレッドで実行しているため、その間に読みが変更されたり変換を開始したり確定している可能性がある。
-                // 現在のStateMachineの読みが異なる場合は補完候補検索結果を捨てて何もしない
-                // okuri == nilのチェックはupdateMarkedTextの補完条件と合わせるため (送り仮名入力中は補完しない)
-                if case .composing(let composing) = self.stateMachine.state.inputMethod, composing.okuri == nil {
-                    if yomi != composing.yomi(for: .hiragana, kanaRule: Global.kanaRule) {
-                        logger.info("補完候補を検索しましたが現在の読みが補完候補検索時と変わっているため補完候補は表示しません")
-                        return
-                    }
-                } else {
-                    logger.info("補完候補を検索しましたが現在の変換の状態が読み入力中でないため補完候補は表示しません")
-                    return
-                }
-                self.stateMachine.completion = completion
-                if case .yomi(let yomis, let yomiIndex) = completion {
-                    if yomis.isEmpty {
-                        Global.completionPanel.orderOut(nil)
-                        self.stateMachine.completion = nil
-                    } else {
-                        Global.completionPanel.viewModel.completion = .yomi(yomis[yomiIndex])
-                        if cursorPosition != .zero {
-                            Global.completionPanel.show(at: cursorPosition, windowLevel: windowLevel(for: textInput))
-                        }
-                    }
-                } else if case .candidates(let candidates) = completion {
-                    if candidates.isEmpty {
-                        Global.completionPanel.orderOut(nil)
-                        self.stateMachine.completion = nil
-                    } else {
-                        // 先頭1ページ分だけ変換候補パネルに表示する。
-                        Global.completionPanel.viewModel.completion = .candidates(Array(candidates.prefix(Global.displayCandidateCount)))
-                        if cursorPosition != .zero {
-                            Global.completionPanel.show(at: cursorPosition, windowLevel: windowLevel(for: textInput))
-                        }
-                    }
-                }
-        }.store(in: &cancellables)
+        // 読みが更新されたときに補完候補の検索・表示を行う処理。
+        // 検索(DispatchQueue.global())と補完候補パネルへの反映はCompletionPresenterに委譲している。
+        completionPresenter.subscribe(
+            to: stateMachine.yomiEvent,
+            state: stateMachine,
+            cursorPosition: { [weak self] in self?.cursorPosition(for: textInput) ?? .zero },
+            windowLevel: { [weak self] in self?.windowLevel(for: textInput) ?? .floating })
         // 読みの補完候補が更新されたときの処理
         stateMachine.yomiEvent
             .compactMap {

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1753,3 +1753,14 @@ final class StateMachine {
         }
     }
 }
+
+extension StateMachine: CompletionStateProtocol {
+    /// 読み入力中(送り仮名なし)ならその読み文字列。それ以外(変換中・送り仮名入力中・未入力)はnil。
+    @MainActor var currentComposingYomi: String? {
+        // okuri == nilのチェックはupdateMarkedTextの補完条件と合わせるため(送り仮名入力中は補完しない)
+        if case .composing(let composing) = state.inputMethod, composing.okuri == nil {
+            return composing.yomi(for: .hiragana, kanaRule: Global.kanaRule)
+        }
+        return nil
+    }
+}

--- a/macSKK/View/CompletionPanel.swift
+++ b/macSKK/View/CompletionPanel.swift
@@ -58,3 +58,9 @@ class CompletionPanel: NSPanel {
         orderFrontRegardless()
     }
 }
+
+extension CompletionPanel: CompletionPanelProtocol {
+    func setCompletion(_ completion: CurrentCompletion) {
+        viewModel.completion = completion
+    }
+}

--- a/macSKKTests/CompletionPresenterTests.swift
+++ b/macSKKTests/CompletionPresenterTests.swift
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AppKit
+import Combine
+import XCTest
+
+@testable import macSKK
+
+/// 補完候補パネルの呼び出しを記録するモック。
+@MainActor final class MockCompletionPanel: CompletionPanelProtocol {
+    private(set) var completions: [CurrentCompletion] = []
+    private(set) var showCount = 0
+    private(set) var orderOutCount = 0
+    /// 非同期パイプラインの完了待ちに使うコールバック。
+    var onUpdate: (() -> Void)?
+
+    func setCompletion(_ completion: CurrentCompletion) {
+        completions.append(completion)
+        onUpdate?()
+    }
+
+    func show(at cursorPosition: NSRect, windowLevel: NSWindow.Level) {
+        showCount += 1
+    }
+
+    func orderOut(_ sender: Any?) {
+        orderOutCount += 1
+        onUpdate?()
+    }
+}
+
+/// レース判定用の状態を差し替え可能にするモック。
+@MainActor final class MockCompletionState: CompletionStateProtocol {
+    var currentComposingYomi: String?
+    var completion: Completion?
+
+    init(currentComposingYomi: String? = nil, completion: Completion? = nil) {
+        self.currentComposingYomi = currentComposingYomi
+        self.completion = completion
+    }
+}
+
+final class CompletionPresenterTests: XCTestCase {
+    override func setUp() async throws {
+        await MainActor.run {
+            Global.showCompletion = true
+            Global.showCandidateForCompletion = true
+            Global.findCompletionFromAllDicts = false
+            Global.searchCompletionsSkkserv = false
+            Global.skkservDict = nil
+            Global.displayCandidateCount = 9
+            Global.kanaRule = Romaji.defaultKanaRule
+            Global.privateMode.send(false)
+        }
+    }
+
+    @MainActor private func makePresenter() -> (CompletionPresenter, MockCompletionPanel) {
+        let panel = MockCompletionPanel()
+        return (CompletionPresenter(panel: panel), panel)
+    }
+
+    private func nonZeroCursor() -> NSRect {
+        NSRect(x: 10, y: 20, width: 1, height: 16)
+    }
+
+    @MainActor private func makeUserDict(entries: [String: [Word]]) throws -> UserDict {
+        try UserDict(dicts: [],
+                     userDictEntries: entries,
+                     privateMode: CurrentValueSubject<Bool, Never>(false),
+                     ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                     dateYomis: [],
+                     dateConversions: [])
+    }
+
+    // MARK: - subscribe()
+
+    @MainActor func testSubscribeSearchesAndShowsCandidates() throws {
+        Global.showCandidateForCompletion = true
+        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいこ": [Word("愛子")], "あいさつ": [Word("挨拶")]])
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let subject = PassthroughSubject<YomiEvent, Never>()
+        let expectation = expectation(description: "補完候補が表示される")
+        panel.onUpdate = { expectation.fulfill() }
+        presenter.subscribe(to: subject.eraseToAnyPublisher(),
+                             state: state,
+                             cursorPosition: { self.nonZeroCursor() },
+                             windowLevel: { .floating })
+        subject.send(.other("あい"))
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(panel.showCount, 1)
+        guard case .candidates(let shown) = panel.completions.last else {
+            return XCTFail("補完候補としてcandidatesが表示される")
+        }
+        XCTAssertEqual(shown.map(\.word), ["愛子", "挨拶"])
+    }
+
+    @MainActor func testSubscribeSearchesAndShowsYomi() throws {
+        Global.showCandidateForCompletion = false
+        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいさつ": [Word("挨拶")]])
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あ")
+        let subject = PassthroughSubject<YomiEvent, Never>()
+        let expectation = expectation(description: "補完読みが表示される")
+        panel.onUpdate = { expectation.fulfill() }
+        presenter.subscribe(to: subject.eraseToAnyPublisher(),
+                             state: state,
+                             cursorPosition: { self.nonZeroCursor() },
+                             windowLevel: { .floating })
+        subject.send(.other("あ"))
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(panel.showCount, 1)
+        guard case .yomi(let shown) = panel.completions.last else {
+            return XCTFail("補完候補として読みが表示される")
+        }
+        XCTAssertEqual(shown, "あい", "先頭の補完読みが表示される")
+    }
+
+    @MainActor func testSubscribeEmptyYomiHidesPanelSynchronously() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "", completion: .yomi(["あい"], 0))
+        let subject = PassthroughSubject<YomiEvent, Never>()
+        presenter.subscribe(to: subject.eraseToAnyPublisher(),
+                             state: state,
+                             cursorPosition: { self.nonZeroCursor() },
+                             windowLevel: { .floating })
+        subject.send(.other(""))
+        // 現在の読みが空文字列の場合は検索を挟まずパネルを閉じる
+        XCTAssertEqual(panel.orderOutCount, 1)
+        XCTAssertNil(state.completion)
+    }
+
+    @MainActor func testSubscribeDoesNothingWhenShowCompletionDisabled() {
+        Global.showCompletion = false
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let subject = PassthroughSubject<YomiEvent, Never>()
+        presenter.subscribe(to: subject.eraseToAnyPublisher(),
+                             state: state,
+                             cursorPosition: { self.nonZeroCursor() },
+                             windowLevel: { .floating })
+        subject.send(.other("あい"))
+        // 補完候補表示が無効な場合は何もしない
+        XCTAssertEqual(panel.orderOutCount, 0)
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertTrue(panel.completions.isEmpty)
+    }
+
+    // MARK: - apply()
+
+    @MainActor func testApplyCandidatesShowsPanel() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let candidates = [Candidate("愛"), Candidate("挨拶")]
+        presenter.apply(.candidates(candidates),
+                         yomi: "あい",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 1)
+        XCTAssertEqual(panel.orderOutCount, 0)
+        XCTAssertEqual(state.completion, .candidates(candidates))
+        guard case .candidates(let shown) = panel.completions.last else {
+            return XCTFail("補完候補パネルにcandidatesが設定されていません")
+        }
+        XCTAssertEqual(shown, candidates)
+    }
+
+    @MainActor func testApplyCandidatesTruncatesToDisplayCount() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let candidates = [Candidate("愛"), Candidate("挨拶"), Candidate("哀")]
+        presenter.apply(.candidates(candidates),
+                         yomi: "あい",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 2,
+                         state: state)
+        guard case .candidates(let shown) = panel.completions.last else {
+            return XCTFail("補完候補パネルにcandidatesが設定されていません")
+        }
+        XCTAssertEqual(shown, Array(candidates.prefix(2)))
+    }
+
+    @MainActor func testApplyEmptyCandidatesHidesPanel() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        presenter.apply(.candidates([]),
+                         yomi: "あい",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertEqual(panel.orderOutCount, 1)
+        XCTAssertTrue(panel.completions.isEmpty)
+        XCTAssertNil(state.completion)
+    }
+
+    @MainActor func testApplyYomiShowsFirstYomi() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あ")
+        presenter.apply(.yomi(["あい", "あお"], 0),
+                         yomi: "あ",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 1)
+        guard case .yomi(let shown) = panel.completions.last else {
+            return XCTFail("補完候補パネルにyomiが設定されていません")
+        }
+        XCTAssertEqual(shown, "あい")
+    }
+
+    @MainActor func testApplyEmptyYomiHidesPanel() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あ")
+        presenter.apply(.yomi([], 0),
+                         yomi: "あ",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertEqual(panel.orderOutCount, 1)
+        XCTAssertNil(state.completion)
+    }
+
+    @MainActor func testApplyDiscardsResultWhenYomiChanged() {
+        // 検索完了時点で現在の読みが検索時と変わっている場合は結果を捨てる
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あお")
+        presenter.apply(.candidates([Candidate("愛")]),
+                         yomi: "あい",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertEqual(panel.orderOutCount, 0)
+        XCTAssertTrue(panel.completions.isEmpty)
+        XCTAssertNil(state.completion)
+    }
+
+    @MainActor func testApplyDiscardsResultWhenNotComposing() {
+        // 読み入力中でない(currentComposingYomiがnil)場合も結果を捨てる
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: nil)
+        presenter.apply(.candidates([Candidate("愛")]),
+                         yomi: "あい",
+                         cursorPosition: nonZeroCursor(),
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertEqual(panel.orderOutCount, 0)
+        XCTAssertNil(state.completion)
+    }
+
+    @MainActor func testApplyDoesNotShowWhenCursorIsZero() {
+        // カーソル位置が取得できていない(.zero)ときはパネルを表示しない
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        presenter.apply(.candidates([Candidate("愛")]),
+                         yomi: "あい",
+                         cursorPosition: .zero,
+                         windowLevel: .floating,
+                         displayCandidateCount: 9,
+                         state: state)
+        XCTAssertEqual(panel.showCount, 0, "カーソル位置が.zeroのときはshowしない")
+        guard case .candidates = panel.completions.last else {
+            return XCTFail("補完候補自体は設定される")
+        }
+        XCTAssertEqual(state.completion, .candidates([Candidate("愛")]))
+    }
+
+    // MARK: - search()
+
+    @MainActor func testSearchReturnsCandidates() throws {
+        Global.showCandidateForCompletion = true
+        // findCompletionsはprefix完全一致("あい")を除外しprefixより長い読みを返すため、
+        // "あいこ"/"あいさつ" の変換候補が展開される。
+        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいこ": [Word("愛子")], "あいさつ": [Word("挨拶")]])
+        guard case .candidates(let candidates) = CompletionPresenter.search(prefix: "あい") else {
+            return XCTFail("showCandidateForCompletionがtrueのときはcandidatesを返す")
+        }
+        XCTAssertEqual(candidates.map(\.word), ["愛子", "挨拶"])
+    }
+
+    @MainActor func testSearchReturnsYomi() throws {
+        Global.showCandidateForCompletion = false
+        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいさつ": [Word("挨拶")]])
+        guard case .yomi(let yomis, let index) = CompletionPresenter.search(prefix: "あ") else {
+            return XCTFail("showCandidateForCompletionがfalseのときはyomiを返す")
+        }
+        XCTAssertEqual(index, 0)
+        XCTAssertEqual(yomis, ["あい", "あいさつ"])
+    }
+}

--- a/macSKKTests/CompletionPresenterTests.swift
+++ b/macSKKTests/CompletionPresenterTests.swift
@@ -64,12 +64,16 @@ final class CompletionPresenterTests: XCTestCase {
     }
 
     @MainActor private func makeUserDict(entries: [String: [Word]]) throws -> UserDict {
-        try UserDict(dicts: [],
-                     userDictEntries: entries,
-                     privateMode: CurrentValueSubject<Bool, Never>(false),
-                     ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
-                     dateYomis: [],
-                     dateConversions: [])
+        // userDictEntriesを渡すとuserDictがMemoryDictになり、FileDict前提の`setEntries`が
+        // 他テストで機能しなくなる。StateMachineTestsと同じくuserDictはFileDictのままにして
+        // エントリはsetEntriesで流し込む。
+        let dict = try UserDict(dicts: [],
+                                privateMode: CurrentValueSubject<Bool, Never>(false),
+                                ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                dateYomis: [],
+                                dateConversions: [])
+        dict.setEntries(entries)
+        return dict
     }
 
     // MARK: - subscribe()


### PR DESCRIPTION
#489 Swift 6対応に向けた布石として、補完候補の検索・表示処理を別クラスに切り出してユニットテストを実装します。
補完候補の検索には今はCombine + DispatchQueueによる並列処理を行っていますが、Swift 6対応でTask.detachedに切り替え予定です。