### PR TITLE
">" 単体の変換で空見出しを辞書登録しないようにする

### DIFF
--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -155,6 +155,10 @@ struct MemoryDict: DictProtocol, Sendable {
     ///   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
     ///   - word: SKK辞書の変換候補。
     @MainActor mutating func add(yomi: String, word: Word) {
+        // 空の見出しはSKK辞書エントリとして不正 (引くことができず、シリアライズすると
+        // " /候補/" のような壊れた行になり、次回読み込みで失敗する)。呼び出し側で
+        // 防いでいるが、念のためここでも登録を拒否する。
+        guard !yomi.isEmpty else { return }
         if var words = entries[yomi] {
             let removed: Word?
             let index = words.firstIndex { $0.word == word.word && $0.okuri == word.okuri }

--- a/macSKK/StateMachine.swift
+++ b/macSKK/StateMachine.swift
@@ -1245,10 +1245,12 @@ final class StateMachine {
         let candidateWords: [Candidate]
         // FIXME: Abbrevモードでも接頭辞、接尾辞を検索するべきか再検討する。
         // いまは ">"で終わる・始まる場合は、Abbrevモードであっても接頭辞・接尾辞を探しているものとして検索する
-        if yomiText.hasSuffix(">") {
+        // ">" 単体のように ">" を除くと読みが空になる場合は接頭辞・接尾辞変換とはみなさず、
+        // ">" をそのまま見出しとして通常変換する (ddskkと同様)。空見出しでの辞書登録を防ぐ。
+        if yomiText.hasSuffix(">") && yomiText.count > 1 {
             yomiText = String(yomiText.dropLast())
             candidateWords = candidates(for: yomiText, option: .prefix) + candidates(for: yomiText, option: nil)
-        } else if yomiText.hasPrefix(">") {
+        } else if yomiText.hasPrefix(">") && yomiText.count > 1 {
             yomiText = String(yomiText.dropFirst())
             candidateWords = candidates(for: yomiText, option: .suffix) + candidates(for: yomiText, option: nil)
         } else if let okuri = composing.okuri, !okuri.isEmpty {

--- a/macSKKTests/MemoryDictTests.swift
+++ b/macSKKTests/MemoryDictTests.swift
@@ -158,6 +158,16 @@ class MemoryDictTests: XCTestCase {
         XCTAssertEqual(dict.refer("いt", option: nil), [Word("行", okuri: "った"), Word("行")])
     }
 
+    @MainActor func testAddEmptyYomiIsIgnored() throws {
+        // 空の見出しはSKK辞書エントリとして不正なので登録しない (シリアライズすると
+        // " /候補/" のような壊れた行になり次回読み込みで失敗するため)
+        var dict = MemoryDict(entries: [:], readonly: false)
+        dict.add(yomi: "", word: Word("＞"))
+        XCTAssertEqual(dict.entryCount, 0)
+        XCTAssertEqual(dict.refer("", option: nil), [])
+        XCTAssertEqual(dict.okuriNashiYomis, [])
+    }
+
     @MainActor func testDelete() throws {
         var dict = MemoryDict(entries: ["あr": [Word("有"), Word("在")], "え": [Word("絵"), Word("柄")]], readonly: false)
         XCTAssertFalse(dict.entries.isEmpty)

--- a/macSKKTests/StateMachineTests.swift
+++ b/macSKKTests/StateMachineTests.swift
@@ -1310,6 +1310,31 @@ final class StateMachineTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    // ">" 単体を変換したときに空見出しで辞書登録しないこと (エンバグ防止)。
+    // ">" を除くと読みが空になるため接頭辞・接尾辞変換とはみなさず、">" をそのまま
+    // 見出しとして変換する。以前は dropLast で空読みになり " /＞/" が登録されていた。
+    @MainActor func testHandleComposingConvertLoneGreaterThan() {
+        Global.dictionary.setEntries([">": [Word("＞")]])
+
+        let stateMachine = StateMachine(initialState: IMEState(inputMode: .hiragana))
+        let expectation = XCTestExpectation()
+        stateMachine.inputMethodEvent.collect(5).sink { events in
+            XCTAssertEqual(events[0], .modeChanged(.direct))
+            XCTAssertEqual(events[1], .markedText(MarkedText([.markerCompose])))
+            XCTAssertEqual(events[2], .markedText(MarkedText([.markerCompose, .plain(">")])))
+            XCTAssertEqual(events[3], .markedText(MarkedText([.markerSelect, .emphasized("＞")])), "\">\" 単体は接頭辞変換せず \">\" を見出しとして変換する")
+            XCTAssertEqual(events[4], .fixedText("＞"))
+            expectation.fulfill()
+        }.store(in: &cancellables)
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: "/")))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: ">", characterIgnoringModifier: ".", withShift: true)))
+        XCTAssertTrue(stateMachine.handle(printableKeyEventAction(character: " ")))
+        XCTAssertTrue(stateMachine.handle(enterAction))
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(Global.dictionary.refer(""), [], "空見出しでは辞書登録しない (エンバグ防止)")
+        XCTAssertEqual(Global.dictionary.refer(">"), [Word("＞")], "\">\" を見出しとして登録する")
+    }
+
     @MainActor func testHandleComposingNumber() {
         let entries = ["だい#": [Word("第#1"), Word("第#0"), Word("第#2"), Word("第#3")], "だい2": [Word("第2")]]
         Global.dictionary.dicts.append(MemoryDict(entries: entries, readonly: true))


### PR DESCRIPTION
## 現象
▽ モードで `>` 単体を変換し、候補 `＞` を確定すると、ユーザー辞書に見出しが空のエントリが登録されます。`skk-jisyo.utf8` には ` /＞/` のような行が書かれ、SKK 辞書では見出しが空の行は不正なので、次回読み込みでこの行がスキップされ失敗通知が出ます。

## 原因
`>` は接頭辞・接尾辞変換の合図で、macSKK は変換時に末尾/先頭の `>` を除いてから辞書を引きます。`>` 単体だと除去後の読みが空になりますが、それでも辞書の `>` エントリ(`＞`)がヒットするため、確定時に空見出しのまま学習登録されていました。

## 修正
`>` を除くと読みが空になる場合(`>` 単体など)は接頭辞・接尾辞変換とみなさず、`>` をそのまま見出しとして通常変換します。これは ddskk と同じ挙動です([skk.el L1014-L1022](https://github.com/skk-dev/ddskk/blob/e8bf68b27021c29781dbfa6a8ef7b770565bdb5b/skk.el#L1014-L1022))。加えて多重防御として `MemoryDict.add` で空見出しの登録を拒否します。

## テスト
- `StateMachineTests.testHandleComposingConvertLoneGreaterThan`: `>` 単体を変換しても空見出しで登録されず、`>` を見出しとして登録されること
- `MemoryDictTests.testAddEmptyYomiIsIgnored`: `add(yomi: "")` が無視されること
- 既存の接頭辞・接尾辞テストが引き続き通ること

## 再現手順
1. ▽ モードで `>`(または Abbrev で `/` → `>`)だけ入力してスペースで変換
2. 出てきた `＞` を確定
3. 修正前: ` /＞/`(見出しが空)が登録され、以降は読み込みのたびに失敗通知が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)
