### PR TITLE
UserDictをバックグラウンドスレッドから辞書検索できるようにする

### DIFF
--- a/macSKK.xcodeproj/project.pbxproj
+++ b/macSKK.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		CED0984D2B779E4700F2E844 /* UNNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED0984C2B779E4700F2E844 /* UNNotifier.swift */; };
 		CED098512B95F32600F2E844 /* WorkaroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED098502B95F32600F2E844 /* WorkaroundView.swift */; };
 		CED1CA1E2BAFBE0600C32AE3 /* SKKServDictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1CA1D2BAFBE0600C32AE3 /* SKKServDictTests.swift */; };
+		CED6B4352FFA888A0027EB92 /* UserDict+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED6B4342FFA88860027EB92 /* UserDict+Snapshot.swift */; };
+		CED6B4372FFA88970027EB92 /* UserDict+SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED6B4362FFA88920027EB92 /* UserDict+SnapshotTests.swift */; };
 		CED7CA2C2A8394F7004EF988 /* FetchUpdateServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA2B2A8394F7004EF988 /* FetchUpdateServiceProtocol.swift */; };
 		CED7CA2E2A8394F7004EF988 /* FetchUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA2D2A8394F7004EF988 /* FetchUpdateService.swift */; };
 		CED7CA302A8394F7004EF988 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED7CA2F2A8394F7004EF988 /* main.swift */; };
@@ -350,6 +352,8 @@
 		CED0984C2B779E4700F2E844 /* UNNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNNotifier.swift; sourceTree = "<group>"; };
 		CED098502B95F32600F2E844 /* WorkaroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkaroundView.swift; sourceTree = "<group>"; };
 		CED1CA1D2BAFBE0600C32AE3 /* SKKServDictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKKServDictTests.swift; sourceTree = "<group>"; };
+		CED6B4342FFA88860027EB92 /* UserDict+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDict+Snapshot.swift"; sourceTree = "<group>"; };
+		CED6B4362FFA88920027EB92 /* UserDict+SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDict+SnapshotTests.swift"; sourceTree = "<group>"; };
 		CED7CA292A8394F7004EF988 /* FetchUpdateService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = FetchUpdateService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED7CA2B2A8394F7004EF988 /* FetchUpdateServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdateServiceProtocol.swift; sourceTree = "<group>"; };
 		CED7CA2D2A8394F7004EF988 /* FetchUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdateService.swift; sourceTree = "<group>"; };
@@ -493,6 +497,7 @@
 				CE5EB6AE2AAC0DEB00389B98 /* MemoryDict.swift */,
 				CE1B00542BA3DDEB00C830FD /* SKKServDict.swift */,
 				CEA78FAF2964209B00B67E25 /* UserDict.swift */,
+				CED6B4342FFA88860027EB92 /* UserDict+Snapshot.swift */,
 				CEADA44A2B025A0F0026E2BD /* Entry.swift */,
 				CE4CB5CB2AD557D90046FA34 /* NumberEntry.swift */,
 				CE84A3E6295DA4DA009394C4 /* Romaji.swift */,
@@ -568,6 +573,7 @@
 				CE06CA292AAC171B00E80E5E /* FileDictTests.swift */,
 				CEA78FB129646CA100B67E25 /* UserDictTests.swift */,
 				CE00C0DE0000000000000004 /* CompletionPresenterTests.swift */,
+				CED6B4362FFA88920027EB92 /* UserDict+SnapshotTests.swift */,
 				CED1CA1D2BAFBE0600C32AE3 /* SKKServDictTests.swift */,
 				CEADA44C2B025A8A0026E2BD /* EntryTests.swift */,
 				CE84A3E8295DA504009394C4 /* RomajiTests.swift */,
@@ -933,6 +939,7 @@
 				CE485A8A2A8FA5C6008271EF /* UserNotificationDelegate.swift in Sources */,
 				CE8871322E574CC900E20BFB /* CompletionSettingsView.swift in Sources */,
 				CE84A3EB295DA715009394C4 /* Dict.swift in Sources */,
+				CED6B4352FFA888A0027EB92 /* UserDict+Snapshot.swift in Sources */,
 				CEA602AC2F02CFB000E605F2 /* OptionalBackgroundModifier.swift in Sources */,
 				CE40D9A12A6D0C2F00D44799 /* SystemDictView.swift in Sources */,
 				CEADA4512B1358D40026E2BD /* InputSource.swift in Sources */,
@@ -1008,6 +1015,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CEE748822FA6388A00818B33 /* MarkedTextTests.swift in Sources */,
+				CED6B4372FFA88970027EB92 /* UserDict+SnapshotTests.swift in Sources */,
 				CE118EE52CE0B4DE00A7C300 /* KeyTests.swift in Sources */,
 				4B8E87D82CE068A0004E7461 /* CurrentInputTests.swift in Sources */,
 				CEA2539A2E23DA9000618E64 /* DictSettingTests.swift in Sources */,

--- a/macSKK/Candidate.swift
+++ b/macSKK/Candidate.swift
@@ -72,6 +72,11 @@ struct Candidate: Hashable {
         self.saveToUserDict = saveToUserDict
     }
 
+    init(word: Word, original: Original? = nil, saveToUserDict: Bool) {
+        let annotations = word.annotation.map { [$0] } ?? []
+        self.init(word.word, annotations: annotations, original: original, saveToUserDict: saveToUserDict)
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(word)
     }

--- a/macSKK/DateConversion.swift
+++ b/macSKK/DateConversion.swift
@@ -4,7 +4,8 @@ import Foundation
 /**
  * 日付の変換の定義
  */
-struct DateConversion: Identifiable {
+// DateFormatterはApple公式ドキュメントにてiOS 7以降スレッドセーフと明記されているため@unchecked Sendableとする
+struct DateConversion: Identifiable, @unchecked Sendable {
     enum DateConversionCalendar: String, CaseIterable {
         case gregorian = "gregorian"
         case japanese = "japanese"

--- a/macSKK/Dict.swift
+++ b/macSKK/Dict.swift
@@ -79,7 +79,7 @@ protocol DictProtocol {
      * - prefixと読みが完全に一致する場合は補完候補とはしない
      * - 数値変換用の読みは補完候補としない
      */
-    func findCompletions(prefix: String) -> [String]
+    @MainActor func findCompletions(prefix: String) -> [String]
 
     /**
      * この辞書から返した変換候補をユーザー辞書に保存するかどうか

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -114,7 +114,7 @@ struct MemoryDict: DictProtocol, Sendable {
     var entryCount: Int { return entries.count }
 
     // MARK: DictProtocol
-    @MainActor func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
+    nonisolated func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {
         if let option {
             switch option {
             case .prefix:
@@ -135,7 +135,7 @@ struct MemoryDict: DictProtocol, Sendable {
         }
     }
 
-    @MainActor func reverseRefer(_ word: String) -> String? {
+    nonisolated func reverseRefer(_ word: String) -> String? {
         // 全探索
         for (yomi, candidates) in entries {
             if candidates.contains(where: { $0.word == word }) {
@@ -232,7 +232,7 @@ struct MemoryDict: DictProtocol, Sendable {
      * - prefixと読みが完全に一致する場合は補完候補とはしない
      * - 数値変換用の読みは補完候補としない
      */
-    func findCompletions(prefix: String) -> [String] {
+    nonisolated func findCompletions(prefix: String) -> [String] {
         if prefix.isEmpty {
             return []
         }

--- a/macSKK/UserDict+Snapshot.swift
+++ b/macSKK/UserDict+Snapshot.swift
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+extension UserDict {
+    /// バックグラウンドスレッドからの辞書検索用スナップショット。
+    /// MemoryDictはstruct+SendableかつCOWのため、値コピーのコストはほぼゼロ。
+    struct Snapshot: Sendable {
+        let userDictSnapshot: MemoryDict?
+        let dictSnapshots: [MemoryDict]
+        let dateYomis: [DateConversion.Yomi]
+        let dateConversions: [DateConversion]
+        let privateMode: Bool
+        let ignoreUserDictInPrivateMode: Bool
+
+        nonisolated func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {
+            guard let userDictSnapshot else { return [] }
+            if privateMode && ignoreUserDictInPrivateMode { return [] }
+            return userDictSnapshot.refer(yomi, option: option)
+        }
+
+        nonisolated func referDicts(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> [Candidate] {
+            var result: [Candidate] = []
+            // ユーザー辞書、それ以外の辞書の順に参照する
+            var candidates = refer(yomi, option: option).map { word in
+                Candidate(word: word, saveToUserDict: true)
+            }
+            if let dateConversionYomi = dateYomis.first(where: { $0.yomi == yomi }) {
+                let date = Date(timeIntervalSinceNow: dateConversionYomi.timeInterval)
+                let dateCandidates = dateConversions.compactMap { conversion -> Candidate? in
+                    guard let word = conversion.dateFormatter.string(for: date) else { return nil }
+                    return Candidate(word, saveToUserDict: false)
+                }
+                candidates.append(contentsOf: dateCandidates)
+            }
+            if findFromAllDicts {
+                dictSnapshots.forEach { dict in
+                    candidates.append(contentsOf: dict.refer(yomi, option: option).map {
+                        Candidate(word: $0, saveToUserDict: dict.saveToUserDict)
+                    })
+                }
+            }
+            if candidates.isEmpty {
+                if let numberYomi = NumberYomi(yomi) {
+                    let midashi = numberYomi.toMidashiString()
+                    candidates = refer(midashi, option: nil).compactMap { word in
+                        guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
+                        guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
+                        let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                        return Candidate(convertedWord,
+                                         annotations: annotations,
+                                         original: Candidate.Original(midashi: midashi, word: word.word),
+                                         saveToUserDict: true)
+                    }
+                    if findFromAllDicts {
+                        dictSnapshots.forEach { dict in
+                            candidates.append(contentsOf: dict.refer(midashi, option: nil).compactMap { word in
+                                guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
+                                guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
+                                let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                                return Candidate(convertedWord,
+                                                 annotations: annotations,
+                                                 original: Candidate.Original(midashi: midashi, word: word.word),
+                                                 saveToUserDict: dict.saveToUserDict)
+                            })
+                        }
+                    }
+                }
+            }
+            for candidate in candidates {
+                if let index = result.firstIndex(where: { $0.word == candidate.word }) {
+                    do {
+                        result[index] = try result[index].merge(candidate)
+                    } catch {
+                        logger.error("異なる変換結果をもつ変換候補同士をマージしようとしました。バグと思われます。")
+                    }
+                } else {
+                    result.append(candidate)
+                }
+            }
+            return result
+        }
+
+        nonisolated func findCompletionsDicts(prefix: String, findFromAllDicts: Bool) -> [String] {
+            if prefix.isEmpty { return [] }
+            var results: [String] = []
+            var seen = Set<String>()
+            if !privateMode || !ignoreUserDictInPrivateMode {
+                if let userDictSnapshot {
+                    for yomi in userDictSnapshot.findCompletions(prefix: prefix) {
+                        if seen.insert(yomi).inserted { results.append(yomi) }
+                    }
+                }
+            }
+            dateYomis.forEach { dateYomi in
+                if dateYomi.yomi.hasPrefix(prefix) && seen.insert(dateYomi.yomi).inserted {
+                    results.append(dateYomi.yomi)
+                }
+            }
+            if findFromAllDicts {
+                for dict in dictSnapshots {
+                    for yomi in dict.findCompletions(prefix: prefix) {
+                        if seen.insert(yomi).inserted { results.append(yomi) }
+                    }
+                }
+            }
+            return results
+        }
+
+        nonisolated func candidatesForCompletion(prefix: String, findFromAllDicts: Bool) -> [Candidate] {
+            if prefix.count == 1 {
+                return referDicts(prefix, option: nil, findFromAllDicts: findFromAllDicts)
+                    .map { candidate in
+                        candidate.withOriginal(Candidate.Original(midashi: prefix, word: candidate.word))
+                    }
+            }
+            var results: [Candidate] = []
+            for midashi in findCompletionsDicts(prefix: prefix, findFromAllDicts: findFromAllDicts) {
+                if results.count >= 100 { break }
+                let candidates = referDicts(midashi, option: nil, findFromAllDicts: findFromAllDicts)
+                    .prefix(100 - results.count)
+                    .map { candidate in
+                        candidate.withOriginal(Candidate.Original(midashi: midashi, word: candidate.word))
+                    }
+                results.append(contentsOf: candidates)
+            }
+            return results
+        }
+    }
+}

--- a/macSKK/UserDict+Snapshot.swift
+++ b/macSKK/UserDict+Snapshot.swift
@@ -6,17 +6,17 @@ extension UserDict {
     /// バックグラウンドスレッドからの辞書検索用スナップショット。
     /// MemoryDictはstruct+SendableかつCOWのため、値コピーのコストはほぼゼロ。
     struct Snapshot: Sendable {
-        let userDictSnapshot: MemoryDict?
-        let dictSnapshots: [MemoryDict]
+        let userDict: MemoryDict?
+        let dicts: [MemoryDict]
         let dateYomis: [DateConversion.Yomi]
         let dateConversions: [DateConversion]
         let privateMode: Bool
         let ignoreUserDictInPrivateMode: Bool
 
         nonisolated func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {
-            guard let userDictSnapshot else { return [] }
+            guard let userDict else { return [] }
             if privateMode && ignoreUserDictInPrivateMode { return [] }
-            return userDictSnapshot.refer(yomi, option: option)
+            return userDict.refer(yomi, option: option)
         }
 
         nonisolated func referDicts(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> [Candidate] {
@@ -34,7 +34,7 @@ extension UserDict {
                 candidates.append(contentsOf: dateCandidates)
             }
             if findFromAllDicts {
-                dictSnapshots.forEach { dict in
+                dicts.forEach { dict in
                     candidates.append(contentsOf: dict.refer(yomi, option: option).map {
                         Candidate(word: $0, saveToUserDict: dict.saveToUserDict)
                     })
@@ -53,7 +53,7 @@ extension UserDict {
                                          saveToUserDict: true)
                     }
                     if findFromAllDicts {
-                        dictSnapshots.forEach { dict in
+                        dicts.forEach { dict in
                             candidates.append(contentsOf: dict.refer(midashi, option: nil).compactMap { word in
                                 guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
                                 guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
@@ -86,8 +86,8 @@ extension UserDict {
             var results: [String] = []
             var seen = Set<String>()
             if !privateMode || !ignoreUserDictInPrivateMode {
-                if let userDictSnapshot {
-                    for yomi in userDictSnapshot.findCompletions(prefix: prefix) {
+                if let userDict {
+                    for yomi in userDict.findCompletions(prefix: prefix) {
                         if seen.insert(yomi).inserted { results.append(yomi) }
                     }
                 }
@@ -98,7 +98,7 @@ extension UserDict {
                 }
             }
             if findFromAllDicts {
-                for dict in dictSnapshots {
+                for dict in dicts {
                     for yomi in dict.findCompletions(prefix: prefix) {
                         if seen.insert(yomi).inserted { results.append(yomi) }
                     }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -110,6 +110,17 @@ enum UserDictAddSource {
         return referDicts(yomi, option: option, skkservDict: Global.skkservDict, findFromAllDicts: true)
     }
 
+    func makeSnapshot() -> Snapshot {
+        Snapshot(
+            userDictSnapshot: (userDict as? FileDict)?.dict ?? (userDict as? MemoryDict),
+            dictSnapshots: dicts.compactMap { ($0 as? FileDict)?.dict ?? ($0 as? MemoryDict) },
+            dateYomis: dateYomis,
+            dateConversions: dateConversions,
+            privateMode: privateMode.value,
+            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode.value
+        )
+    }
+
     /**
      * 保持する辞書を順に引き変換候補順に返す。
      *
@@ -130,9 +141,9 @@ enum UserDictAddSource {
      */
     func referDicts(_ yomi: String, option: DictReferringOption?, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool) -> [Candidate] {
         var result: [Candidate] = []
+        // ユーザー辞書、それ以外の辞書の順に参照する
         var candidates = refer(yomi, option: option).map { word in
-            let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-            return Candidate(word.word, annotations: annotations)
+            Candidate(word: word, saveToUserDict: true)
         }
         if let dateConversionYomi = dateYomis.first(where: { $0.yomi == yomi }) {
             let date = Date(timeIntervalSinceNow: dateConversionYomi.timeInterval)
@@ -142,14 +153,10 @@ enum UserDictAddSource {
             }
             candidates.append(contentsOf: dateCandidates)
         }
-        // ユーザー辞書、それ以外の辞書の順に参照する
-        candidates.append(contentsOf: refer(yomi, option: option).map { word in
-            return wordToCandidate(word, original: nil, saveToUserDict: true)
-        })
         if findFromAllDicts {
             dicts.forEach { dict in
                 candidates.append(contentsOf: dict.refer(yomi, option: option).map {
-                    wordToCandidate($0, original: nil, saveToUserDict: dict.saveToUserDict)
+                    Candidate(word: $0, saveToUserDict: dict.saveToUserDict)
                 })
             }
         }
@@ -495,11 +502,6 @@ enum UserDictAddSource {
         if recentRegisteredCandidates.count > maxRecentRegisteredCandidateCount {
             recentRegisteredCandidates.removeLast(recentRegisteredCandidates.count - maxRecentRegisteredCandidateCount)
         }
-    }
-
-    private func wordToCandidate(_ word: Word, original: Candidate.Original?, saveToUserDict: Bool) -> Candidate {
-        let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-        return Candidate(word.word, annotations: annotations, original: original, saveToUserDict: saveToUserDict)
     }
 
     /**

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -110,10 +110,10 @@ enum UserDictAddSource {
         return referDicts(yomi, option: option, skkservDict: Global.skkservDict, findFromAllDicts: true)
     }
 
-    func makeSnapshot() -> Snapshot {
+    func snapshot() -> Snapshot {
         Snapshot(
-            userDictSnapshot: (userDict as? FileDict)?.dict ?? (userDict as? MemoryDict),
-            dictSnapshots: dicts.compactMap { ($0 as? FileDict)?.dict ?? ($0 as? MemoryDict) },
+            userDict: (userDict as? FileDict)?.dict ?? (userDict as? MemoryDict),
+            dicts: dicts.compactMap { ($0 as? FileDict)?.dict ?? ($0 as? MemoryDict) },
             dateYomis: dateYomis,
             dateConversions: dateConversions,
             privateMode: privateMode.value,

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+import Combine
+
+@testable import macSKK
+
+final class UserDictSnapshotTests: XCTestCase {
+    @MainActor func testSnapshotCandidatesForCompletion() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
+        let annotation1 = Annotation(dictId: UserDict.userDictFilename, text: "日本の注釈")
+        let annotation2 = Annotation(dictId: "dict2", text: "日本語の注釈")
+        let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
+        let dict2 = MemoryDict(entries: [
+            "にほん": [Word("二本")],
+            "にほんご": [Word("日本語", annotation: annotation2)],
+            "に": [Word("似")]], readonly: false)
+        let userDict = try UserDict(
+            dicts: [dict1, dict2],
+            userDictEntries: ["にふ": [Word("二歩")],
+                              "にほん": [Word("日本", annotation: annotation1)]],
+            privateMode: privateMode,
+            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+            dateYomis: [],
+            dateConversions: [])
+        let snapshot = userDict.makeSnapshot()
+        XCTAssertEqual(
+            snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: false),
+            [
+                Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本"))
+            ])
+        // 全辞書を対象
+        XCTAssertEqual(
+            snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: true),
+            [
+                Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本")),
+                Candidate("二本", annotations: [], original: .init(midashi: "にほん", word: "二本")),
+                Candidate("日本語", annotations: [annotation2], original: .init(midashi: "にほんご", word: "日本語")),
+            ])
+        XCTAssertEqual(
+            snapshot.candidatesForCompletion(prefix: "に", findFromAllDicts: true),
+            [Candidate("似", original: .init(midashi: "に", word: "似"))],
+        )
+    }
+
+    @MainActor func testSnapshotCandidatesForCompletionTotalLimit() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(false)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
+        // 50見出し語×3候補=150件になるが返値は100件に絞られる
+        let entries = Dictionary(uniqueKeysWithValues: (1...50).map { i in
+            (String(format: "あい%02d", i), [Word("候補A\(i)"), Word("候補B\(i)"), Word("候補C\(i)")])
+        })
+        let dict = MemoryDict(entries: entries, readonly: false)
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: privateMode,
+            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+            dateYomis: [],
+            dateConversions: [])
+        let results = userDict.makeSnapshot().candidatesForCompletion(prefix: "あい", findFromAllDicts: true)
+        XCTAssertEqual(results.count, 100)
+    }
+}

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -24,7 +24,7 @@ final class UserDictSnapshotTests: XCTestCase {
             ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
             dateYomis: [],
             dateConversions: [])
-        let snapshot = userDict.makeSnapshot()
+        let snapshot = userDict.snapshot()
         XCTAssertEqual(
             snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: false),
             [
@@ -59,7 +59,7 @@ final class UserDictSnapshotTests: XCTestCase {
             ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
             dateYomis: [],
             dateConversions: [])
-        let results = userDict.makeSnapshot().candidatesForCompletion(prefix: "あい", findFromAllDicts: true)
+        let results = userDict.snapshot().candidatesForCompletion(prefix: "あい", findFromAllDicts: true)
         XCTAssertEqual(results.count, 100)
     }
 }


### PR DESCRIPTION
#489 Swift 6対応。UserDictの参照系メソッドをメインスレッド以外から利用できるようにします。
バックグラウンドスレッドから参照するときは、まずメインスレッドで`UserDict.makeSnapshot()` で SendableなUserDict.Snapshot構造体の値を作り、参照はUserDict.Snapshotに生やした参照メソッドを使用します。

なおこのPRではSnapshotはまだ使っていません (ユニットテストのみ)。
今後補完候補の検索をバックグラウンドスレッドからやっているところをSnapshot利用に差し替えます。
