### PR TITLE
SKKServDictViewのCancelで編集内容を破棄する

### DIFF
--- a/macSKK/Settings/DictionariesView.swift
+++ b/macSKK/Settings/DictionariesView.swift
@@ -95,7 +95,10 @@ struct DictionariesView: View {
                 )
             }
             .sheet(isPresented: $isShowingSkkservSheet) {
-                SKKServDictView(settingsViewModel: settingsViewModel, isShowSheet: $isShowingSkkservSheet)
+                SKKServDictView(settingsViewModel: settingsViewModel,
+                                isShowSheet: $isShowingSkkservSheet,
+                                setting: settingsViewModel.skkservDictSetting,
+                                autoDisableThreshold: settingsViewModel.skkservAutoDisableThreshold)
             }
             Text("SettingsNoteDictionaries")
                 .font(.subheadline)

--- a/macSKK/Settings/SKKServDictSetting.swift
+++ b/macSKK/Settings/SKKServDictSetting.swift
@@ -1,21 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-import Combine
 
-final class SKKServDictSetting: ObservableObject {
+struct SKKServDictSetting: Equatable {
     /// SKKServが有効かどうか
-    @Published var enabled: Bool
+    var enabled: Bool
     /// IPv4/v6アドレス ("127.0.0.1" や "::1" など) や ホスト名 ("localhost" など) どちらでも可能
-    @Published var address: String
+    var address: String
     /// 通常は1178になっていることが多い
-    @Published var port: UInt16
+    var port: UInt16
     /// 見出し (リクエスト) 送信時のエンコーディング。通常はEUC-JPのことが多い。yaskkserv2の--midashi-utf8などUTF-8で見出しを受けられる実装もある。
-    @Published var requestEncoding: String.Encoding
+    var requestEncoding: String.Encoding
     /// 応答 (レスポンス) 受信時のエンコーディング。通常はEUC-JPのことが多い。yaskkserv2などUTF-8を返すことが可能な実装もある。
-    @Published var responseEncoding: String.Encoding
+    var responseEncoding: String.Encoding
     /// 変換履歴をユーザー辞書に保存するかどうか
-    @Published var saveToUserDict: Bool
+    var saveToUserDict: Bool
     /// 補完候補をSKKServから取得するか
-    @Published var enableCompletion: Bool
+    var enableCompletion: Bool
 
     init(enabled: Bool, address: String, port: UInt16, requestEncoding: String.Encoding, responseEncoding: String.Encoding, saveToUserDict: Bool, enableCompletion: Bool) {
         self.enabled = enabled

--- a/macSKK/Settings/SKKServDictView.swift
+++ b/macSKK/Settings/SKKServDictView.swift
@@ -7,6 +7,8 @@ import Network
 struct SKKServDictView: View {
     @StateObject var settingsViewModel: SettingsViewModel
     @Binding var isShowSheet: Bool
+    @State var setting: SKKServDictSetting
+    @State var autoDisableThreshold: Int
     @State var information: String = ""
     @State var testing: Bool = false
     @State var yomi: String = ""
@@ -15,31 +17,31 @@ struct SKKServDictView: View {
         VStack {
             Form {
                 Section {
-                    TextField("Address", text: $settingsViewModel.skkservDictSetting.address)
-                    TextField("TCP Port", value: $settingsViewModel.skkservDictSetting.port,
+                    TextField("Address", text: $setting.address)
+                    TextField("TCP Port", value: $setting.port,
                               format: .number.grouping(.never), prompt: Text("1178"))
-                    Picker("Request Encoding", selection: $settingsViewModel.skkservDictSetting.requestEncoding) {
+                    Picker("Request Encoding", selection: $setting.requestEncoding) {
                         ForEach(AllowedEncoding.allCases, id: \.encoding) { allowedEncoding in
                             Text(allowedEncoding.description).tag(allowedEncoding.encoding)
                         }
                     }
                     .pickerStyle(.radioGroup)
-                    Picker("Response Encoding", selection: $settingsViewModel.skkservDictSetting.responseEncoding) {
+                    Picker("Response Encoding", selection: $setting.responseEncoding) {
                         ForEach(AllowedEncoding.allCases, id: \.encoding) { allowedEncoding in
                             Text(allowedEncoding.description).tag(allowedEncoding.encoding)
                         }
                     }
                     .pickerStyle(.radioGroup)
-                    Toggle(isOn: $settingsViewModel.skkservDictSetting.saveToUserDict) {
+                    Toggle(isOn: $setting.saveToUserDict) {
                         Text("Save conversion history to User Dictionary")
                     }
                     .toggleStyle(.switch)
-                    Toggle(isOn: $settingsViewModel.skkservDictSetting.enableCompletion) {
+                    Toggle(isOn: $setting.enableCompletion) {
                         Text("Search completions")
                     }
                     .toggleStyle(.switch)
                     TextField("SKKServAutoDisableThreshold",
-                              value: $settingsViewModel.skkservAutoDisableThreshold,
+                              value: $autoDisableThreshold,
                               format: .number)
                 } header: {
                     Text("SKKServDictTitle")
@@ -50,7 +52,6 @@ struct SKKServDictView: View {
                         Spacer()
                         Button {
                             let skkservService = SKKServService()
-                            let setting = settingsViewModel.skkservDictSetting
                             let destination = SKKServDestination(host: setting.address,
                                                                  port: setting.port,
                                                                  requestEncoding: setting.requestEncoding,
@@ -72,7 +73,6 @@ struct SKKServDictView: View {
                         }.disabled(yomi.isEmpty || testing)
                         Button {
                             let skkservService = SKKServService()
-                            let setting = settingsViewModel.skkservDictSetting
                             let destination = SKKServDestination(host: setting.address,
                                                                  port: setting.port,
                                                                  requestEncoding: setting.requestEncoding,
@@ -107,7 +107,6 @@ struct SKKServDictView: View {
             HStack {
                 Button {
                     let skkservService = SKKServService()
-                    let setting = settingsViewModel.skkservDictSetting
                     let destination = SKKServDestination(host: setting.address,
                                                          port: setting.port,
                                                          requestEncoding: setting.requestEncoding,
@@ -138,6 +137,11 @@ struct SKKServDictView: View {
                 }
                 .keyboardShortcut(.cancelAction)
                 Button {
+                    var newSetting = setting
+                    // enabledはこの画面では編集しない
+                    newSetting.enabled = settingsViewModel.skkservDictSetting.enabled
+                    settingsViewModel.skkservDictSetting = newSetting
+                    settingsViewModel.skkservAutoDisableThreshold = autoDisableThreshold
                     isShowSheet = false
                 } label: {
                     Text("Done")
@@ -149,6 +153,10 @@ struct SKKServDictView: View {
             Spacer()
         }
         .frame(width: 480, height: 450)
+        .onAppear {
+            setting = settingsViewModel.skkservDictSetting
+            autoDisableThreshold = settingsViewModel.skkservAutoDisableThreshold
+        }
     }
 
     private func showError(_ error: any Error) {
@@ -187,5 +195,8 @@ struct SKKServDictView: View {
         saveToUserDict: true,
         enableCompletion: false)
     return SKKServDictView(settingsViewModel: try! SettingsViewModel(skkservDictSetting: setting),
-                    isShowSheet: .constant(true), information: "skkservが応答していません")
+                    isShowSheet: .constant(true),
+                    setting: setting,
+                    autoDisableThreshold: 3,
+                    information: "skkservが応答していません")
 }

--- a/macSKK/Settings/SettingsViewModel.swift
+++ b/macSKK/Settings/SettingsViewModel.swift
@@ -457,7 +457,7 @@ final class SettingsViewModel: ObservableObject {
             }
         }
 
-        $skkservDictSetting.sink { setting in
+        $skkservDictSetting.removeDuplicates().sink { setting in
             if setting.enabled {
                 let destination = SKKServDestination(host: setting.address, port: setting.port, requestEncoding: setting.requestEncoding, responseEncoding: setting.responseEncoding)
                 logger.log("skkserv辞書を設定します")
@@ -581,7 +581,6 @@ final class SettingsViewModel: ObservableObject {
             .sink { [weak self] notification in
                 guard let self else { return }
                 self.skkservDictSetting.enabled = false
-                self.skkservDictSetting = self.skkservDictSetting
                 let consecutiveErrorCount = notification.object as? Int ?? Global.skkservAutoDisableThreshold
                 UNNotifier.sendNotificationForSKKServAutoDisabled(consecutiveErrorCount: consecutiveErrorCount)
             }
@@ -592,7 +591,6 @@ final class SettingsViewModel: ObservableObject {
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.skkservDictSetting.enabled.toggle()
-                self.skkservDictSetting = self.skkservDictSetting
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
SKKServDictViewがsettingsViewModel.skkservDictSettingを直接バインディングしていたバグを修正。

- Cancelを押しても編集内容が巻き戻らない
- 入力するたびにUserDefaultsへの保存とGlobal.skkservDictの再生成が行われてしまう

SKKServDictSettingをclassからstruct (Equatable) に変更し、Doneを押したときだけsettingsViewModelに反映するようにします (skkservAutoDisableThresholdも同様)。