### PR TITLE
バックグラウンドスレッドで補完候補の検索を安全に行う

### DIFF
--- a/macSKK/CompletionPresenter.swift
+++ b/macSKK/CompletionPresenter.swift
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import AppKit
-import Combine
 
 /// 補完候補パネルの表示を抽象化するプロトコル。
 /// InputControllerからは具象の`CompletionPanel`を注入し、テストではモックを注入する。
@@ -18,79 +17,155 @@ import Combine
 @MainActor protocol CompletionStateProtocol: AnyObject {
     /// 読み入力中(送り仮名なし)ならその読み文字列。それ以外(変換中・送り仮名入力中・未入力)はnil。
     var currentComposingYomi: String? { get }
-    /// 現在の補完候補。
+    /// 現在の補完候補。補完候補がない(補完候補パネルを表示していない)ときはnil。
+    /// nilでないときは必ず1件以上の補完候補をもつ。
     var completion: Completion? { get set }
 }
 
-/// 読みの更新イベントを購読して補完候補を検索し、補完候補パネルへ反映(提示)する。
+/// 読みの更新イベントを受け取って補完候補を検索し、補完候補パネルへ反映(提示)する。
 ///
-/// 検索はDispatchQueue.global()で実行し、結果の反映(`apply`)はMainActorで行う。
+/// MainActor上で`UserDict.Snapshot`を取得し、検索は`@concurrent`な関数として
+/// MainActor外で実行、結果の反映(`apply`/`applySKKServResult`)はMainActorで行う。
 /// UIと状態はプロトコルで注入するため、XCTestからモックを使って補完ロジックを検証できる。
 @MainActor final class CompletionPresenter {
     private let panel: any CompletionPanelProtocol
-    private var cancellable: AnyCancellable?
+    private var completionTask: Task<Void, Never>?
 
     init(panel: any CompletionPanelProtocol) {
         self.panel = panel
     }
 
-    /// `yomiEvent`を購読して補完候補の検索・表示を行うパイプラインを構築する。
+    /// 読みの更新イベントを受け取り、補完候補の検索・表示を行う。
     ///
-    /// 補完候補の検索はDispatchQueue.global()で行い、検索結果の反映はMainActorで行う。
+    /// 補完候補の検索は`@concurrent`な関数としてMainActor外で実行し、検索結果の反映はMainActorで行う。
+    /// ローカル辞書の検索結果を先に表示し、skkservの検索結果はあとから追記する2段階レスポンスをとる。
     /// `cursorPosition`/`windowLevel`はtextInput依存のためクロージャで受け取り、
     /// 検索が必要(=読みが空でない)なときだけ評価する。
-    func subscribe(to yomiEvent: AnyPublisher<YomiEvent, Never>,
-                   state: any CompletionStateProtocol,
-                   cursorPosition: @escaping () -> NSRect,
-                   windowLevel: @escaping () -> NSWindow.Level) {
-        cancellable = yomiEvent
-            .compactMap { [weak self] event -> (String, NSRect)? in
-                guard let self else { return nil }
-                if Global.showCompletion {
-                    if case .other(let yomi) = event {
-                        // 変換開始時などもyomiが空になるので、そのときは
-                        // すでにCandidatesPanelによる補完候補が表示されていることがあるのでCompletionPanelを閉じる。
-                        // YomiEvent.otherじゃないときは補完されたときなので何もしない。
-                        if yomi.isEmpty {
-                            self.panel.orderOut(nil)
-                            state.completion = nil
-                        } else {
-                            return (yomi, cursorPosition())
-                        }
-                    }
-                }
-                return nil
+    func handle(_ event: YomiEvent,
+                state: any CompletionStateProtocol,
+                cursorPosition: () -> NSRect,
+                windowLevel: @escaping () -> NSWindow.Level) {
+        switch event {
+        case .completed(let nextYomi):
+            // 補完により読みが更新されたときは補完候補の再検索はせず、表示中の補完候補パネルの読みだけを更新する。
+            if nextYomi.isEmpty {
+                logger.warning("補完候補を使って補完されましたが空文字列になっており、バグの可能性があります。")
+            } else {
+                panel.setCompletion(.yomi(nextYomi))
             }
-            .receive(on: DispatchQueue.global())
-            .map { (yomi, cursor) -> (String, Completion, NSRect) in
-                (yomi, Self.search(prefix: yomi), cursor)
+        case .other(let yomi):
+            guard Global.showCompletion else { return }
+            completionTask?.cancel()
+            // 変換開始時などもyomiが空になるので、そのときは
+            // すでにCandidatesPanelによる補完候補が表示されていることがあるのでCompletionPanelを閉じる。
+            if yomi.isEmpty {
+                panel.orderOut(nil)
+                state.completion = nil
+                return
             }
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] (yomi, completion, cursor) in
-                self?.apply(completion,
-                            yomi: yomi,
-                            cursorPosition: cursor,
-                            windowLevel: windowLevel(),
-                            displayCandidateCount: Global.displayCandidateCount,
-                            state: state)
+            let cursor = cursorPosition()
+            // MainActor上でスナップショットを取得 (COWにより O(1))
+            let snapshot = Global.dictionary.snapshot()
+            let showCandidateForCompletion = Global.showCandidateForCompletion
+            let findFromAllDicts = Global.findCompletionFromAllDicts
+            let displayCandidateCount = Global.displayCandidateCount
+            let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
+            completionTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                // 検索処理は@concurrentのためMainActor外で実行される。
+                // 同一タスクのままエグゼキュータだけ切り替わるため、completionTaskのキャンセルが
+                // 検索処理内のTask.isCancelledで観測できる。
+                let (completion, midashis) = await Self.search(prefix: yomi,
+                                                               snapshot: snapshot,
+                                                               showCandidateForCompletion: showCandidateForCompletion,
+                                                               findFromAllDicts: findFromAllDicts)
+                guard !Task.isCancelled else { return }
+                self.apply(completion,
+                           yomi: yomi,
+                           cursorPosition: cursor,
+                           windowLevel: windowLevel(),
+                           displayCandidateCount: displayCandidateCount,
+                           state: state)
+                // skkservへの問い合わせはTCP経由でオンメモリの辞書より桁違いに遅いため、
+                // ローカル辞書の検索結果を表示したあとに検索して結果を追記する
+                guard let skkservDict else { return }
+                let appending = await Self.searchSkkserv(prefix: yomi,
+                                                         midashis: midashis,
+                                                         skkservDict: skkservDict,
+                                                         referLimit: displayCandidateCount,
+                                                         showCandidateForCompletion: showCandidateForCompletion)
+                guard !Task.isCancelled else { return }
+                self.applySKKServResult(appending,
+                                        yomi: yomi,
+                                        cursorPosition: cursor,
+                                        windowLevel: windowLevel(),
+                                        displayCandidateCount: displayCandidateCount,
+                                        state: state)
             }
+        }
     }
 
-    /// 補完候補を辞書から検索する。
-    static func search(prefix yomi: String) -> Completion {
-        let skkservDict = Global.searchCompletionsSkkserv ? Global.skkservDict : nil
-        if Global.showCandidateForCompletion {
-            let skkservOption = skkservDict.map { CompletionSKKServOption(dict: $0, referLimit: Global.displayCandidateCount) }
-            let candidates = Global.dictionary.candidatesForCompletion(prefix: yomi,
-                                                                       skkservOption: skkservOption,
-                                                                       findFromAllDicts: Global.findCompletionFromAllDicts)
-            return .candidates(candidates)
+    /// 補完候補を辞書のスナップショットから検索する。
+    /// `@concurrent` のためMainActor外で実行される。
+    ///
+    /// - Important: `@concurrent` は必須。SWIFT_APPROACHABLE_CONCURRENCYが有効なため、
+    ///   これがないとNonisolatedNonsendingByDefault (SE-0461) により呼び出し元のMainActor上で
+    ///   実行され、辞書検索でUIが固まる。
+    ///
+    /// - Returns: 補完候補と、ローカル辞書から見つかった見出し語のリスト。
+    ///   見出し語はskkservへの変換候補問い合わせ (``searchSkkserv(prefix:midashis:skkservDict:referLimit:showCandidateForCompletion:)``) に渡す。
+    ///   skkservからの見出し語の補完はそちらで合流させるため、ここではローカル辞書の見出し語だけを返す。
+    @concurrent nonisolated static func search(prefix yomi: String,
+                                               snapshot: UserDict.Snapshot,
+                                               showCandidateForCompletion: Bool,
+                                               findFromAllDicts: Bool) async -> (completion: Completion, midashis: [String]) {
+        if showCandidateForCompletion {
+            let found = snapshot.candidatesForCompletion(prefix: yomi, findFromAllDicts: findFromAllDicts)
+            return (.candidates(found.candidates), found.midashis)
         } else {
-            let completions = Global.dictionary.findCompletionsDicts(prefix: yomi,
-                                                                     skkservDict: skkservDict,
-                                                                     findFromAllDicts: Global.findCompletionFromAllDicts)
-            return .yomi(completions, 0)
+            let yomis = snapshot.findCompletionsDicts(prefix: yomi, findFromAllDicts: findFromAllDicts)
+            return (.yomi(yomis, 0), yomis)
         }
+    }
+
+    /// 補完候補をskkservから検索し、問い合わせごとの成否を ``UserDict/handleSKKServResults(_:)`` でMainActor上に反映する。
+    /// `@concurrent` のためMainActor外で実行される。タスクがキャンセルされたら以降の問い合わせを打ち切る。
+    ///
+    /// 読みの補完 (`showCandidateForCompletion == false`) ではskkservから見出し語の補完だけを検索する。
+    /// 変換候補の補完 (`showCandidateForCompletion == true`) ではskkservから見出し語の補完を検索したうえで、
+    /// ローカル辞書の見出し語 (`midashis`) と合わせた見出し語について変換候補を問い合わせる。
+    ///
+    /// - Important: `@concurrent` は必須。理由は ``search(prefix:snapshot:showCandidateForCompletion:findFromAllDicts:)`` と同じ。
+    ///
+    /// - Returns: skkservから見つかった補完候補。
+    @concurrent nonisolated static func searchSkkserv(prefix yomi: String,
+                                                      midashis: [String],
+                                                      skkservDict: any SKKServDictProtocol,
+                                                      referLimit: Int,
+                                                      showCandidateForCompletion: Bool) async -> Completion {
+        let appending: Completion
+        let skkservResults: [Result<Void, any Error>]
+        if showCandidateForCompletion {
+            let found = UserDict.Snapshot.skkservCandidatesForCompletion(prefix: yomi,
+                                                                         midashis: midashis,
+                                                                         skkservDict: skkservDict,
+                                                                         referLimit: referLimit)
+            appending = .candidates(found.candidates)
+            skkservResults = found.skkservResults
+        } else {
+            switch skkservDict.findCompletions(prefix: yomi) {
+            case .success(let yomis):
+                appending = .yomi(yomis, 0)
+                skkservResults = [.success(())]
+            case .failure(let error):
+                appending = .yomi([], 0)
+                skkservResults = [.failure(error)]
+            }
+        }
+        // skkservへの問い合わせ自体は完了しているため、その成否はキャンセルされていても反映する。
+        // キャンセル時に捨てると連続エラーがカウントされず自動無効化が発動しなくなる。
+        await Global.dictionary.handleSKKServResults(skkservResults)
+        return appending
     }
 
     /// 補完候補の検索結果を補完候補パネルと状態へ反映する。
@@ -106,25 +181,63 @@ import Combine
             logger.info("補完候補を検索しましたが現在の読みが検索時と変わっているため補完候補は表示しません")
             return
         }
-        state.completion = completion
+        // 「completionがnilでないなら必ず1件以上もつ」を保つため、空かどうかを判定してから代入する。
         switch completion {
-        case .yomi(let yomis, let index):
-            if yomis.isEmpty {
-                panel.orderOut(nil)
-                state.completion = nil
+        case .yomi(let yomis, let index) where !yomis.isEmpty:
+            state.completion = completion
+            panel.setCompletion(.yomi(yomis[index]))
+            showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
+        case .candidates(let candidates) where !candidates.isEmpty:
+            state.completion = completion
+            // 先頭1ページ分だけ補完候補パネルに表示する。
+            panel.setCompletion(.candidates(Array(candidates.prefix(displayCandidateCount))))
+            showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
+        default:
+            // 補完候補が0件のときは補完候補パネルを閉じて補完候補なしにする
+            panel.orderOut(nil)
+            state.completion = nil
+        }
+    }
+
+    /// バックグラウンドで検索したskkservの補完候補の検索結果を、表示済みのローカル辞書の検索結果に反映する。
+    /// 表示中の補完候補の選択位置が無効にならないように、読みの補完候補は末尾に追記する。
+    /// ローカル辞書から補完候補が見つからず補完候補パネルが閉じられている場合は新規に表示する。
+    func applySKKServResult(_ appending: Completion,
+                            yomi: String,
+                            cursorPosition: NSRect,
+                            windowLevel: NSWindow.Level,
+                            displayCandidateCount: Int,
+                            state: any CompletionStateProtocol) {
+        guard state.currentComposingYomi == yomi else {
+            logger.info("skkservから補完候補を検索しましたが現在の読みが検索時と変わっているため補完候補は表示しません")
+            return
+        }
+        switch appending {
+        case .yomi(let newYomis, _):
+            guard !newYomis.isEmpty else { return }
+            if case .yomi(let yomis, let yomiIndex) = state.completion {
+                let merged = UserDict.Snapshot.mergeYomis(yomis, appending: newYomis)
+                guard merged.count > yomis.count else { return }
+                state.completion = .yomi(merged, yomiIndex)
+                // 表示中の読み (merged[yomiIndex]) は変わらないため補完パネルの表示更新は不要
             } else {
-                panel.setCompletion(.yomi(yomis[index]))
+                // ローカル辞書からは補完候補が見つからず補完パネルが閉じられているケース
+                state.completion = .yomi(newYomis, 0)
+                panel.setCompletion(.yomi(newYomis[0]))
                 showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
             }
-        case .candidates(let candidates):
-            if candidates.isEmpty {
-                panel.orderOut(nil)
-                state.completion = nil
+        case .candidates(let newCandidates):
+            guard !newCandidates.isEmpty else { return }
+            let candidates: [Candidate] = if case .candidates(let candidates) = state.completion {
+                candidates
             } else {
-                // 先頭1ページ分だけ補完候補パネルに表示する。
-                panel.setCompletion(.candidates(Array(candidates.prefix(displayCandidateCount))))
-                showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
+                []
             }
+            let merged = UserDict.Snapshot.mergeCandidates(candidates, appending: newCandidates)
+            state.completion = .candidates(merged)
+            // 先頭1ページ分だけ補完候補パネルに表示する。
+            panel.setCompletion(.candidates(Array(merged.prefix(displayCandidateCount))))
+            showIfPositioned(at: cursorPosition, windowLevel: windowLevel)
         }
     }
 

--- a/macSKK/InputController.swift
+++ b/macSKK/InputController.swift
@@ -174,27 +174,17 @@ class InputController: IMKInputController {
                 self?.showMarkerWhenEmpty = bundleIdentifiers.contains(bundleIdentifier)
             }
         }.store(in: &cancellables)
-        // 読みが更新されたときに補完候補の検索・表示を行う処理。
-        // 検索(DispatchQueue.global())と補完候補パネルへの反映はCompletionPresenterに委譲している。
-        completionPresenter.subscribe(
-            to: stateMachine.yomiEvent,
-            state: stateMachine,
-            cursorPosition: { [weak self] in self?.cursorPosition(for: textInput) ?? .zero },
-            windowLevel: { [weak self] in self?.windowLevel(for: textInput) ?? .floating })
-        // 読みの補完候補が更新されたときの処理
+        // 読みが更新・補完されたときの処理。
+        // 補完候補の検索(MainActor外で実行する@concurrentな関数)と
+        // 補完候補パネルへの反映はCompletionPresenterに委譲している。
         stateMachine.yomiEvent
-            .compactMap {
-                if case .completed(let nextYomi) = $0 {
-                    return nextYomi
-                }
-                return nil
-            }
-            .sink { nextYomi in
-                if nextYomi.isEmpty {
-                    logger.warning("補完候補を使って補完されましたが空文字列になっており、バグの可能性があります。")
-                } else {
-                    Global.completionPanel.viewModel.completion = .yomi(nextYomi)
-                }
+            .sink { [weak self] event in
+                guard let self else { return }
+                self.completionPresenter.handle(
+                    event,
+                    state: self.stateMachine,
+                    cursorPosition: { [weak self] in self?.cursorPosition(for: textInput) ?? .zero },
+                    windowLevel: { [weak self] in self?.windowLevel(for: textInput) ?? .floating })
             }
             .store(in: &cancellables)
         // Safariでアドレスバーに移動するときなど、処理が固まることがあるので非同期で実行する

--- a/macSKK/SKKServDict.swift
+++ b/macSKK/SKKServDict.swift
@@ -12,13 +12,6 @@ protocol SKKServDictProtocol: Sendable {
     func invalidate()
 }
 
-/// 補完候補検索でのskkserv検索オプション
-struct CompletionSKKServOption {
-    let dict: any SKKServDictProtocol
-    /// skkservへのreferの問い合わせの上限回数
-    let referLimit: Int
-}
-
 /**
  * skkservを辞書として使う辞書定義
  *

--- a/macSKK/UserDict+Snapshot.swift
+++ b/macSKK/UserDict+Snapshot.swift
@@ -19,7 +19,9 @@ extension UserDict {
             return userDict.refer(yomi, option: option)
         }
 
-        nonisolated func referDicts(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> [Candidate] {
+        /// ローカル辞書 (ユーザー辞書・日付変換・ファイル辞書) から変換候補を検索する。
+        /// 数値変換のフォールバックと注釈のマージは行わない。
+        nonisolated private func localCandidates(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> [Candidate] {
             // ユーザー辞書、それ以外の辞書の順に参照する
             var candidates = refer(yomi, option: option).map { word in
                 Candidate(word: word, saveToUserDict: true)
@@ -39,32 +41,62 @@ extension UserDict {
                     })
                 }
             }
-            if candidates.isEmpty {
-                if let numberYomi = NumberYomi(yomi) {
-                    let midashi = numberYomi.toMidashiString()
-                    candidates = refer(midashi, option: nil).compactMap { word in
-                        guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
-                        guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
-                        let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                        return Candidate(convertedWord,
-                                         annotations: annotations,
-                                         original: Candidate.Original(midashi: midashi, word: word.word),
-                                         saveToUserDict: true)
-                    }
-                    if findFromAllDicts {
-                        dicts.forEach { dict in
-                            candidates.append(contentsOf: dict.refer(midashi, option: nil).compactMap { word in
-                                guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
-                                guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
-                                let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                                return Candidate(convertedWord,
-                                                 annotations: annotations,
-                                                 original: Candidate.Original(midashi: midashi, word: word.word),
-                                                 saveToUserDict: dict.saveToUserDict)
-                            })
-                        }
-                    }
+            return candidates
+        }
+
+        /// 数値変換のフォールバックの結果。
+        /// skkservへの問い合わせ結果を同じ見出しで数値変換するために numberYomi と midashi も保持する。
+        private struct NumberFallback {
+            let numberYomi: NumberYomi
+            /// 数値を "#" に置換した見出し
+            let midashi: String
+            /// ローカル辞書から見つかった変換候補
+            let candidates: [Candidate]
+        }
+
+        /// yomiが数値を含む場合に、数値を "#" に置換した見出しでローカル辞書を引く。
+        /// yomiが数値を含まない場合はnilを返す。
+        /// optionは通常の検索と同じものを渡す (接頭辞・接尾辞から検索する場合は数値変換の見出しも同じ扱いで引く)。
+        nonisolated private func numberFallback(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> NumberFallback? {
+            guard let numberYomi = NumberYomi(yomi) else { return nil }
+            let midashi = numberYomi.toMidashiString()
+            var candidates = Self.numberCandidates(from: refer(midashi, option: option),
+                                                   numberYomi: numberYomi,
+                                                   midashi: midashi,
+                                                   saveToUserDict: true)
+            if findFromAllDicts {
+                dicts.forEach { dict in
+                    candidates.append(contentsOf: Self.numberCandidates(from: dict.refer(midashi, option: option),
+                                                                        numberYomi: numberYomi,
+                                                                        midashi: midashi,
+                                                                        saveToUserDict: dict.saveToUserDict))
                 }
+            }
+            return NumberFallback(numberYomi: numberYomi, midashi: midashi, candidates: candidates)
+        }
+
+        /// 数値変換の変換候補を組み立てる。数値変換できない候補は除外する。
+        nonisolated private static func numberCandidates(from words: [Word],
+                                                         numberYomi: NumberYomi,
+                                                         midashi: String,
+                                                         saveToUserDict: Bool) -> [Candidate] {
+            words.compactMap { word in
+                guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
+                guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
+                let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                return Candidate(convertedWord,
+                                 annotations: annotations,
+                                 original: Candidate.Original(midashi: midashi, word: word.word),
+                                 saveToUserDict: saveToUserDict)
+            }
+        }
+
+        /// ローカル辞書のみを引き変換候補順に返す。
+        /// 複数の辞書に同じ変換がある場合、注釈を結合して返す。
+        nonisolated func referDicts(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> [Candidate] {
+            var candidates = localCandidates(yomi, option: option, findFromAllDicts: findFromAllDicts)
+            if candidates.isEmpty, let fallback = numberFallback(yomi, option: option, findFromAllDicts: findFromAllDicts) {
+                candidates = fallback.candidates
             }
             // 複数の辞書に同じ変換候補があれば注釈をマージして1つにまとめる
             return Self.mergeCandidates([], appending: candidates)

--- a/macSKK/UserDict+Snapshot.swift
+++ b/macSKK/UserDict+Snapshot.swift
@@ -20,7 +20,6 @@ extension UserDict {
         }
 
         nonisolated func referDicts(_ yomi: String, option: DictReferringOption?, findFromAllDicts: Bool) -> [Candidate] {
-            var result: [Candidate] = []
             // ユーザー辞書、それ以外の辞書の順に参照する
             var candidates = refer(yomi, option: option).map { word in
                 Candidate(word: word, saveToUserDict: true)
@@ -67,18 +66,8 @@ extension UserDict {
                     }
                 }
             }
-            for candidate in candidates {
-                if let index = result.firstIndex(where: { $0.word == candidate.word }) {
-                    do {
-                        result[index] = try result[index].merge(candidate)
-                    } catch {
-                        logger.error("異なる変換結果をもつ変換候補同士をマージしようとしました。バグと思われます。")
-                    }
-                } else {
-                    result.append(candidate)
-                }
-            }
-            return result
+            // 複数の辞書に同じ変換候補があれば注釈をマージして1つにまとめる
+            return Self.mergeCandidates([], appending: candidates)
         }
 
         nonisolated func findCompletionsDicts(prefix: String, findFromAllDicts: Bool) -> [String] {
@@ -107,15 +96,24 @@ extension UserDict {
             return results
         }
 
-        nonisolated func candidatesForCompletion(prefix: String, findFromAllDicts: Bool) -> [Candidate] {
+        /// 現在入力中のprefixに続く変換候補を検索する。
+        /// prefixが1文字のときは完全一致だけを、2文字以上のときは見つかったものから最大100件までを返す。
+        ///
+        /// - Returns: 変換候補と、skkservへ変換候補を問い合わせるための見出し語のリスト。
+        ///   見出し語は ``skkservCandidatesForCompletion(prefix:midashis:skkservDict:referLimit:)`` に渡す想定。
+        ///   prefixが1文字のときは辞書に存在するかによらずprefix自身の1件、2文字以上のときは
+        ///   ローカル辞書から見つかった見出し語を全件返す (変換候補の100件上限にかからなかったものも含む)。
+        nonisolated func candidatesForCompletion(prefix: String, findFromAllDicts: Bool) -> (candidates: [Candidate], midashis: [String]) {
             if prefix.count == 1 {
-                return referDicts(prefix, option: nil, findFromAllDicts: findFromAllDicts)
+                let candidates = referDicts(prefix, option: nil, findFromAllDicts: findFromAllDicts)
                     .map { candidate in
                         candidate.withOriginal(Candidate.Original(midashi: prefix, word: candidate.word))
                     }
+                return (candidates, [prefix])
             }
+            let midashis = findCompletionsDicts(prefix: prefix, findFromAllDicts: findFromAllDicts)
             var results: [Candidate] = []
-            for midashi in findCompletionsDicts(prefix: prefix, findFromAllDicts: findFromAllDicts) {
+            for midashi in midashis {
                 if results.count >= 100 { break }
                 let candidates = referDicts(midashi, option: nil, findFromAllDicts: findFromAllDicts)
                     .prefix(100 - results.count)
@@ -124,7 +122,96 @@ extension UserDict {
                     }
                 results.append(contentsOf: candidates)
             }
-            return results
+            return (results, midashis)
+        }
+
+        /**
+         * skkservから補完候補となる変換候補を検索する。
+         *
+         * skkservへの問い合わせはTCP経由でオンメモリの辞書より桁違いに遅いため、
+         * ローカル辞書の検索結果 (``candidatesForCompletion(prefix:findFromAllDicts:)``) を
+         * 表示したあとに呼び出して結果を追記する用途を想定している。
+         *
+         * まずskkservから見出し語の補完を検索し、ローカル辞書から見つかった見出し語 (midashis) の
+         * 末尾に重複を除いて追記する。そのうえで先頭referLimit件の見出し語について変換候補を問い合わせる。
+         * prefixが1文字のときは ``candidatesForCompletion(prefix:findFromAllDicts:)`` と同じ規則で
+         * 完全一致だけを対象とし、skkservからの見出し語の補完は行わない。
+         * 問い合わせに失敗した場合は接続レベルのエラーの可能性が高いため以降の問い合わせは打ち切る。
+         * タスクがキャンセルされた場合も以降の問い合わせを打ち切る (それまでの成否は返す)。
+         *
+         * - Parameters:
+         *   - prefix: SKK辞書の見出しの接頭辞。 ``candidatesForCompletion(prefix:findFromAllDicts:)`` に渡したものと同じ文字列
+         *   - midashis: ``candidatesForCompletion(prefix:findFromAllDicts:)`` が返した見出し語リスト
+         *   - skkservDict: SKKServ辞書
+         *   - referLimit: skkservへのreferの問い合わせの上限回数
+         * - Returns: skkservから見つかった変換候補と、skkservへの問い合わせごとの成否。
+         *   成否はエラーカウント処理のためMainActor上で ``UserDict/handleSKKServResults(_:)`` に渡すこと。
+         */
+        nonisolated static func skkservCandidatesForCompletion(prefix: String, midashis: [String], skkservDict: any SKKServDictProtocol, referLimit: Int) -> (candidates: [Candidate], skkservResults: [Result<Void, any Error>]) {
+            var candidates: [Candidate] = []
+            var skkservResults: [Result<Void, any Error>] = []
+            var midashis = midashis
+            // 1文字のときは全探索するとめちゃくちゃ量が多いので完全一致だけ探す
+            if prefix.count > 1 {
+                // 新しい読みの入力などで検索がキャンセルされたら残りの問い合わせは無駄なので打ち切る
+                if Task.isCancelled {
+                    return (candidates, skkservResults)
+                }
+                switch skkservDict.findCompletions(prefix: prefix) {
+                case .success(let yomis):
+                    skkservResults.append(.success(()))
+                    midashis = mergeYomis(midashis, appending: yomis)
+                case .failure(let error):
+                    // 接続レベルのエラーの可能性が高いため以降の問い合わせは打ち切る
+                    skkservResults.append(.failure(error))
+                    return (candidates, skkservResults)
+                }
+            }
+            for midashi in midashis.prefix(referLimit) {
+                // 新しい読みの入力などで検索がキャンセルされたら残りの問い合わせは無駄なので打ち切る
+                if Task.isCancelled {
+                    return (candidates, skkservResults)
+                }
+                switch skkservDict.refer(midashi, option: nil) {
+                case .success(let words):
+                    skkservResults.append(.success(()))
+                    candidates.append(contentsOf: words.map { word in
+                        Candidate(word: word,
+                                  original: Candidate.Original(midashi: midashi, word: word.word),
+                                  saveToUserDict: skkservDict.saveToUserDict)
+                    })
+                case .failure(let error):
+                    // 接続レベルのエラーの可能性が高いため以降の問い合わせは打ち切る
+                    skkservResults.append(.failure(error))
+                    return (candidates, skkservResults)
+                }
+            }
+            return (candidates, skkservResults)
+        }
+
+        /// 補完候補の読みのリストに新しい読みを追加したリストを返す。
+        /// 表示中の読みの選択位置が無効にならないように既存の読みの順序は保持し、新規の読みは末尾に追記する。
+        nonisolated static func mergeYomis(_ yomis: [String], appending newYomis: [String]) -> [String] {
+            var seen = Set(yomis)
+            return yomis + newYomis.filter { seen.insert($0).inserted }
+        }
+
+        /// 変換候補のリストに新しい変換候補を追加したリストを返す。
+        /// 同じ変換結果をもつ候補は注釈を結合し、新規の候補は末尾に追記する。
+        nonisolated static func mergeCandidates(_ candidates: [Candidate], appending newCandidates: [Candidate]) -> [Candidate] {
+            var result = candidates
+            for candidate in newCandidates {
+                if let index = result.firstIndex(where: { $0.word == candidate.word }) {
+                    do {
+                        result[index] = try result[index].merge(candidate)
+                    } catch {
+                        logger.error("異なる変換結果をもつ変換候補同士をマージしようとしました。バグと思われます。")
+                    }
+                } else {
+                    result.append(candidate)
+                }
+            }
+            return result
         }
     }
 }

--- a/macSKK/UserDict+Snapshot.swift
+++ b/macSKK/UserDict+Snapshot.swift
@@ -102,6 +102,63 @@ extension UserDict {
             return Self.mergeCandidates([], appending: candidates)
         }
 
+        /// skkservから返された変換候補を組み立てる。
+        nonisolated private static func candidates(from words: [Word], skkservDict: any SKKServDictProtocol) -> [Candidate] {
+            words.map { word in
+                let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
+                return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
+            }
+        }
+
+        /**
+         * ローカル辞書に加えてskkservからも変換候補を検索する。
+         *
+         * skkservの変換候補はローカル辞書の変換候補の後に追加する。
+         * ローカル辞書とskkservのどちらからも見つからなかった場合のみ数値変換のフォールバックを行う。
+         * skkservへの問い合わせが失敗した場合は接続レベルのエラーの可能性が高いため、
+         * 数値変換のフォールバックでの問い合わせは行わない。
+         *
+         * - Returns: 変換候補と、skkservへの問い合わせごとの成否。
+         *   成否はエラーカウント処理のためMainActor上で ``UserDict/handleSKKServResults(_:)`` に渡すこと。
+         */
+        nonisolated func referDicts(_ yomi: String,
+                                    option: DictReferringOption?,
+                                    findFromAllDicts: Bool,
+                                    skkservDict: any SKKServDictProtocol)
+            -> (candidates: [Candidate], skkservResults: [Result<Void, any Error>]) {
+            var candidates = localCandidates(yomi, option: option, findFromAllDicts: findFromAllDicts)
+            var skkservResults: [Result<Void, any Error>] = []
+            var skkservFailed = false
+            // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
+            switch skkservDict.refer(yomi, option: option) {
+            case .success(let words):
+                skkservResults.append(.success(()))
+                candidates.append(contentsOf: Self.candidates(from: words, skkservDict: skkservDict))
+            case .failure(let error):
+                skkservResults.append(.failure(error))
+                skkservFailed = true
+            }
+            if candidates.isEmpty, let fallback = numberFallback(yomi, option: option, findFromAllDicts: findFromAllDicts) {
+                candidates = fallback.candidates
+                // 1回目の問い合わせが失敗したときは接続レベルのエラーの可能性が高いため問い合わせない
+                if !skkservFailed {
+                    // 現状のSKKServDictはoptionを見ずに見出しをそのまま送るが、通常の問い合わせと揃えて渡しておく
+                    switch skkservDict.refer(fallback.midashi, option: option) {
+                    case .success(let words):
+                        skkservResults.append(.success(()))
+                        candidates.append(contentsOf: Self.numberCandidates(from: words,
+                                                                           numberYomi: fallback.numberYomi,
+                                                                           midashi: fallback.midashi,
+                                                                           saveToUserDict: skkservDict.saveToUserDict))
+                    case .failure(let error):
+                        skkservResults.append(.failure(error))
+                    }
+                }
+            }
+            // 複数の辞書に同じ変換候補があれば注釈をマージして1つにまとめる
+            return (Self.mergeCandidates([], appending: candidates), skkservResults)
+        }
+
         nonisolated func findCompletionsDicts(prefix: String, findFromAllDicts: Bool) -> [String] {
             if prefix.isEmpty { return [] }
             var results: [String] = []

--- a/macSKK/UserDict+Snapshot.swift
+++ b/macSKK/UserDict+Snapshot.swift
@@ -103,10 +103,10 @@ extension UserDict {
         }
 
         /// skkservから返された変換候補を組み立てる。
-        nonisolated private static func candidates(from words: [Word], skkservDict: any SKKServDictProtocol) -> [Candidate] {
+        nonisolated private static func skkservCandidates(from words: [Word], saveToUserDict: Bool) -> [Candidate] {
             words.map { word in
                 let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
+                return Candidate(word.word, annotations: annotations, saveToUserDict: saveToUserDict)
             }
         }
 
@@ -133,7 +133,8 @@ extension UserDict {
             switch skkservDict.refer(yomi, option: option) {
             case .success(let words):
                 skkservResults.append(.success(()))
-                candidates.append(contentsOf: Self.candidates(from: words, skkservDict: skkservDict))
+                candidates.append(contentsOf: Self.skkservCandidates(from: words,
+                                                                     saveToUserDict: skkservDict.saveToUserDict))
             case .failure(let error):
                 skkservResults.append(.failure(error))
                 skkservFailed = true

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -308,36 +308,27 @@ enum UserDictAddSource {
     }
 
     /**
-     * バックグラウンドで実行したskkservへの問い合わせの成否を問い合わせ順に処理する。
+     * skkservへの問い合わせの成否を問い合わせ順に処理する。
      * 成功時はエラーカウントをリセットし、失敗時はエラーカウントを増やして
      * 連続エラー数が閾値に達していればskkservを無効化する。
      *
-     * skkservからの問い合わせ結果自体はバックグラウンドで処理済みのため成否だけを受け取る。
+     * skkservからの問い合わせ結果自体は ``UserDict/Snapshot`` で処理済みのため成否だけを受け取る。
      */
     @MainActor func handleSKKServResults(_ results: [Result<Void, any Error>]) {
         for result in results {
             // 自動無効化された場合は無効化の通知を重複して送らないように残りの成否は処理しない
             guard Global.skkservDict != nil else { return }
-            handleSKKServResult(result) { _ in }
-        }
-    }
-
-    /**
-     * skkservへの問い合わせ結果を処理する。成功時はエラーカウントをリセットしてonSuccessに結果を渡す。
-     * 失敗時はエラーカウントを増やし、連続エラー数が閾値に達していればskkservを無効化する。
-     */
-    @MainActor private func handleSKKServResult<T>(_ result: Result<T, any Error>, onSuccess: (T) -> Void) {
-        switch result {
-        case .success(let value):
-            Global.skkservConsecutiveErrorCount = 0
-            onSuccess(value)
-        case .failure:
-            Global.skkservConsecutiveErrorCount += 1
-            if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {
-                logger.log("skkservへの接続エラーが\(Global.skkservConsecutiveErrorCount)回連続したため無効化します")
-                Global.skkservDict?.invalidate()
-                Global.skkservDict = nil
-                NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: Global.skkservConsecutiveErrorCount)
+            switch result {
+            case .success:
+                Global.skkservConsecutiveErrorCount = 0
+            case .failure:
+                Global.skkservConsecutiveErrorCount += 1
+                if Global.skkservConsecutiveErrorCount >= Global.skkservAutoDisableThreshold {
+                    logger.log("skkservへの接続エラーが\(Global.skkservConsecutiveErrorCount)回連続したため無効化します")
+                    Global.skkservDict?.invalidate()
+                    Global.skkservDict = nil
+                    NotificationCenter.default.post(name: notificationNameSKKServAutoDisabled, object: Global.skkservConsecutiveErrorCount)
+                }
             }
         }
     }

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -118,8 +118,35 @@ enum UserDictAddSource {
         NSFileCoordinator.removeFilePresenter(self)
     }
 
+    /**
+     * 保持する辞書を順に引き変換候補順に返す。
+     *
+     * 複数の辞書に同じ変換がある場合、注釈を結合して返す。
+     * 検索処理そのものは ``UserDict/Snapshot/referDicts(_:option:findFromAllDicts:skkservDict:)`` に委譲し、
+     * このメソッドではskkservへの問い合わせの成否をMainActor上のエラーカウントに反映する。
+     *
+     * ## skkservについて
+     * skkservを辞書とする場合はすべてのファイル辞書の変換候補の末尾に付けて返す。
+     * skkserv辞書の変換候補を末尾につけるのは仮の仕様で将来は利用者が選択可能にする可能性がある。
+     *
+     * skkservからの応答が一定時間なかった場合、XPC側がそのTCP接続を破棄する。
+     * 接続はXPC側でプールされているため、次にこのメソッドが呼ばれたときは
+     * 残っている接続を使い回すか、なければ新しく接続する。
+     *
+     * - Parameters:
+     *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
+     *   - option: 辞書を引くときに接頭辞や接尾辞から検索するかどうか。nilなら通常のエントリから検索する
+     */
     @MainActor func referDicts(_ yomi: String, option: DictReferringOption? = nil) -> [Candidate] {
-        return referDicts(yomi, option: option, skkservDict: Global.skkservDict, findFromAllDicts: true)
+        guard let skkservDict = Global.skkservDict else {
+            return snapshot().referDicts(yomi, option: option, findFromAllDicts: true)
+        }
+        let (candidates, skkservResults) = snapshot().referDicts(yomi,
+                                                                 option: option,
+                                                                 findFromAllDicts: true,
+                                                                 skkservDict: skkservDict)
+        handleSKKServResults(skkservResults)
+        return candidates
     }
 
     func snapshot() -> Snapshot {
@@ -134,104 +161,7 @@ enum UserDictAddSource {
     }
 
     /**
-     * 保持する辞書を順に引き変換候補順に返す。
-     *
-     * 複数の辞書に同じ変換がある場合、注釈を結合して返す。
-     *
-     * ## skkservについて
-     * skkservを辞書とする場合はすべてのファイル辞書の変換候補の末尾に付けて返す。
-     * skkserv辞書の変換候補を末尾につけるのは仮の仕様で将来は利用者が選択可能にする可能性がある。
-     *
-     * skkservからの応答が一定時間なかった場合、XPC側がそのTCP接続を破棄する。
-     * 接続はXPC側でプールされているため、次にこのメソッドが呼ばれたときは
-     * 残っている接続を使い回すか、なければ新しく接続する。
-     *
-     * - Parameters:
-     *   - yomi: SKK辞書の見出し。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
-     *   - option: 辞書を引くときに接頭辞や接尾辞から検索するかどうか。nilなら通常のエントリから検索する
-     *   - skkservDict: SKKServ辞書。nilのときはskkservを引かない
-     *   - findFromAllDicts: ユーザー辞書以外を検索するか。trueにするのは補完候補検索時のみ。
-     */
-    func referDicts(_ yomi: String, option: DictReferringOption?, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool) -> [Candidate] {
-        // ユーザー辞書、それ以外の辞書の順に参照する
-        var candidates = refer(yomi, option: option).map { word in
-            Candidate(word: word, saveToUserDict: true)
-        }
-        if let dateConversionYomi = dateYomis.first(where: { $0.yomi == yomi }) {
-            let date = Date(timeIntervalSinceNow: dateConversionYomi.timeInterval)
-            let dateCandidates = dateConversions.compactMap { conversion -> Candidate? in
-                guard let word = conversion.dateFormatter.string(for: date) else { return nil }
-                return Candidate(word, saveToUserDict: false)
-            }
-            candidates.append(contentsOf: dateCandidates)
-        }
-        if findFromAllDicts {
-            dicts.forEach { dict in
-                candidates.append(contentsOf: dict.refer(yomi, option: option).map {
-                    Candidate(word: $0, saveToUserDict: dict.saveToUserDict)
-                })
-            }
-        }
-        // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
-        // NOTE: Global.skkservDictは接続エラーが連続するとhandleSKKServResultによる自動無効化でnilに変わる。
-        // このメソッドの実行中に無効化された場合に再度問い合わせないようGlobal.skkservDictもチェックする。
-        if let skkservDict, Global.skkservDict != nil {
-            handleSKKServResult(skkservDict.refer(yomi, option: option)) { words in
-                candidates.append(contentsOf: words.map { word in
-                    let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                    return Candidate(word.word, annotations: annotations, saveToUserDict: skkservDict.saveToUserDict)
-                })
-            }
-        }
-        if candidates.isEmpty {
-            // yomiが数値を含む場合は "#" に置換して辞書を引く
-            if let numberYomi = NumberYomi(yomi) {
-                let midashi = numberYomi.toMidashiString()
-                candidates = refer(midashi, option: nil).compactMap({ word in
-                    guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
-                    guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
-                    let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                    return Candidate(convertedWord,
-                                     annotations: annotations,
-                                     original: Candidate.Original(midashi: midashi, word: word.word),
-                                     saveToUserDict: true)
-                })
-                if findFromAllDicts {
-                    dicts.forEach { dict in
-                        candidates.append(contentsOf: dict.refer(midashi, option: option).compactMap { word in
-                            guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
-                            guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
-                            let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                            return Candidate(convertedWord,
-                                             annotations: annotations,
-                                             original: Candidate.Original(midashi: midashi, word: word.word),
-                                             saveToUserDict: dict.saveToUserDict)
-                        })
-                    }
-                }
-                // NOTE: Global.skkservDictは接続エラーが連続するとhandleSKKServResultによる自動無効化でnilに変わる。
-                // このメソッドの実行中に無効化された場合に再度問い合わせないようGlobal.skkservDictもチェックする。
-                if let skkservDict, Global.skkservDict != nil {
-                    handleSKKServResult(skkservDict.refer(midashi, option: option)) { words in
-                        candidates.append(contentsOf: words.compactMap { word in
-                            guard let numberCandidate = try? NumberCandidate(yomi: word.word) else { return nil }
-                            guard let convertedWord = numberCandidate.toString(yomi: numberYomi) else { return nil }
-                            let annotations: [Annotation] = if let annotation = word.annotation { [annotation] } else { [] }
-                            return Candidate(convertedWord,
-                                             annotations: annotations,
-                                             original: Candidate.Original(midashi: midashi, word: word.word),
-                                             saveToUserDict: skkservDict.saveToUserDict)
-                        })
-                    }
-                }
-            }
-        }
-        // 複数の辞書に同じ変換候補があれば注釈をマージして1つにまとめる
-        return Snapshot.mergeCandidates([], appending: candidates)
-    }
-
-    /**
-     * ユーザー辞書のみから検索して他のSKK辞書は参照しない。すべての辞書から参照する場合は ``referDicts(_:option:skkservDict:findFromAllDicts:)`` を使用すること。
+     * ユーザー辞書のみから検索して他のSKK辞書は参照しない。すべての辞書から参照する場合は ``referDicts(_:option:)`` を使用すること。
      * プライベートモードで入力したエントリは参照しない。
      */
     @MainActor func refer(_ yomi: String, option: DictReferringOption? = nil) -> [Word] {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -153,7 +153,6 @@ enum UserDictAddSource {
      *   - findFromAllDicts: ユーザー辞書以外を検索するか。trueにするのは補完候補検索時のみ。
      */
     func referDicts(_ yomi: String, option: DictReferringOption?, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool) -> [Candidate] {
-        var result: [Candidate] = []
         // ユーザー辞書、それ以外の辞書の順に参照する
         var candidates = refer(yomi, option: option).map { word in
             Candidate(word: word, saveToUserDict: true)
@@ -174,8 +173,8 @@ enum UserDictAddSource {
             }
         }
         // ひとまずskkservを辞書として使う場合はファイル辞書より後に追加する
-        // NOTE: Global.skkservDictは接続エラーが連続するとnilに変わるが、それを呼び出し側でチェックできてない。
-        // Swift Concurrency対応で呼び出し元で修正予定。
+        // NOTE: Global.skkservDictは接続エラーが連続するとhandleSKKServResultによる自動無効化でnilに変わる。
+        // このメソッドの実行中に無効化された場合に再度問い合わせないようGlobal.skkservDictもチェックする。
         if let skkservDict, Global.skkservDict != nil {
             handleSKKServResult(skkservDict.refer(yomi, option: option)) { words in
                 candidates.append(contentsOf: words.map { word in
@@ -210,8 +209,8 @@ enum UserDictAddSource {
                         })
                     }
                 }
-                // NOTE: Global.skkservDictは接続エラーが連続するとnilに変わるが、それを呼び出し側でチェックできてない。
-                // Swift Concurrency対応で呼び出し元で修正予定。
+                // NOTE: Global.skkservDictは接続エラーが連続するとhandleSKKServResultによる自動無効化でnilに変わる。
+                // このメソッドの実行中に無効化された場合に再度問い合わせないようGlobal.skkservDictもチェックする。
                 if let skkservDict, Global.skkservDict != nil {
                     handleSKKServResult(skkservDict.refer(midashi, option: option)) { words in
                         candidates.append(contentsOf: words.compactMap { word in
@@ -227,63 +226,8 @@ enum UserDictAddSource {
                 }
             }
         }
-        for candidate in candidates {
-            if let index = result.firstIndex(where: { $0.word == candidate.word }) {
-                // 注釈だけマージする
-                do {
-                    result[index] = try result[index].merge(candidate)
-                } catch {
-                    logger.error("異なる変換結果をもつ変換候補同士をマージしようとしました。バグと思われます。")
-                }
-            } else {
-                result.append(candidate)
-            }
-        }
-        return result
-    }
-
-    /**
-     * 保持する辞書を順に引き現在入力中のprefixに続く入力候補を返す。見つからなければ空配列を返す。
-     *
-     * ## skkservについて
-     * skkservを辞書とする場合はすべてのファイル辞書の候補の末尾に付けて返す。
-     * skkserv辞書の変換候補を末尾につけるのは仮の仕様で将来は利用者が選択可能にする可能性がある。
-     *
-     * skkservからの応答が一定時間なかった場合、XPC側がそのTCP接続を破棄する。
-     * 接続はXPC側でプールされているため、次にこのメソッドが呼ばれたときは
-     * 残っている接続を使い回すか、なければ新しく接続する。
-     *
-     * - Parameters:
-     *   - prefix: SKK辞書の見出しの接頭辞。複数のひらがな、もしくは複数のひらがな + ローマ字からなる文字列
-     *   - skkservDict: SKKServ辞書。nilのときはskkservを引かない
-     *   - findFromAllDicts: ユーザー辞書以外を検索するか
-     */
-    func findCompletionsDicts(prefix: String, skkservDict: (any SKKServDictProtocol)?, findFromAllDicts: Bool) -> [String] {
-        if prefix.isEmpty {
-            return []
-        }
-        var results: [String] = findCompletions(prefix: prefix)
-        // 重複排除は順序を保ちつつSetでメンバーシップ判定する (Array.containsだと該当読み数Mに対しO(M^2)になる)
-        var seen = Set(results)
-        if findFromAllDicts {
-            for dict in dicts {
-                for yomi in dict.findCompletions(prefix: prefix) {
-                    if seen.insert(yomi).inserted {
-                        results.append(yomi)
-                    }
-                }
-            }
-        }
-        if let skkservDict {
-            handleSKKServResult(skkservDict.findCompletions(prefix: prefix)) { completions in
-                for yomi in completions {
-                    if seen.insert(yomi).inserted {
-                        results.append(yomi)
-                    }
-                }
-            }
-        }
-        return results
+        // 複数の辞書に同じ変換候補があれば注釈をマージして1つにまとめる
+        return Snapshot.mergeCandidates([], appending: candidates)
     }
 
     /**
@@ -373,89 +317,6 @@ enum UserDictAddSource {
         return false
     }
 
-    /**
-     * 現在入力中のprefixに続く入力候補を返す。見つからなければ空配列を返す。
-     *
-     * 以下のように補完候補を探します。
-     * ※将来この仕様は変更する可能性が大いにあります。
-     *
-     * - prefixが空文字列なら空配列を返す
-     * - ユーザー辞書の送りなしの読みのうち、最近変換したものから選択する。
-     * - prefixと読みが完全に一致する場合は補完候補とはしない
-     * - 数値変換用の読みは補完候補としない
-     */
-    @MainActor func findCompletions(prefix: String) -> [String] {
-        if prefix.isEmpty {
-            return []
-        }
-        var results: [String] = []
-        // 重複排除は順序を保ちつつSetでメンバーシップ判定する (Array.containsだと読み数に対しO(n^2)になる)
-        var seen = Set<String>()
-        if !privateMode.value || !ignoreUserDictInPrivateMode.value {
-            if let userDict {
-                for yomi in userDict.findCompletions(prefix: prefix) {
-                    if seen.insert(yomi).inserted {
-                        results.append(yomi)
-                    }
-                }
-            }
-        }
-        dateYomis.forEach { dateYomi in
-            if dateYomi.yomi.hasPrefix(prefix) && seen.insert(dateYomi.yomi).inserted {
-                results.append(dateYomi.yomi)
-            }
-        }
-        return results
-    }
-
-    /**
-     * 現在入力中のprefixに続く変換候補を返す。
-     * prefixが1文字しかないときは完全一致だけを返す。
-     * 2文字以上あるときは見つかったものから最大100件まで返す。
-     *
-     * skkservへの変換候補問い合わせはファイル辞書に比べて引くのにコストがかかるため、別に上限を設ける。
-     * ``Global.displayCandidateCount`` 回数引いたらそれ以上は引かない。
-     * 将来AsyncStreamにできたら遅延しながら引くのはありかも。
-     *
-     * - Parameters:
-     *   - prefix: SKK辞書の見出しの一部。
-     *   - skkservOption: SKKServを検索対象とする場合に渡す。nilのときはskkservを引かない
-     *   - findFromAllDicts: ユーザー辞書以外を検索対象とするか
-     *
-     * NOTE: asyncにするかも? (skkservとかで便利そう)
-     * AsyncStreamにするかも?
-     */
-    func candidatesForCompletion(prefix: String, skkservOption: CompletionSKKServOption?, findFromAllDicts: Bool) -> [Candidate] {
-        let skkservDict = skkservOption?.dict
-        // 1文字のときは全探索するとめちゃくちゃ量が多いので完全一致だけ探す
-        if prefix.count == 1 {
-            return referDicts(prefix, option: nil, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts)
-                .map { candidate in
-                    candidate.withOriginal(Candidate.Original(midashi: prefix, word: candidate.word))
-                }
-        }
-        // FIXME: Candidateの配列じゃなくて、(String, Candidate) のように見出し語と変換候補のタプルの配列を返すほうがよさそう
-        var results: [Candidate] = []
-        var skkservReferCount = 0
-        for midashi in findCompletionsDicts(prefix: prefix, skkservDict: skkservDict, findFromAllDicts: findFromAllDicts) {
-            if results.count >= 100 { break }
-            let currentSkkservDict: (any SKKServDictProtocol)?
-            if let option = skkservOption, skkservReferCount < option.referLimit {
-                 currentSkkservDict = option.dict
-                 skkservReferCount += 1
-             } else {
-                 currentSkkservDict = nil
-             }
-            let candidates = referDicts(midashi, option: nil, skkservDict: currentSkkservDict, findFromAllDicts: findFromAllDicts)
-                .prefix(100 - results.count)
-                .map { candidate in
-                    candidate.withOriginal(Candidate.Original(midashi: midashi, word: candidate.word))
-                }
-            results.append(contentsOf: candidates)
-        }
-        return results
-    }
-
     /// ユーザー辞書の永続化を予約する
     /// 短期間に複数の保存要求があっても60秒に一回にまとめる
     @MainActor private func scheduleSave() {
@@ -517,14 +378,23 @@ enum UserDictAddSource {
     }
 
     /**
+     * バックグラウンドで実行したskkservへの問い合わせの成否を問い合わせ順に処理する。
+     * 成功時はエラーカウントをリセットし、失敗時はエラーカウントを増やして
+     * 連続エラー数が閾値に達していればskkservを無効化する。
+     *
+     * skkservからの問い合わせ結果自体はバックグラウンドで処理済みのため成否だけを受け取る。
+     */
+    @MainActor func handleSKKServResults(_ results: [Result<Void, any Error>]) {
+        for result in results {
+            // 自動無効化された場合は無効化の通知を重複して送らないように残りの成否は処理しない
+            guard Global.skkservDict != nil else { return }
+            handleSKKServResult(result) { _ in }
+        }
+    }
+
+    /**
      * skkservへの問い合わせ結果を処理する。成功時はエラーカウントをリセットしてonSuccessに結果を渡す。
      * 失敗時はエラーカウントを増やし、連続エラー数が閾値に達していればskkservを無効化する。
-     *
-     * - TODO: このメソッドは@MainActor指定されているが、呼び出し元のInputControllerの補完検索を
-     * .receive(on: DispatchQueue.global())以降で同期的に呼んでいるため実際にはメインスレッド以外から
-     * 実行されることがあり、SettingsViewModel (実際にメインスレッドで実行) からのGlobal.skkservDict等への
-     * 書き込みとデータ競合する可能性がある。referDicts/findCompletionsDictsをnonisolated async化し、
-     * このメソッドの呼び出しをMainActor.run経由にすることで解消する予定。
      */
     @MainActor private func handleSKKServResult<T>(_ result: Result<T, any Error>, onSuccess: (T) -> Void) {
         switch result {

--- a/macSKK/UserDict.swift
+++ b/macSKK/UserDict.swift
@@ -122,8 +122,10 @@ enum UserDictAddSource {
      * 保持する辞書を順に引き変換候補順に返す。
      *
      * 複数の辞書に同じ変換がある場合、注釈を結合して返す。
-     * 検索処理そのものは ``UserDict/Snapshot/referDicts(_:option:findFromAllDicts:skkservDict:)`` に委譲し、
-     * このメソッドではskkservへの問い合わせの成否をMainActor上のエラーカウントに反映する。
+     * 検索処理そのものは ``UserDict/Snapshot`` に委譲する。
+     * skkservを辞書として使わない通常の状態では ``UserDict/Snapshot/referDicts(_:option:findFromAllDicts:)`` を、
+     * skkservを辞書として使う場合は ``UserDict/Snapshot/referDicts(_:option:findFromAllDicts:skkservDict:)`` を呼び、
+     * 後者ではskkservへの問い合わせの成否をMainActor上のエラーカウントに反映する。
      *
      * ## skkservについて
      * skkservを辞書とする場合はすべてのファイル辞書の変換候補の末尾に付けて返す。

--- a/macSKKTests/CompletionPresenterTests.swift
+++ b/macSKKTests/CompletionPresenterTests.swift
@@ -32,7 +32,11 @@ import XCTest
 /// レース判定用の状態を差し替え可能にするモック。
 @MainActor final class MockCompletionState: CompletionStateProtocol {
     var currentComposingYomi: String?
-    var completion: Completion?
+    var completion: Completion? {
+        didSet { onCompletionUpdate?() }
+    }
+    /// 非同期パイプラインの完了待ちに使うコールバック。
+    var onCompletionUpdate: (() -> Void)?
 
     init(currentComposingYomi: String? = nil, completion: Completion? = nil) {
         self.currentComposingYomi = currentComposingYomi
@@ -48,6 +52,8 @@ final class CompletionPresenterTests: XCTestCase {
             Global.findCompletionFromAllDicts = false
             Global.searchCompletionsSkkserv = false
             Global.skkservDict = nil
+            Global.skkservConsecutiveErrorCount = 0
+            Global.skkservAutoDisableThreshold = 3
             Global.displayCandidateCount = 9
             Global.kanaRule = Romaji.defaultKanaRule
             Global.privateMode.send(false)
@@ -76,21 +82,19 @@ final class CompletionPresenterTests: XCTestCase {
         return dict
     }
 
-    // MARK: - subscribe()
+    // MARK: - handle()
 
-    @MainActor func testSubscribeSearchesAndShowsCandidates() throws {
+    @MainActor func testHandleSearchesAndShowsCandidates() throws {
         Global.showCandidateForCompletion = true
         Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいこ": [Word("愛子")], "あいさつ": [Word("挨拶")]])
         let (presenter, panel) = makePresenter()
         let state = MockCompletionState(currentComposingYomi: "あい")
-        let subject = PassthroughSubject<YomiEvent, Never>()
         let expectation = expectation(description: "補完候補が表示される")
         panel.onUpdate = { expectation.fulfill() }
-        presenter.subscribe(to: subject.eraseToAnyPublisher(),
-                             state: state,
-                             cursorPosition: { self.nonZeroCursor() },
-                             windowLevel: { .floating })
-        subject.send(.other("あい"))
+        presenter.handle(.other("あい"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(panel.showCount, 1)
         guard case .candidates(let shown) = panel.completions.last else {
@@ -99,19 +103,17 @@ final class CompletionPresenterTests: XCTestCase {
         XCTAssertEqual(shown.map(\.word), ["愛子", "挨拶"])
     }
 
-    @MainActor func testSubscribeSearchesAndShowsYomi() throws {
+    @MainActor func testHandleSearchesAndShowsYomi() throws {
         Global.showCandidateForCompletion = false
         Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいさつ": [Word("挨拶")]])
         let (presenter, panel) = makePresenter()
         let state = MockCompletionState(currentComposingYomi: "あ")
-        let subject = PassthroughSubject<YomiEvent, Never>()
         let expectation = expectation(description: "補完読みが表示される")
         panel.onUpdate = { expectation.fulfill() }
-        presenter.subscribe(to: subject.eraseToAnyPublisher(),
-                             state: state,
-                             cursorPosition: { self.nonZeroCursor() },
-                             windowLevel: { .floating })
-        subject.send(.other("あ"))
+        presenter.handle(.other("あ"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(panel.showCount, 1)
         guard case .yomi(let shown) = panel.completions.last else {
@@ -120,34 +122,50 @@ final class CompletionPresenterTests: XCTestCase {
         XCTAssertEqual(shown, "あい", "先頭の補完読みが表示される")
     }
 
-    @MainActor func testSubscribeEmptyYomiHidesPanelSynchronously() {
+    @MainActor func testHandleEmptyYomiHidesPanelSynchronously() {
         let (presenter, panel) = makePresenter()
         let state = MockCompletionState(currentComposingYomi: "", completion: .yomi(["あい"], 0))
-        let subject = PassthroughSubject<YomiEvent, Never>()
-        presenter.subscribe(to: subject.eraseToAnyPublisher(),
-                             state: state,
-                             cursorPosition: { self.nonZeroCursor() },
-                             windowLevel: { .floating })
-        subject.send(.other(""))
+        presenter.handle(.other(""),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
         // 現在の読みが空文字列の場合は検索を挟まずパネルを閉じる
         XCTAssertEqual(panel.orderOutCount, 1)
         XCTAssertNil(state.completion)
     }
 
-    @MainActor func testSubscribeDoesNothingWhenShowCompletionDisabled() {
-        Global.showCompletion = false
+    @MainActor func testHandleCompletedUpdatesPanelYomi() {
+        // 補完により読みが更新されたときは再検索せず表示中の補完候補パネルの読みだけを更新する。
+        // .completedは補完候補を表示しているときにしか発生しないため、表示中の状態から始める。
         let (presenter, panel) = makePresenter()
-        let state = MockCompletionState(currentComposingYomi: "あい")
-        let subject = PassthroughSubject<YomiEvent, Never>()
-        presenter.subscribe(to: subject.eraseToAnyPublisher(),
-                             state: state,
-                             cursorPosition: { self.nonZeroCursor() },
-                             windowLevel: { .floating })
-        subject.send(.other("あい"))
-        // 補完候補表示が無効な場合は何もしない
+        let displayed = Completion.yomi(["あいさつ", "あいこ"], 0)
+        let state = MockCompletionState(currentComposingYomi: "あい", completion: displayed)
+        presenter.handle(.completed("あいさつ"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
+        guard case .yomi(let shown) = panel.completions.last else {
+            return XCTFail("補完候補パネルにyomiが設定されていません")
+        }
+        XCTAssertEqual(shown, "あいさつ")
+        XCTAssertEqual(panel.showCount, 0, "パネルの表示状態は変更しない")
         XCTAssertEqual(panel.orderOutCount, 0)
-        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertEqual(state.completion, displayed, "補完候補の一覧と選択位置は変更しない")
+    }
+
+    @MainActor func testHandleCompletedEmptyDoesNothing() {
+        // 次の補完候補がない場合は空文字列が渡されるが何もしない (警告ログのみ)
+        let (presenter, panel) = makePresenter()
+        let displayed = Completion.yomi(["あいさつ"], 0)
+        let state = MockCompletionState(currentComposingYomi: "あい", completion: displayed)
+        presenter.handle(.completed(""),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
         XCTAssertTrue(panel.completions.isEmpty)
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertEqual(panel.orderOutCount, 0)
+        XCTAssertEqual(state.completion, displayed, "表示中の補完候補も変更しない")
     }
 
     // MARK: - apply()
@@ -188,8 +206,10 @@ final class CompletionPresenterTests: XCTestCase {
     }
 
     @MainActor func testApplyEmptyCandidatesHidesPanel() {
+        // 直前の読みの補完候補を表示していたが、新しい読みでは0件になったケース
         let (presenter, panel) = makePresenter()
-        let state = MockCompletionState(currentComposingYomi: "あい")
+        let state = MockCompletionState(currentComposingYomi: "あい",
+                                        completion: .candidates([Candidate("藍")]))
         presenter.apply(.candidates([]),
                          yomi: "あい",
                          cursorPosition: nonZeroCursor(),
@@ -199,7 +219,7 @@ final class CompletionPresenterTests: XCTestCase {
         XCTAssertEqual(panel.showCount, 0)
         XCTAssertEqual(panel.orderOutCount, 1)
         XCTAssertTrue(panel.completions.isEmpty)
-        XCTAssertNil(state.completion)
+        XCTAssertNil(state.completion, "表示中だった補完候補はクリアされる")
     }
 
     @MainActor func testApplyYomiShowsFirstYomi() {
@@ -219,8 +239,10 @@ final class CompletionPresenterTests: XCTestCase {
     }
 
     @MainActor func testApplyEmptyYomiHidesPanel() {
+        // 直前の読みの補完候補を表示していたが、新しい読みでは0件になったケース
         let (presenter, panel) = makePresenter()
-        let state = MockCompletionState(currentComposingYomi: "あ")
+        let state = MockCompletionState(currentComposingYomi: "あ",
+                                        completion: .yomi(["あい"], 0))
         presenter.apply(.yomi([], 0),
                          yomi: "あ",
                          cursorPosition: nonZeroCursor(),
@@ -229,13 +251,15 @@ final class CompletionPresenterTests: XCTestCase {
                          state: state)
         XCTAssertEqual(panel.showCount, 0)
         XCTAssertEqual(panel.orderOutCount, 1)
-        XCTAssertNil(state.completion)
+        XCTAssertNil(state.completion, "表示中だった補完候補はクリアされる")
     }
 
     @MainActor func testApplyDiscardsResultWhenYomiChanged() {
-        // 検索完了時点で現在の読みが検索時と変わっている場合は結果を捨てる
+        // 検索完了時点で現在の読みが検索時と変わっている場合は結果を捨てる。
+        // 新しい読みの検索が終わるまでは直前の補完候補が表示されたままになる。
         let (presenter, panel) = makePresenter()
-        let state = MockCompletionState(currentComposingYomi: "あお")
+        let displayed = Completion.candidates([Candidate("藍")])
+        let state = MockCompletionState(currentComposingYomi: "あお", completion: displayed)
         presenter.apply(.candidates([Candidate("愛")]),
                          yomi: "あい",
                          cursorPosition: nonZeroCursor(),
@@ -245,13 +269,14 @@ final class CompletionPresenterTests: XCTestCase {
         XCTAssertEqual(panel.showCount, 0)
         XCTAssertEqual(panel.orderOutCount, 0)
         XCTAssertTrue(panel.completions.isEmpty)
-        XCTAssertNil(state.completion)
+        XCTAssertEqual(state.completion, displayed, "捨てるだけで表示中の補完候補には触らない")
     }
 
     @MainActor func testApplyDiscardsResultWhenNotComposing() {
         // 読み入力中でない(currentComposingYomiがnil)場合も結果を捨てる
         let (presenter, panel) = makePresenter()
-        let state = MockCompletionState(currentComposingYomi: nil)
+        let displayed = Completion.candidates([Candidate("藍")])
+        let state = MockCompletionState(currentComposingYomi: nil, completion: displayed)
         presenter.apply(.candidates([Candidate("愛")]),
                          yomi: "あい",
                          cursorPosition: nonZeroCursor(),
@@ -260,7 +285,7 @@ final class CompletionPresenterTests: XCTestCase {
                          state: state)
         XCTAssertEqual(panel.showCount, 0)
         XCTAssertEqual(panel.orderOutCount, 0)
-        XCTAssertNil(state.completion)
+        XCTAssertEqual(state.completion, displayed, "捨てるだけで表示中の補完候補には触らない")
     }
 
     @MainActor func testApplyDoesNotShowWhenCursorIsZero() {
@@ -282,24 +307,218 @@ final class CompletionPresenterTests: XCTestCase {
 
     // MARK: - search()
 
-    @MainActor func testSearchReturnsCandidates() throws {
-        Global.showCandidateForCompletion = true
+    @MainActor func testSearchReturnsCandidates() async throws {
         // findCompletionsはprefix完全一致("あい")を除外しprefixより長い読みを返すため、
         // "あいこ"/"あいさつ" の変換候補が展開される。
-        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいこ": [Word("愛子")], "あいさつ": [Word("挨拶")]])
-        guard case .candidates(let candidates) = CompletionPresenter.search(prefix: "あい") else {
+        let userDict = try makeUserDict(entries: ["あい": [Word("愛")], "あいこ": [Word("愛子")], "あいさつ": [Word("挨拶")]])
+        let (completion, midashis) = await CompletionPresenter.search(prefix: "あい",
+                                                                      snapshot: userDict.snapshot(),
+                                                                      showCandidateForCompletion: true,
+                                                                      findFromAllDicts: false)
+        guard case .candidates(let candidates) = completion else {
             return XCTFail("showCandidateForCompletionがtrueのときはcandidatesを返す")
         }
         XCTAssertEqual(candidates.map(\.word), ["愛子", "挨拶"])
+        XCTAssertEqual(midashis, ["あいこ", "あいさつ"], "skkserv問い合わせ用の見出し語も返す")
     }
 
-    @MainActor func testSearchReturnsYomi() throws {
-        Global.showCandidateForCompletion = false
-        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")], "あいさつ": [Word("挨拶")]])
-        guard case .yomi(let yomis, let index) = CompletionPresenter.search(prefix: "あ") else {
+    @MainActor func testSearchReturnsYomi() async throws {
+        let userDict = try makeUserDict(entries: ["あい": [Word("愛")], "あいさつ": [Word("挨拶")]])
+        let (completion, _) = await CompletionPresenter.search(prefix: "あ",
+                                                               snapshot: userDict.snapshot(),
+                                                               showCandidateForCompletion: false,
+                                                               findFromAllDicts: false)
+        guard case .yomi(let yomis, let index) = completion else {
             return XCTFail("showCandidateForCompletionがfalseのときはyomiを返す")
         }
         XCTAssertEqual(index, 0)
         XCTAssertEqual(yomis, ["あい", "あいさつ"])
+    }
+
+    // MARK: - applySKKServResult()
+
+    @MainActor func testApplySKKServResultYomiMergesKeepingSelection() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あ",
+                                        completion: .yomi(["あい", "あお"], 1))
+        presenter.applySKKServResult(.yomi(["あか", "あい"], 0),
+                                     yomi: "あ",
+                                     cursorPosition: nonZeroCursor(),
+                                     windowLevel: .floating,
+                                     displayCandidateCount: 9,
+                                     state: state)
+        // 既存の読みの順序と選択位置は保持し、新規の読みだけ末尾に追記する
+        XCTAssertEqual(state.completion, .yomi(["あい", "あお", "あか"], 1))
+        // 表示中の読みは変わらないため補完候補パネルの表示更新は不要
+        XCTAssertTrue(panel.completions.isEmpty)
+        XCTAssertEqual(panel.showCount, 0)
+    }
+
+    @MainActor func testApplySKKServResultYomiShowsWhenPanelClosed() {
+        // ローカル辞書からは補完候補が見つからず補完候補パネルが閉じられているケース
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あ", completion: nil)
+        presenter.applySKKServResult(.yomi(["あか"], 0),
+                                     yomi: "あ",
+                                     cursorPosition: nonZeroCursor(),
+                                     windowLevel: .floating,
+                                     displayCandidateCount: 9,
+                                     state: state)
+        XCTAssertEqual(state.completion, .yomi(["あか"], 0))
+        XCTAssertEqual(panel.showCount, 1)
+        guard case .yomi(let shown) = panel.completions.last else {
+            return XCTFail("補完候補パネルにyomiが設定されていません")
+        }
+        XCTAssertEqual(shown, "あか")
+    }
+
+    @MainActor func testApplySKKServResultCandidatesMergesAndTruncates() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい",
+                                        completion: .candidates([Candidate("愛"), Candidate("挨拶")]))
+        presenter.applySKKServResult(.candidates([Candidate("愛"), Candidate("哀")]),
+                                     yomi: "あい",
+                                     cursorPosition: nonZeroCursor(),
+                                     windowLevel: .floating,
+                                     displayCandidateCount: 2,
+                                     state: state)
+        // 既存と同じ変換結果はマージされ、新規の候補は末尾に追記される
+        XCTAssertEqual(state.completion, .candidates([Candidate("愛"), Candidate("挨拶"), Candidate("哀")]))
+        XCTAssertEqual(panel.showCount, 1)
+        guard case .candidates(let shown) = panel.completions.last else {
+            return XCTFail("補完候補パネルにcandidatesが設定されていません")
+        }
+        XCTAssertEqual(shown, [Candidate("愛"), Candidate("挨拶")], "先頭displayCandidateCount件だけ表示する")
+    }
+
+    @MainActor func testApplySKKServResultDiscardsWhenYomiChanged() {
+        // 検索完了時点で現在の読みが検索時と変わっている場合は結果を捨てる
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あお",
+                                        completion: .candidates([Candidate("愛")]))
+        presenter.applySKKServResult(.candidates([Candidate("哀")]),
+                                     yomi: "あい",
+                                     cursorPosition: nonZeroCursor(),
+                                     windowLevel: .floating,
+                                     displayCandidateCount: 9,
+                                     state: state)
+        XCTAssertEqual(state.completion, .candidates([Candidate("愛")]))
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertTrue(panel.completions.isEmpty)
+    }
+
+    @MainActor func testApplySKKServResultEmptyDoesNothing() {
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい",
+                                        completion: .candidates([Candidate("愛")]))
+        presenter.applySKKServResult(.candidates([]),
+                                     yomi: "あい",
+                                     cursorPosition: nonZeroCursor(),
+                                     windowLevel: .floating,
+                                     displayCandidateCount: 9,
+                                     state: state)
+        XCTAssertEqual(state.completion, .candidates([Candidate("愛")]))
+        XCTAssertEqual(panel.showCount, 0)
+        XCTAssertTrue(panel.completions.isEmpty)
+    }
+
+    // MARK: - skkservの2段階レスポンス
+
+    @MainActor func testHandleAppendsSkkservCandidates() throws {
+        Global.showCandidateForCompletion = true
+        Global.searchCompletionsSkkserv = true
+        let mock = MockSKKServDict(wordsPerYomi: ["あいこ": [Word("相子")]])
+        Global.skkservDict = mock
+        Global.dictionary = try makeUserDict(entries: ["あいこ": [Word("愛子")]])
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let expectation = expectation(description: "ローカル辞書とskkservの2段階で補完候補が表示される")
+        expectation.expectedFulfillmentCount = 2
+        panel.onUpdate = { expectation.fulfill() }
+        presenter.handle(.other("あい"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(panel.completions.count, 2)
+        guard case .candidates(let first) = panel.completions.first else {
+            return XCTFail("ローカル辞書の検索結果が先に表示される")
+        }
+        XCTAssertEqual(first.map(\.word), ["愛子"])
+        guard case .candidates(let second) = panel.completions.last else {
+            return XCTFail("skkservの検索結果が追記される")
+        }
+        XCTAssertEqual(second.map(\.word), ["愛子", "相子"])
+    }
+
+    @MainActor func testHandleAppendsSkkservCandidatesOfSkkservOnlyMidashi() throws {
+        // ローカル辞書にない見出しはskkservの見出し語の補完から見つけて変換候補を問い合わせる
+        Global.showCandidateForCompletion = true
+        Global.searchCompletionsSkkserv = true
+        let mock = MockSKKServDict(wordsPerYomi: ["あいさつ": [Word("挨拶")]])
+        Global.skkservDict = mock
+        Global.dictionary = try makeUserDict(entries: ["あいこ": [Word("愛子")]])
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let expectation = expectation(description: "ローカル辞書とskkservの2段階で補完候補が表示される")
+        expectation.expectedFulfillmentCount = 2
+        panel.onUpdate = { expectation.fulfill() }
+        presenter.handle(.other("あい"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
+        wait(for: [expectation], timeout: 1.0)
+        guard case .candidates(let shown) = panel.completions.last else {
+            return XCTFail("skkservの検索結果が追記される")
+        }
+        XCTAssertEqual(shown.map(\.word), ["愛子", "挨拶"])
+    }
+
+    @MainActor func testHandleDisablesSkkservAfterConsecutiveErrors() throws {
+        // 補完検索でのskkservの連続エラーがUserDict.handleSKKServResults経由で自動無効化につながることを確認
+        Global.showCandidateForCompletion = true
+        Global.searchCompletionsSkkserv = true
+        let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
+        Global.skkservDict = mock
+        Global.skkservConsecutiveErrorCount = 0
+        Global.skkservAutoDisableThreshold = 1
+        Global.dictionary = try makeUserDict(entries: ["あいこ": [Word("愛子")]])
+        let (presenter, _) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あい")
+        let expectation = XCTNSNotificationExpectation(name: notificationNameSKKServAutoDisabled)
+        presenter.handle(.other("あい"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertNil(Global.skkservDict, "連続エラー数が閾値に達したのでskkservが無効化される")
+    }
+
+    @MainActor func testHandleAppendsSkkservYomis() throws {
+        Global.showCandidateForCompletion = false
+        Global.searchCompletionsSkkserv = true
+        let mock = MockSKKServDict(wordsPerYomi: ["あお": [Word("青")]])
+        Global.skkservDict = mock
+        Global.dictionary = try makeUserDict(entries: ["あい": [Word("愛")]])
+        let (presenter, panel) = makePresenter()
+        let state = MockCompletionState(currentComposingYomi: "あ")
+        let panelExpectation = expectation(description: "ローカル辞書の補完読みが表示される")
+        panel.onUpdate = { panelExpectation.fulfill() }
+        // ローカル辞書の検索結果の反映(apply)とskkservの検索結果の追記(append)で2回更新される
+        let stateExpectation = expectation(description: "skkservの補完読みが追記される")
+        stateExpectation.expectedFulfillmentCount = 2
+        state.onCompletionUpdate = { stateExpectation.fulfill() }
+        presenter.handle(.other("あ"),
+                         state: state,
+                         cursorPosition: { self.nonZeroCursor() },
+                         windowLevel: { .floating })
+        wait(for: [panelExpectation, stateExpectation], timeout: 1.0)
+        guard case .yomi(let shown) = panel.completions.last else {
+            return XCTFail("補完候補として読みが表示される")
+        }
+        XCTAssertEqual(shown, "あい")
+        // skkservの読みは表示中の選択位置を保つため末尾に追記され、パネルの表示は変わらない
+        XCTAssertEqual(state.completion, .yomi(["あい", "あお"], 0))
+        XCTAssertEqual(panel.completions.count, 1, "表示中の読みは変わらないためパネルの表示更新はされない")
     }
 }

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -158,6 +158,59 @@ final class UserDictSnapshotTests: XCTestCase {
                        "接頭辞の見出し (だい#>) だけを引き、通常の見出し (だい#) は引かない")
     }
 
+    @MainActor func testSnapshotReferDictsSKKServ() throws {
+        let dict = MemoryDict(entries: ["い": [Word("胃")]], readonly: true)
+        let mock = MockSKKServDict(wordsPerYomi: ["い": [Word("意")]])
+        let userDict = try UserDict(dicts: [dict],
+                                    userDictEntries: ["い": [Word("井")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let found = userDict.snapshot().referDicts("い", option: nil, findFromAllDicts: true, skkservDict: mock)
+        XCTAssertEqual(found.candidates,
+                       [Candidate("井"),
+                        Candidate("胃"),
+                        Candidate("意", saveToUserDict: false)],
+                       "skkservの候補はローカル辞書の候補より後に付く")
+        XCTAssertEqual(found.skkservResults.count, 1)
+        XCTAssertTrue(found.skkservResults.allSatisfy { if case .success = $0 { true } else { false } })
+    }
+
+    @MainActor func testSnapshotReferDictsSKKServNumberYomi() throws {
+        let mock = MockSKKServDict(wordsPerYomi: ["だい#かい": [Word("第#0回")]])
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: [:],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let found = userDict.snapshot().referDicts("だい100かい", option: nil, findFromAllDicts: true, skkservDict: mock)
+        XCTAssertEqual(found.candidates,
+                       [Candidate("第100回",
+                                  original: .init(midashi: "だい#かい", word: "第#0回"),
+                                  saveToUserDict: false)],
+                       "数値変換のフォールバックでもskkservを引く")
+        XCTAssertEqual(mock.referCallCount, 2, "通常の見出しと数値変換の見出しの2回問い合わせる")
+        XCTAssertEqual(found.skkservResults.count, 2)
+    }
+
+    @MainActor func testSnapshotReferDictsSKKServStopsAfterFailure() throws {
+        let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: [:],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        // 数値を含む読みなので通常なら数値変換のフォールバックでも問い合わせるが、1回目が失敗したので打ち切られる
+        let found = userDict.snapshot().referDicts("だい100かい", option: nil, findFromAllDicts: true, skkservDict: mock)
+        XCTAssertEqual(mock.referCallCount, 1)
+        XCTAssertEqual(found.candidates, [])
+        XCTAssertEqual(found.skkservResults.count, 1)
+        XCTAssertTrue(found.skkservResults.allSatisfy { if case .failure = $0 { true } else { false } })
+    }
+
     @MainActor func testSnapshotSkkservCandidatesForCompletion() throws {
         let dict = MemoryDict(entries: ["にほん": [Word("日本")], "にほんご": [Word("日本語")]], readonly: false)
         let mock = MockSKKServDict(wordsPerYomi: ["にほん": [Word("二本")]])

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -173,8 +173,24 @@ final class UserDictSnapshotTests: XCTestCase {
                         Candidate("胃"),
                         Candidate("意", saveToUserDict: false)],
                        "skkservの候補はローカル辞書の候補より後に付く")
+        XCTAssertEqual(mock.referCallCount, 1, "ローカル候補があるので数値変換のフォールバックはせず1回で終わる")
         XCTAssertEqual(found.skkservResults.count, 1)
         XCTAssertTrue(found.skkservResults.allSatisfy { if case .success = $0 { true } else { false } })
+    }
+
+    @MainActor func testSnapshotReferDictsSKKServSuppressesNumberFallback() throws {
+        let mock = MockSKKServDict(wordsPerYomi: ["だい100かい": [Word("第100回")]])
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: [:],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        // ローカル辞書は空だがskkservが通常の見出しで候補を返すので数値変換のフォールバックは走らない
+        let found = userDict.snapshot().referDicts("だい100かい", option: nil, findFromAllDicts: true, skkservDict: mock)
+        XCTAssertEqual(found.candidates, [Candidate("第100回", saveToUserDict: false)])
+        XCTAssertEqual(mock.referCallCount, 1, "skkservから見つかったので数値変換の見出しでは問い合わせない")
+        XCTAssertEqual(found.skkservResults.count, 1)
     }
 
     @MainActor func testSnapshotReferDictsSKKServNumberYomi() throws {

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -211,6 +211,85 @@ final class UserDictSnapshotTests: XCTestCase {
         XCTAssertTrue(found.skkservResults.allSatisfy { if case .failure = $0 { true } else { false } })
     }
 
+    @MainActor func testSnapshotReferDictsMergeAnnotation() throws {
+        let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true, saveToUserDict: true)
+        let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
+        let userDict = try UserDict(dicts: [dict1, dict2],
+                                    userDictEntries: [:],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let snapshot = userDict.snapshot()
+        XCTAssertEqual(snapshot.referDicts("い", option: nil, findFromAllDicts: true).map({ $0.word }), ["胃", "伊", "意"])
+        XCTAssertEqual(snapshot.referDicts("い", option: nil, findFromAllDicts: true).map({ $0.annotations.map({ $0.dictId }) }),
+                       [["dict1", "dict2"], [], []], "dict1, dict2に胃が1つずつある")
+    }
+
+    @MainActor func testSnapshotReferDictsWithOption() throws {
+        let dict = MemoryDict(entries: ["あき>": [Word("空き")],
+                                        "あき": [Word("秋")],
+                                        ">し": [Word("氏")],
+                                        "し": [Word("詩")]],
+                              readonly: true)
+        let userDict = try UserDict(dicts: [dict],
+                                    userDictEntries: ["あき>": [Word("飽き")],
+                                                      "あき": [Word("安芸")],
+                                                      ">し": [Word("詞")],
+                                                      "し": [Word("士")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let snapshot = userDict.snapshot()
+        XCTAssertEqual(snapshot.referDicts("あき", option: nil, findFromAllDicts: true), [Candidate("安芸"), Candidate("秋")])
+        XCTAssertEqual(snapshot.referDicts("あき", option: .prefix, findFromAllDicts: true), [Candidate("飽き"), Candidate("空き")])
+        XCTAssertEqual(snapshot.referDicts("あき", option: .suffix, findFromAllDicts: true), [])
+        XCTAssertEqual(snapshot.referDicts("し", option: nil, findFromAllDicts: true), [Candidate("士"), Candidate("詩")])
+        XCTAssertEqual(snapshot.referDicts("し", option: .suffix, findFromAllDicts: true), [Candidate("詞"), Candidate("氏")])
+        XCTAssertEqual(snapshot.referDicts("し", option: .prefix, findFromAllDicts: true), [])
+    }
+
+    @MainActor func testSnapshotReferDictsDateConversion() throws {
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: ["きょう": [Word("今日")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis:  [
+                                        .init(yomi: "today", relative: .now),
+                                        .init(yomi: "yesterday", relative: .yesterday),
+                                        .init(yomi: "tomorrow", relative: .tomorrow),
+                                        .init(yomi: "きょう", relative: .now),
+                                    ],
+                                    dateConversions: [
+                                        DateConversion(format: "YYYY/MM/dd", locale: .enUS, calendar: .gregorian),
+                                        DateConversion(format: "Gy年M月d日", locale: .jaJP, calendar: .japanese),
+                                    ])
+        let snapshot = userDict.snapshot()
+        let candidatesToday = snapshot.referDicts("today", option: nil, findFromAllDicts: true)
+        XCTAssertEqual(candidatesToday.count, 2)
+        XCTAssertTrue(candidatesToday.allSatisfy({ $0.saveToUserDict == false }))
+        // 現在時間で変わるので正規表現マッチ。現在時間をDIできるようにしてもいいかも。
+        XCTAssertNotNil(candidatesToday[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
+        XCTAssertNotNil(candidatesToday[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
+
+        let candidatesYesterday = snapshot.referDicts("yesterday", option: nil, findFromAllDicts: true)
+        XCTAssertEqual(candidatesYesterday.count, 2)
+        XCTAssertTrue(candidatesYesterday.allSatisfy({ $0.saveToUserDict == false }))
+        XCTAssertNotNil(candidatesYesterday[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
+        XCTAssertNotNil(candidatesYesterday[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
+
+        let candidatesTomorrow = snapshot.referDicts("tomorrow", option: nil, findFromAllDicts: true)
+        XCTAssertEqual(candidatesTomorrow.count, 2)
+        XCTAssertTrue(candidatesTomorrow.allSatisfy({ $0.saveToUserDict == false }))
+        XCTAssertNotNil(candidatesTomorrow[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
+        XCTAssertNotNil(candidatesTomorrow[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
+
+        let candidatesKyou = snapshot.referDicts("きょう", option: nil, findFromAllDicts: true)
+        XCTAssertEqual(candidatesKyou.count, 3)
+        XCTAssertEqual(candidatesKyou.first?.word, "今日") // ユーザー辞書の方が日付変換より前
+    }
+
     @MainActor func testSnapshotSkkservCandidatesForCompletion() throws {
         let dict = MemoryDict(entries: ["にほん": [Word("日本")], "にほんご": [Word("日本語")]], readonly: false)
         let mock = MockSKKServDict(wordsPerYomi: ["にほん": [Word("二本")]])

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -107,6 +107,57 @@ final class UserDictSnapshotTests: XCTestCase {
         XCTAssertEqual(snapshot.findCompletionsDicts(prefix: "y", findFromAllDicts: false), ["yesterday"])
     }
 
+    @MainActor func testSnapshotReferDicts() throws {
+        let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊"), Word("位")]], readonly: true, saveToUserDict: false)
+        let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true, saveToUserDict: true)
+        let userDict = try UserDict(dicts: [dict1, dict2],
+                                    userDictEntries: ["い": [Word("井"), Word("伊")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let snapshot = userDict.snapshot()
+        XCTAssertEqual(snapshot.referDicts("い", option: nil, findFromAllDicts: true).map { $0.word },
+                       ["井", "伊", "胃", "位", "意"])
+        XCTAssertEqual(snapshot.referDicts("い", option: nil, findFromAllDicts: true).map { $0.saveToUserDict },
+                       [true, true, true, false, true])
+        XCTAssertEqual(snapshot.referDicts("い", option: nil, findFromAllDicts: false).map { $0.word },
+                       ["井", "伊"], "findFromAllDictsがfalseならユーザー辞書だけを引く")
+    }
+
+    @MainActor func testSnapshotReferDictsNumberYomi() throws {
+        let dict = MemoryDict(entries: ["だい#かい": [Word("第#0回")]], readonly: true)
+        let userDict = try UserDict(dicts: [dict],
+                                    userDictEntries: ["だい#かい": [Word("代#0回")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let snapshot = userDict.snapshot()
+        // 通常の見出しで見つからないときだけ数値を "#" に置換した見出しで引き直す
+        XCTAssertEqual(snapshot.referDicts("だい100かい", option: nil, findFromAllDicts: true),
+                       [Candidate("代100回", original: .init(midashi: "だい#かい", word: "代#0回")),
+                        Candidate("第100回", original: .init(midashi: "だい#かい", word: "第#0回"))])
+        // 数値を含まない読みではフォールバックしない
+        XCTAssertEqual(snapshot.referDicts("だいかい", option: nil, findFromAllDicts: true), [])
+    }
+
+    @MainActor func testSnapshotReferDictsNumberYomiWithOption() throws {
+        // 数値変換のフォールバックでも接頭辞・接尾辞の指定は通常の検索と同じように扱う
+        let dict = MemoryDict(entries: ["だい#>": [Word("第#0")], "だい#": [Word("台#0")]], readonly: true)
+        let userDict = try UserDict(dicts: [dict],
+                                    userDictEntries: ["だい#>": [Word("代#0")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let snapshot = userDict.snapshot()
+        XCTAssertEqual(snapshot.referDicts("だい100", option: .prefix, findFromAllDicts: true),
+                       [Candidate("代100", original: .init(midashi: "だい#", word: "代#0")),
+                        Candidate("第100", original: .init(midashi: "だい#", word: "第#0"))],
+                       "接頭辞の見出し (だい#>) だけを引き、通常の見出し (だい#) は引かない")
+    }
+
     @MainActor func testSnapshotSkkservCandidatesForCompletion() throws {
         let dict = MemoryDict(entries: ["にほん": [Word("日本")], "にほんご": [Word("日本語")]], readonly: false)
         let mock = MockSKKServDict(wordsPerYomi: ["にほん": [Word("二本")]])

--- a/macSKKTests/UserDict+SnapshotTests.swift
+++ b/macSKKTests/UserDict+SnapshotTests.swift
@@ -26,22 +26,24 @@ final class UserDictSnapshotTests: XCTestCase {
             dateConversions: [])
         let snapshot = userDict.snapshot()
         XCTAssertEqual(
-            snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: false),
+            snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: false).candidates,
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本"))
             ])
         // 全辞書を対象
+        let found = snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: true)
         XCTAssertEqual(
-            snapshot.candidatesForCompletion(prefix: "にほ", findFromAllDicts: true),
+            found.candidates,
             [
                 Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本")),
                 Candidate("二本", annotations: [], original: .init(midashi: "にほん", word: "二本")),
                 Candidate("日本語", annotations: [annotation2], original: .init(midashi: "にほんご", word: "日本語")),
             ])
-        XCTAssertEqual(
-            snapshot.candidatesForCompletion(prefix: "に", findFromAllDicts: true),
-            [Candidate("似", original: .init(midashi: "に", word: "似"))],
-        )
+        XCTAssertEqual(found.midashis, ["にほん", "にほんご"], "ローカル辞書から見つかった見出し語も返す")
+        // 1文字のときは完全一致だけを探し、skkservへ渡す見出し語もprefix自身の1件だけになる
+        let foundSingle = snapshot.candidatesForCompletion(prefix: "に", findFromAllDicts: true)
+        XCTAssertEqual(foundSingle.candidates, [Candidate("似", original: .init(midashi: "に", word: "似"))])
+        XCTAssertEqual(foundSingle.midashis, ["に"])
     }
 
     @MainActor func testSnapshotCandidatesForCompletionTotalLimit() throws {
@@ -59,7 +61,160 @@ final class UserDictSnapshotTests: XCTestCase {
             ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
             dateYomis: [],
             dateConversions: [])
-        let results = userDict.snapshot().candidatesForCompletion(prefix: "あい", findFromAllDicts: true)
-        XCTAssertEqual(results.count, 100)
+        let found = userDict.snapshot().candidatesForCompletion(prefix: "あい", findFromAllDicts: true)
+        XCTAssertEqual(found.candidates.count, 100)
+        XCTAssertEqual(found.midashis.count, 50, "見出し語は変換候補の100件上限にかからず全件返す")
+    }
+
+    @MainActor func testSnapshotFindCompletionsDictsPrivateMode() throws {
+        let privateMode = CurrentValueSubject<Bool, Never>(true)
+        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
+        let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
+        let dict2 = MemoryDict(entries: ["にほんご": [Word("日本語")]], readonly: false)
+        let userDict = try UserDict(dicts: [dict1, dict2],
+                                    userDictEntries: ["にふ": [Word("二歩")]],
+                                    privateMode: privateMode,
+                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
+                                    dateYomis: [],
+                                    dateConversions: [])
+        // プライベートモード時は通常はユーザー辞書から検索する
+        XCTAssertEqual(userDict.snapshot().findCompletionsDicts(prefix: "に", findFromAllDicts: false), ["にふ"])
+        // プライベートモードかつユーザー辞書から検索しない設定のとき
+        // (Snapshotは作成時点の設定を保持するため設定変更後に取り直す)
+        ignoreUserDictInPrivateMode.send(true)
+        XCTAssertEqual(userDict.snapshot().findCompletionsDicts(prefix: "に", findFromAllDicts: false), [])
+        // ユーザー辞書から検索しない設定だがプライベートモードじゃないときはユーザー辞書から検索する
+        privateMode.send(false)
+        XCTAssertEqual(userDict.snapshot().findCompletionsDicts(prefix: "に", findFromAllDicts: false), ["にふ"])
+    }
+
+    @MainActor func testSnapshotFindCompletionsDictsDateYomi() throws {
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: ["tower": [Word("塔")]],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [
+                                        .init(yomi: "today", relative: .now),
+                                        .init(yomi: "yesterday", relative: .yesterday),
+                                        .init(yomi: "tomorrow", relative: .tomorrow),
+                                    ],
+                                    dateConversions: [])
+        let snapshot = userDict.snapshot()
+        XCTAssertEqual(snapshot.findCompletionsDicts(prefix: "", findFromAllDicts: false), [], "prefixが空だと空")
+        XCTAssertEqual(snapshot.findCompletionsDicts(prefix: "t", findFromAllDicts: false), ["tower", "today", "tomorrow"])
+        XCTAssertEqual(snapshot.findCompletionsDicts(prefix: "to", findFromAllDicts: false), ["tower", "today", "tomorrow"])
+        XCTAssertEqual(snapshot.findCompletionsDicts(prefix: "tod", findFromAllDicts: false), ["today"])
+        XCTAssertEqual(snapshot.findCompletionsDicts(prefix: "y", findFromAllDicts: false), ["yesterday"])
+    }
+
+    @MainActor func testSnapshotSkkservCandidatesForCompletion() throws {
+        let dict = MemoryDict(entries: ["にほん": [Word("日本")], "にほんご": [Word("日本語")]], readonly: false)
+        let mock = MockSKKServDict(wordsPerYomi: ["にほん": [Word("二本")]])
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: CurrentValueSubject<Bool, Never>(false),
+            ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+            dateYomis: [],
+            dateConversions: [])
+        // ローカル辞書の検索で見つかった見出し (にほん, にほんご) について問い合わせる
+        let midashis = userDict.snapshot().candidatesForCompletion(prefix: "にほ", findFromAllDicts: true).midashis
+        let found = UserDict.Snapshot.skkservCandidatesForCompletion(prefix: "にほ",
+                                                                     midashis: midashis,
+                                                                     skkservDict: mock,
+                                                                     referLimit: 9)
+        XCTAssertEqual(mock.findCompletionsCallCount, 1)
+        XCTAssertEqual(mock.referCallCount, 2)
+        XCTAssertEqual(
+            found.candidates,
+            [Candidate("二本", original: .init(midashi: "にほん", word: "二本"), saveToUserDict: false)])
+        XCTAssertEqual(found.skkservResults.count, 3, "見出し語の補完1回と変換候補2回の成否を返す")
+        XCTAssertTrue(found.skkservResults.allSatisfy { if case .success = $0 { true } else { false } })
+    }
+
+    @MainActor func testSnapshotSkkservCandidatesForCompletionFindsMidashisFromSkkserv() throws {
+        let dict = MemoryDict(entries: ["にほん": [Word("日本")]], readonly: false)
+        // "にほんご" はローカル辞書にはなくskkservにだけある見出し
+        let mock = MockSKKServDict(wordsPerYomi: ["にほんご": [Word("日本語")]])
+        let userDict = try UserDict(
+            dicts: [dict],
+            userDictEntries: [:],
+            privateMode: CurrentValueSubject<Bool, Never>(false),
+            ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+            dateYomis: [],
+            dateConversions: [])
+        let midashis = userDict.snapshot().candidatesForCompletion(prefix: "にほ", findFromAllDicts: true).midashis
+        XCTAssertEqual(midashis, ["にほん"], "ローカル辞書からは にほん しか見つからない")
+        let found = UserDict.Snapshot.skkservCandidatesForCompletion(prefix: "にほ",
+                                                                     midashis: midashis,
+                                                                     skkservDict: mock,
+                                                                     referLimit: 9)
+        // skkservの見出し語の補完で見つかった にほんご についても変換候補を問い合わせる
+        XCTAssertEqual(mock.referCallCount, 2)
+        XCTAssertEqual(
+            found.candidates,
+            [Candidate("日本語", original: .init(midashi: "にほんご", word: "日本語"), saveToUserDict: false)])
+    }
+
+    @MainActor func testSnapshotSkkservCandidatesForCompletionSingleCharacterPrefix() {
+        // prefixが1文字のときは完全一致だけを対象とし、skkservからの見出し語の補完は行わない
+        let mock = MockSKKServDict(wordsPerYomi: ["に": [Word("荷")], "にほん": [Word("二本")]])
+        let found = UserDict.Snapshot.skkservCandidatesForCompletion(prefix: "に",
+                                                                     midashis: ["に"],
+                                                                     skkservDict: mock,
+                                                                     referLimit: 9)
+        XCTAssertEqual(mock.findCompletionsCallCount, 0)
+        XCTAssertEqual(mock.referCallCount, 1)
+        XCTAssertEqual(
+            found.candidates,
+            [Candidate("荷", original: .init(midashi: "に", word: "荷"), saveToUserDict: false)])
+    }
+
+    @MainActor func testSnapshotSkkservCandidatesForCompletionReferLimit() {
+        // skkservへのreferの問い合わせがreferLimit回で打ち切られることを確認
+        let yomis = (1...20).map { String(format: "あい%02d", $0) }
+        let skkservEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
+            (yomi, [Word("SKK\(i + 1)")])
+        })
+        let mock = MockSKKServDict(wordsPerYomi: skkservEntries)
+        let limit = 9
+        let found = UserDict.Snapshot.skkservCandidatesForCompletion(prefix: "あい",
+                                                                     midashis: yomis,
+                                                                     skkservDict: mock,
+                                                                     referLimit: limit)
+        XCTAssertEqual(mock.referCallCount, limit)
+        XCTAssertEqual(found.skkservResults.count, limit + 1, "見出し語の補完1回分を含む")
+    }
+
+    @MainActor func testSnapshotSkkservCandidatesForCompletionStopsAfterFailure() {
+        // 問い合わせの失敗は接続レベルのエラーの可能性が高いため、以降の問い合わせが打ち切られることを確認
+        let yomis = (1...20).map { String(format: "あい%02d", $0) }
+        let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
+        let found = UserDict.Snapshot.skkservCandidatesForCompletion(prefix: "あい",
+                                                                     midashis: yomis,
+                                                                     skkservDict: mock,
+                                                                     referLimit: 9)
+        // 最初の見出し語の補完で失敗するので変換候補は1回も問い合わせない
+        XCTAssertEqual(mock.findCompletionsCallCount, 1)
+        XCTAssertEqual(mock.referCallCount, 0)
+        XCTAssertEqual(found.candidates, [])
+        XCTAssertEqual(found.skkservResults.count, 1)
+    }
+
+    @MainActor func testSnapshotSkkservCandidatesForCompletionStopsWhenCancelled() async {
+        // 検索タスクがキャンセルされたら以降のskkservへの問い合わせが打ち切られることを確認
+        let mock = MockSKKServDict(wordsPerYomi: ["にほん": [Word("二本")]])
+        let found = await Task {
+            // タスクを自らキャンセルした状態で呼び出すと1件も問い合わせずに打ち切られる
+            withUnsafeCurrentTask { $0?.cancel() }
+            return UserDict.Snapshot.skkservCandidatesForCompletion(prefix: "にほ",
+                                                                    midashis: ["にほん", "にほんご"],
+                                                                    skkservDict: mock,
+                                                                    referLimit: 9)
+        }.value
+        XCTAssertEqual(mock.findCompletionsCallCount, 0)
+        XCTAssertEqual(mock.referCallCount, 0)
+        XCTAssertTrue(found.candidates.isEmpty)
+        XCTAssertTrue(found.skkservResults.isEmpty)
     }
 }

--- a/macSKKTests/UserDict+Utilities.swift
+++ b/macSKKTests/UserDict+Utilities.swift
@@ -1,7 +1,54 @@
 // SPDX-FileCopyrightText: 2023 mtgto <hogerappa@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import Foundation
+import os
+
 @testable import macSKK
+
+/**
+ * skkservへの問い合わせはCompletionPresenterの@concurrentな検索処理などから
+ * MainActor外で行われるため、問い合わせ回数はロックで保護する。
+ * 本来はMutex (SE-0433) を使いたいがmacOS 15以降のためデプロイメントターゲット13.3では使えない。
+ */
+final class MockSKKServDict: SKKServDictProtocol {
+    /// skkservへの問い合わせ回数
+    struct CallCount {
+        var refer = 0
+        var findCompletions = 0
+    }
+
+    let saveToUserDict = false
+    let wordsPerYomi: [String: [Word]]
+    let shouldFail: Bool
+    private let callCount = OSAllocatedUnfairLock(initialState: CallCount())
+
+    var referCallCount: Int { callCount.withLock { $0.refer } }
+    var findCompletionsCallCount: Int { callCount.withLock { $0.findCompletions } }
+
+    init(wordsPerYomi: [String: [Word]], shouldFail: Bool = false) {
+        self.wordsPerYomi = wordsPerYomi
+        self.shouldFail = shouldFail
+    }
+
+    func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error> {
+        callCount.withLock { $0.refer += 1 }
+        if shouldFail {
+            return .failure(NSError(domain: "MockSKKServDict", code: 0))
+        }
+        return .success(wordsPerYomi[yomi] ?? [])
+    }
+
+    func findCompletions(prefix: String) -> Result<[String], any Error> {
+        callCount.withLock { $0.findCompletions += 1 }
+        if shouldFail {
+            return .failure(NSError(domain: "MockSKKServDict", code: 0))
+        }
+        return .success(wordsPerYomi.keys.filter { $0.hasPrefix(prefix) && $0 != prefix }.sorted())
+    }
+
+    func invalidate() {}
+}
 
 extension UserDict {
     func setEntries(_ entries: [String: [Word]]) {

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -25,44 +25,6 @@ final class UserDictTests: XCTestCase {
                                     dateYomis: [],
                                     dateConversions: [])
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["井", "伊"], "UserDictのエントリだけを返す")
-        XCTAssertEqual(userDict.referDicts("い").map { $0.word }, ["井", "伊", "胃", "位", "意"])
-        XCTAssertEqual(userDict.referDicts("い").map { $0.saveToUserDict }, [true, true, true, false, true])
-    }
-
-    @MainActor func testReferDictsMergeAnnotation() throws {
-        let dict1 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict1", text: "d1ann")), Word("伊")]], readonly: true, saveToUserDict: true)
-        let dict2 = MemoryDict(entries: ["い": [Word("胃", annotation: Annotation(dictId: "dict2", text: "d2ann")), Word("意")]], readonly: true)
-        let userDict = try UserDict(dicts: [dict1, dict2],
-                                    userDictEntries: [:],
-                                    privateMode: CurrentValueSubject<Bool, Never>(false),
-                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
-                                    dateYomis: [],
-                                    dateConversions: [])
-        XCTAssertEqual(userDict.referDicts("い").map({ $0.word }), ["胃", "伊", "意"])
-        XCTAssertEqual(userDict.referDicts("い").map({ $0.annotations.map({ $0.dictId }) }), [["dict1", "dict2"], [], []], "dict1, dict2に胃が1つずつある")
-    }
-
-    @MainActor func testReferDictsWithOption() throws {
-        let dict = MemoryDict(entries: ["あき>": [Word("空き")],
-                                        "あき": [Word("秋")],
-                                        ">し": [Word("氏")],
-                                        "し": [Word("詩")]],
-                              readonly: true)
-        let userDict = try UserDict(dicts: [dict],
-                                    userDictEntries: ["あき>": [Word("飽き")],
-                                                      "あき": [Word("安芸")],
-                                                      ">し": [Word("詞")],
-                                                      "し": [Word("士")]],
-                                    privateMode: CurrentValueSubject<Bool, Never>(false),
-                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
-                                    dateYomis: [],
-                                    dateConversions: [])
-        XCTAssertEqual(userDict.referDicts("あき", option: nil), [Candidate("安芸"), Candidate("秋")])
-        XCTAssertEqual(userDict.referDicts("あき", option: .prefix), [Candidate("飽き"), Candidate("空き")])
-        XCTAssertEqual(userDict.referDicts("あき", option: .suffix), [])
-        XCTAssertEqual(userDict.referDicts("し", option: nil), [Candidate("士"), Candidate("詩")])
-        XCTAssertEqual(userDict.referDicts("し", option: .suffix), [Candidate("詞"), Candidate("氏")])
-        XCTAssertEqual(userDict.referDicts("し", option: .prefix), [])
     }
 
     @MainActor func testPrivateMode() throws {
@@ -82,45 +44,6 @@ final class UserDictTests: XCTestCase {
         XCTAssertEqual(userDict.refer("い").map { $0.word }, ["位"])
         // deleteのテスト
         XCTAssertTrue(userDict.delete(yomi: "い", word: Word("井")))
-    }
-
-    @MainActor func testReferDictsDateConversion() throws {
-        let userDict = try UserDict(dicts: [],
-                                    userDictEntries: ["きょう": [Word("今日")]],
-                                    privateMode: CurrentValueSubject<Bool, Never>(false),
-                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
-                                    dateYomis:  [
-                                        .init(yomi: "today", relative: .now),
-                                        .init(yomi: "yesterday", relative: .yesterday),
-                                        .init(yomi: "tomorrow", relative: .tomorrow),
-                                        .init(yomi: "きょう", relative: .now),
-                                    ],
-                                    dateConversions: [
-                                        DateConversion(format: "YYYY/MM/dd", locale: .enUS, calendar: .gregorian),
-                                        DateConversion(format: "Gy年M月d日", locale: .jaJP, calendar: .japanese),
-                                    ])
-        let candidatesToday = userDict.referDicts("today")
-        XCTAssertEqual(candidatesToday.count, 2)
-        XCTAssertTrue(candidatesToday.allSatisfy({ $0.saveToUserDict == false }))
-        // 現在時間で変わるので正規表現マッチ。現在時間をDIできるようにしてもいいかも。
-        XCTAssertNotNil(candidatesToday[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
-        XCTAssertNotNil(candidatesToday[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
-
-        let candidatesYesterday = userDict.referDicts("yesterday")
-        XCTAssertEqual(candidatesYesterday.count, 2)
-        XCTAssertTrue(candidatesYesterday.allSatisfy({ $0.saveToUserDict == false }))
-        XCTAssertNotNil(candidatesYesterday[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
-        XCTAssertNotNil(candidatesYesterday[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
-
-        let candidatesTomorrow = userDict.referDicts("tomorrow")
-        XCTAssertEqual(candidatesTomorrow.count, 2)
-        XCTAssertTrue(candidatesTomorrow.allSatisfy({ $0.saveToUserDict == false }))
-        XCTAssertNotNil(candidatesTomorrow[0].word.wholeMatch(of: /\d{4}\/\d{2}\/\d{2}/))
-        XCTAssertNotNil(candidatesTomorrow[1].word.wholeMatch(of: /令和\d{1,}年\d{1,2}月\d{1,2}日/))
-
-        let candidatesKyou = userDict.referDicts("きょう")
-        XCTAssertEqual(candidatesKyou.count, 3)
-        XCTAssertEqual(candidatesKyou.first?.word, "今日") // ユーザー辞書の方が日付変換より前
     }
 
     @MainActor func testHandleSKKServErrorDisablesSkkservDict() throws {

--- a/macSKKTests/UserDictTests.swift
+++ b/macSKKTests/UserDictTests.swift
@@ -15,40 +15,6 @@ final class UserDictTests: XCTestCase {
         }
     }
 
-    /**
-     * `referCallCount` は `@MainActor` に隔離した可変状態としているため、クラス自体は素直にSendableにできる。
-     * `refer(_:option:)` はプロトコル要件でnonisolatedな同期メソッドだが、
-     * 実際の呼び出しは常にMainActor経由であることが保証されているためassumeIsolatedで安全にアクセスする。
-     */
-    final class MockSKKServDict: SKKServDictProtocol, Sendable {
-        let saveToUserDict = false
-        let wordsPerYomi: [String: [Word]]
-        let shouldFail: Bool
-        @MainActor private(set) var referCallCount = 0
-
-        init(wordsPerYomi: [String: [Word]], shouldFail: Bool = false) {
-            self.wordsPerYomi = wordsPerYomi
-            self.shouldFail = shouldFail
-        }
-
-        func refer(_ yomi: String, option: DictReferringOption?) -> Result<[Word], any Error> {
-            MainActor.assumeIsolated { referCallCount += 1 }
-            if shouldFail {
-                return .failure(NSError(domain: "MockSKKServDict", code: 0))
-            }
-            return .success(wordsPerYomi[yomi] ?? [])
-        }
-
-        func findCompletions(prefix: String) -> Result<[String], any Error> {
-            if shouldFail {
-                return .failure(NSError(domain: "MockSKKServDict", code: 0))
-            }
-            return .success(wordsPerYomi.keys.filter { $0.hasPrefix(prefix) && $0 != prefix }.sorted())
-        }
-
-        func invalidate() {}
-    }
-
     @MainActor func testRefer() throws {
         let dict1 = MemoryDict(entries: ["い": [Word("胃"), Word("伊"), Word("位")]], readonly: true, saveToUserDict: false)
         let dict2 = MemoryDict(entries: ["い": [Word("胃"), Word("意")]], readonly: true, saveToUserDict: true)
@@ -157,130 +123,6 @@ final class UserDictTests: XCTestCase {
         XCTAssertEqual(candidatesKyou.first?.word, "今日") // ユーザー辞書の方が日付変換より前
     }
 
-    @MainActor func testFindCompletionsPrivateMode() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(true)
-        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
-        let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
-        let dict2 = MemoryDict(entries: ["にほんご": [Word("日本語")]], readonly: false)
-        let userDict = try UserDict(dicts: [dict1, dict2],
-                                    userDictEntries: ["にふ": [Word("二歩")]],
-                                    privateMode: privateMode,
-                                    ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
-                                    dateYomis: [],
-                                    dateConversions: [])
-        // プライベートモード時は通常はユーザー辞書から検索する
-        XCTAssertEqual(userDict.findCompletions(prefix: "に"), ["にふ"])
-        ignoreUserDictInPrivateMode.send(true)
-        // プライベートモードかつユーザー辞書から検索しない設定のとき
-        XCTAssertEqual(userDict.findCompletions(prefix: "に"), [])
-        // ユーザー辞書から検索しない設定だがプライベートモードじゃないときはユーザー辞書から検索する
-        privateMode.send(false)
-        XCTAssertEqual(userDict.findCompletions(prefix: "に"), ["にふ"])
-    }
-
-    @MainActor func testFindCompletionsDateYomi() throws {
-        let userDict = try UserDict(dicts: [],
-                                    userDictEntries: ["tower": [Word("塔")]],
-                                    privateMode: CurrentValueSubject<Bool, Never>(false),
-                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
-                                    dateYomis: [
-                                        .init(yomi: "today", relative: .now),
-                                        .init(yomi: "yesterday", relative: .yesterday),
-                                        .init(yomi: "tomorrow", relative: .tomorrow),
-                                    ],
-                                    dateConversions: [])
-        XCTAssertEqual(userDict.findCompletions(prefix: ""), [], "prefixが空だと空")
-        XCTAssertEqual(userDict.findCompletions(prefix: "t"), ["tower", "today", "tomorrow"])
-        XCTAssertEqual(userDict.findCompletions(prefix: "to"), ["tower", "today", "tomorrow"])
-        XCTAssertEqual(userDict.findCompletions(prefix: "tod"), ["today"])
-        XCTAssertEqual(userDict.findCompletions(prefix: "y"), ["yesterday"])
-    }
-
-    // TODO: UserDict自体から `@MainActor` を外したらここの `@MainActor` を外す
-    @MainActor func testCandidatesForCompletion() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
-        let annotation1 = Annotation(dictId: UserDict.userDictFilename, text: "日本の注釈")
-        let annotation2 = Annotation(dictId: "dict2", text: "日本語の注釈")
-        let dict1 = MemoryDict(entries: ["にほん": [Word("日本")], "にほ": [Word("2歩")]], readonly: false)
-        let dict2 = MemoryDict(entries: [
-            "にほん": [Word("二本")],
-            "にほんご": [Word("日本語", annotation: annotation2)],
-            "に": [Word("似")]], readonly: false)
-        let userDict = try UserDict(
-            dicts: [dict1, dict2],
-            userDictEntries: ["にふ": [Word("二歩")],
-                              "にほん": [Word("日本", annotation: annotation1)]],
-            privateMode: privateMode,
-            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
-            dateYomis: [],
-            dateConversions: [])
-        XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservOption: nil, findFromAllDicts: false),
-            [
-                Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本"))
-            ])
-        // 全辞書を対象
-        XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "にほ", skkservOption: nil, findFromAllDicts: true),
-            [
-                Candidate("日本", annotations: [annotation1], original: .init(midashi: "にほん", word: "日本")),
-                Candidate("二本", annotations: [], original: .init(midashi: "にほん", word: "二本")),
-                Candidate("日本語", annotations: [annotation2], original: .init(midashi: "にほんご", word: "日本語")),
-            ])
-        XCTAssertEqual(
-            userDict.candidatesForCompletion(prefix: "に", skkservOption: nil, findFromAllDicts: true),
-            [Candidate("似", original: .init(midashi: "に", word: "似"))],
-        )
-    }
-
-    // TODO: UserDict自体から `@MainActor` を外したらここの `@MainActor` を外す
-    @MainActor func testCandidatesForCompletionTotalLimit() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
-        // 50見出し語×3候補=150件になるが返値は100件に絞られる
-        let entries = Dictionary(uniqueKeysWithValues: (1...50).map { i in
-            (String(format: "あい%02d", i), [Word("候補A\(i)"), Word("候補B\(i)"), Word("候補C\(i)")])
-        })
-        let dict = MemoryDict(entries: entries, readonly: false)
-        let userDict = try UserDict(
-            dicts: [dict],
-            userDictEntries: [:],
-            privateMode: privateMode,
-            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
-            dateYomis: [],
-            dateConversions: [])
-        let results = userDict.candidatesForCompletion(prefix: "あい", skkservOption: nil, findFromAllDicts: true)
-        XCTAssertEqual(results.count, 100)
-    }
-
-    // TODO: UserDict自体から `@MainActor` を外したらここの `@MainActor` を外す
-    @MainActor func testCandidatesForCompletionSkkservLimit() throws {
-        let privateMode = CurrentValueSubject<Bool, Never>(false)
-        let ignoreUserDictInPrivateMode = CurrentValueSubject<Bool, Never>(false)
-        // skkservへのreferの問い合わせがskkservCandidateLimit回で打ち切られることを確認
-        let yomis = (1...20).map { String(format: "あい%02d", $0) }
-        let dictEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
-            (yomi, [Word("漢字\(i + 1)")])
-        })
-        let skkservEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
-            (yomi, [Word("SKK\(i + 1)")])
-        })
-        let dict = MemoryDict(entries: dictEntries, readonly: false)
-        let mock = MockSKKServDict(wordsPerYomi: skkservEntries)
-        Global.skkservDict = mock
-        let userDict = try UserDict(
-            dicts: [dict],
-            userDictEntries: [:],
-            privateMode: privateMode,
-            ignoreUserDictInPrivateMode: ignoreUserDictInPrivateMode,
-            dateYomis: [],
-            dateConversions: [])
-        let limit = 9
-        _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, referLimit: limit), findFromAllDicts: true)
-        XCTAssertEqual(mock.referCallCount, limit)
-    }
-
     @MainActor func testHandleSKKServErrorDisablesSkkservDict() throws {
         let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
         Global.skkservDict = mock
@@ -296,30 +138,26 @@ final class UserDictTests: XCTestCase {
         XCTAssertNil(Global.skkservDict)
     }
 
-    // candidatesForCompletionの1回の呼び出し中にskkservが自動無効化された場合、
-    // それ以降のskkservへの問い合わせを打ち切ることを確認する
-    @MainActor func testCandidatesForCompletionStopsRequeryingAfterAutoDisabled() throws {
-        let yomis = (1...20).map { String(format: "あい%02d", $0) }
-        let dictEntries = Dictionary(uniqueKeysWithValues: yomis.enumerated().map { (i, yomi) in
-            (yomi, [Word("漢字\(i + 1)")])
-        })
-        let dict = MemoryDict(entries: dictEntries, readonly: false)
-        let mock = MockSKKServDict(wordsPerYomi: [:], shouldFail: true)
+    @MainActor func testHandleSKKServResults() throws {
+        let mock = MockSKKServDict(wordsPerYomi: [:])
         Global.skkservDict = mock
         Global.skkservConsecutiveErrorCount = 0
-        // findCompletionsDicts内のmock.findCompletions()呼び出しで1回分エラーカウントが消費されるため、
-        // 残り2回のmock.refer()失敗で無効化されるように3を指定する
         Global.skkservAutoDisableThreshold = 3
-        let userDict = try UserDict(
-            dicts: [dict],
-            userDictEntries: [:],
-            privateMode: CurrentValueSubject<Bool, Never>(false),
-            ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
-            dateYomis: [],
-            dateConversions: [])
-        _ = userDict.candidatesForCompletion(prefix: "あい", skkservOption: CompletionSKKServOption(dict: mock, referLimit: 9), findFromAllDicts: true)
-        // referLimitの9回まで問い合わせを続けず、無効化された時点で打ち切られる
-        XCTAssertEqual(mock.referCallCount, 2)
-        XCTAssertNil(Global.skkservDict)
+        let userDict = try UserDict(dicts: [],
+                                    userDictEntries: [:],
+                                    privateMode: CurrentValueSubject<Bool, Never>(false),
+                                    ignoreUserDictInPrivateMode: CurrentValueSubject<Bool, Never>(false),
+                                    dateYomis: [],
+                                    dateConversions: [])
+        let error = NSError(domain: "MockSKKServDict", code: 0)
+        userDict.handleSKKServResults([.failure(error), .failure(error)])
+        XCTAssertNotNil(Global.skkservDict, "連続エラー数が閾値未満では無効化されない")
+        XCTAssertEqual(Global.skkservConsecutiveErrorCount, 2)
+        userDict.handleSKKServResults([.success(()), .failure(error)])
+        XCTAssertNotNil(Global.skkservDict)
+        XCTAssertEqual(Global.skkservConsecutiveErrorCount, 1, "成功でエラーカウントがリセットされる")
+        userDict.handleSKKServResults([.failure(error), .failure(error), .failure(error)])
+        XCTAssertNil(Global.skkservDict, "連続エラー数が閾値に達すると無効化される")
+        XCTAssertEqual(Global.skkservConsecutiveErrorCount, 3, "無効化された時点で残りの成否は処理されない")
     }
 }


### PR DESCRIPTION
#489 Swift 6対応。

入力中の読みが変更されたときの補完候補の検索を #500 で追加した `UserDict.Snapshot` を使ってメインアクター外で行うように修正します。あわせて `UserDict.referDicts` も `Snapshot` への委譲に置き換え、`UserDict` と `UserDict.Snapshot` に二重にあった検索ロジックを一本化します。

## 変更内容

### 1. 補完候補の検索を `@concurrent` + `UserDict.Snapshot` に置き換え

MainActor上でUserDictからsnapshotを取得し、検索処理自体はSendableな値だけを引数に取る `@concurrent` な関数で実行、結果の反映はMainActor上のTaskで行うようにしました。

`@concurrent` の付与は必須です。#508 で `SWIFT_APPROACHABLE_CONCURRENCY` を有効にしたため、これがないと `NonisolatedNonsendingByDefault` ([SE-0461](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md)) により呼び出し元のメインアクター上で実行され、辞書検索でUIが固まります。コンパイルもテストも通ってしまうため、`CompletionPresenter.search` のドキュメントコメントに `- Important:` として理由を残しています。

`Task.detached` ではなく同一タスク内で `await` する形にしたので、新しい読みが入力されて `completionTask` をキャンセルしたときに、検索処理内の `Task.isCancelled` でそれを観測して飛行中のskkservへの問い合わせ列を打ち切れます。

### 2. `UserDict.referDicts` を `Snapshot` への委譲に置き換え

`UserDict` と `UserDict.Snapshot` に重複していた検索ロジックを `Snapshot` 側に一本化しました。`Snapshot.referDicts` はskkservに触れない純粋な部分 (`localCandidates` / `numberFallback` / `numberCandidates` / `skkservCandidates`) と骨格に分割してあります。

**挙動の変更**: 数値変換のフォールバックで引く見出しの `option` (接頭辞・接尾辞) が、これまではユーザー辞書だけ無視されていました (理由は特に覚えてないので単なるバグだと思っています)が、ファイル辞書・skkservと揃えて渡すようにしています。

`Snapshot` の生成コストは辞書10個で約3.08マイクロ秒/回のため (`O(1)`)、変換のたびに呼んでも問題ないと判断しました。

なお変換候補の検索 (`referDicts`) は、これまでどおりMainActor上で同期的にskkservを引いて一度に返します。メインアクター外への追い出しは本PRでは補完候補の検索だけが対象です。

### 3. 補完候補のskkservへの問い合わせを2段階レスポンスに

skkservへの問い合わせはTCP経由でオンメモリの辞書より桁違いに遅いため、補完候補の検索についてはローカル辞書の検索結果を先に表示し、skkservの結果はあとから追記するようにしました。

- 読みの補完: 既存の読みの順序と選択位置を保つため、新規の読みだけ末尾に追記します。表示中の読みは変わらないのでパネルの表示更新はしません
- 変換候補の補完: 同じ変換結果をもつ候補は注釈を結合し、新規の候補を末尾に追記して先頭1ページ分を再表示します
- ローカル辞書から候補が見つからずパネルが閉じている場合は、skkservの結果で新規に表示します

挙動の変更: 補完候補パネルでのskkservの候補は、これまで見出しごとにローカル辞書の候補の直後に挿入されていましたが、ローカル辞書の候補をすべて並べたあとに追記される形になります。変換候補 (`referDicts`) の並び順はこれまでどおりで、skkservの候補はすべてのファイル辞書の候補の末尾に付きます。

### 4. skkservの成否の反映を `handleSKKServResults` に集約

`Snapshot` 側は問い合わせごとの成否を `[Result<Void, any Error>]` として返すだけにして、連続エラー時の自動無効化は `UserDict.handleSKKServResults(_:)` でMainActor上にまとめて反映します。自動無効化されたら残りの成否は処理せず、無効化の通知が重複して飛ばないようにしています。

これまでは `Global.skkservDict != nil` を問い合わせのたびにチェックしていましたが、「1回目の問い合わせが失敗したら接続レベルのエラーとみなして以降を打ち切る」規則に統一しました。

挙動の変更: 1回の検索で数える連続エラーが最大1回になります。これまでは1回の補完検索で複数回skkservを参照した場合複数回エラーがカウントされる可能性があったため、自動無効化に到達するまでに必要な補完・変換回数が増えます。

## テストの変更

- `UserDictTests` の補完系4テストは削除し、`Snapshot` に対する同等のテストを `UserDict+SnapshotTests` へ移動
- 追加: skkservの見出し語補完から見つかった見出しの変換候補が追記されること、prefixが1文字のときは見出し語の補完を引かないこと、referLimitでの打ち切り、失敗・キャンセル時の打ち切り
- 追加: 数値変換のフォールバックで `option` が伝播すること
- 追加: `applySKKServResult` のマージ (読みの選択位置維持 / パネルが閉じている場合の新規表示 / 注釈結合と `displayCandidateCount` での切り詰め)
- 追加: `handle()` 経由でskkservの連続エラーが自動無効化につながること、`.completed` でパネルの読みだけが更新されること
- `MockSKKServDict` はskkservへの問い合わせがメインアクター外から行われるようになったため、呼び出し回数をMainActor隔離からロック保護に変更
- 削除: `testSubscribeDoesNothingWhenShowCompletionDisabled`。「検索しない」という意図した仕様の検査と「表示中の補完候補を消さない」という意図していない挙動の検査が分離できていないことに気付いたため。`Global.showCompletion = false` となったときにUIに反映する修正は別PRで対応する。