### PR TITLE
MemoryDictのsaveToUserDict設定がファイルの読み込み後に失われるのを修正

### DIFF
--- a/macSKK/FileDict.swift
+++ b/macSKK/FileDict.swift
@@ -46,7 +46,7 @@ enum FileDictType: Equatable {
      */
     private let readonly: Bool
     /// この辞書から返した変換候補をユーザー辞書に保存するかどうか
-    let saveToUserDict: Bool
+    var saveToUserDict: Bool { dict.saveToUserDict }
 
     /// シリアライズ時に先頭に付ける
     static let headers = [";; -*- mode: fundamental; coding: utf-8 -*-"]
@@ -82,24 +82,26 @@ enum FileDictType: Equatable {
         self.type = type
         self.dict = MemoryDict(entries: [:], readonly: readonly, saveToUserDict: saveToUserDict)
         self.readonly = readonly
-        self.saveToUserDict = saveToUserDict
         self.fileModificationDate = try fileURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
         super.init()
         NSFileCoordinator.addFilePresenter(self)
     }
 
-    private init(id: String, fileURL: URL, type: FileDictType, dict: MemoryDict, readonly: Bool, saveToUserDict: Bool, hasUnsavedChanges: Bool) {
+    private init(id: String, fileURL: URL, type: FileDictType, dict: MemoryDict, readonly: Bool, hasUnsavedChanges: Bool) {
         self.id = id
         self.fileURL = fileURL
         self.type = type
         self.dict = dict
         self.readonly = readonly
-        self.saveToUserDict = saveToUserDict
         self.hasUnsavedChanges = hasUnsavedChanges
     }
 
     func with(saveToUserDict: Bool) -> FileDict {
-        FileDict(id: id, fileURL: fileURL, type: type, dict: dict, readonly: readonly, saveToUserDict: saveToUserDict,
+        FileDict(id: id,
+                 fileURL: fileURL,
+                 type: type,
+                 dict: dict.with(saveToUserDict: saveToUserDict),
+                 readonly: readonly,
                  hasUnsavedChanges: hasUnsavedChanges)
     }
 
@@ -108,6 +110,7 @@ enum FileDictType: Equatable {
         let fileURL = self.fileURL
         let type = self.type
         let readonly = self.readonly
+        let saveToUserDict = self.saveToUserDict
 
         NotificationCenter.default.post(name: notificationNameDictLoad,
                                         object: DictLoadEvent(id: id, status: .loading, trigger: .load))
@@ -133,14 +136,14 @@ enum FileDictType: Equatable {
                         }
                         let okuriAriEntries = jisyo.okuriAri.mapValues { $0.map { Word($0) } }
                         let okuriNashiEntries = jisyo.okuriNasi.mapValues { $0.map { Word($0) } }
-                        continuation.resume(returning: .success(MemoryDict(okuriAriEntries: okuriAriEntries, okuriNashiEntries: okuriNashiEntries, readonly: readonly)))
+                        continuation.resume(returning: .success(MemoryDict(okuriAriEntries: okuriAriEntries, okuriNashiEntries: okuriNashiEntries, readonly: readonly, saveToUserDict: saveToUserDict)))
                     } else if case .traditional(let encoding) = type {
                         let source = try Self.loadString(try self.loadData(url), encoding: encoding)
                         if source.isEmpty {
                             // 辞書ファイルを書き込み中に読み込んでしまった?
                             logger.warning("辞書 \(id) を読み込んだところ0バイトだったため更新を無視します")
                         }
-                        continuation.resume(returning: .success(MemoryDict(dictId: id, source: source, readonly: readonly)))
+                        continuation.resume(returning: .success(MemoryDict(dictId: id, source: source, readonly: readonly, saveToUserDict: saveToUserDict)))
                     } else {
                         continuation.resume(returning: .failure(FileDictError.decode))
                     }
@@ -320,7 +323,7 @@ enum FileDictType: Equatable {
 
     // ユニットテスト用
     func setEntries(_ entries: [String: [Word]], readonly: Bool) {
-        self.dict = MemoryDict(entries: entries, readonly: readonly)
+        self.dict = MemoryDict(entries: entries, readonly: readonly, saveToUserDict: saveToUserDict)
     }
 }
 

--- a/macSKK/MemoryDict.swift
+++ b/macSKK/MemoryDict.swift
@@ -111,7 +111,27 @@ struct MemoryDict: DictProtocol, Sendable {
         self.saveToUserDict = saveToUserDict
     }
 
+    init(readonly: Bool, entries: [String: [Word]], failedEntryCount: Int, okuriNashiYomis: [String], okuriAriYomis: [String], saveToUserDict: Bool) {
+        self.readonly = readonly
+        self.entries = entries
+        self.failedEntryCount = failedEntryCount
+        self.okuriNashiYomis = okuriNashiYomis
+        self.okuriAriYomis = okuriAriYomis
+        self.saveToUserDict = saveToUserDict
+    }
+
     var entryCount: Int { return entries.count }
+
+    nonisolated func with(saveToUserDict: Bool) -> MemoryDict {
+        MemoryDict(
+            readonly: readonly,
+            entries: entries,
+            failedEntryCount: failedEntryCount,
+            okuriNashiYomis: okuriNashiYomis,
+            okuriAriYomis: okuriAriYomis,
+            saveToUserDict: saveToUserDict
+        )
+    }
 
     // MARK: DictProtocol
     nonisolated func refer(_ yomi: String, option: DictReferringOption?) -> [Word] {

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -105,6 +105,33 @@ import XCTest
         await fulfillment(of: [loadingExpectation, loadedExpectation], timeout: 1.0, enforceOrder: true)
     }
 
+    func testLoadSaveToUserDict() async throws {
+        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
+        // saveToUserDict = false
+        let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: false)
+        XCTAssertFalse(dict.saveToUserDict)
+        XCTAssertFalse(dict.dict.saveToUserDict)
+        let dictId = dict.id
+        let loadingExpectation = expectation(forNotification: notificationNameDictLoad, object: nil) { notification in
+            guard let loadEvent = notification.object as? DictLoadEvent, loadEvent.id == dictId,
+                  case .loading = loadEvent.status else { return false }
+            XCTAssertEqual(loadEvent.trigger, .load, "ファイル読み込みの通知はすべて .load であるべき")
+            return true
+        }
+        let loadedExpectation = expectation(forNotification: notificationNameDictLoad, object: nil) { notification in
+            guard let loadEvent = notification.object as? DictLoadEvent, loadEvent.id == dictId,
+                  case .loaded(let loadCount, let failureCount) = loadEvent.status else { return false }
+            XCTAssertEqual(loadCount, 1)
+            XCTAssertEqual(failureCount, 0)
+            XCTAssertEqual(loadEvent.trigger, .load, "ファイル読み込みの通知はすべて .load であるべき")
+            return true
+        }
+        await dict.load()
+        await fulfillment(of: [loadingExpectation, loadedExpectation], timeout: 1.0, enforceOrder: true)
+        XCTAssertFalse(dict.saveToUserDict)
+        XCTAssertFalse(dict.dict.saveToUserDict)
+    }
+
     func testAdd() throws {
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
         let dictId = dict.id


### PR DESCRIPTION
UserDict+Snapshotを使った実装中に発覚したバグの修正。
Snapshot側を参照しない限りユーザーに不具合はないです。

FileDict.load()やsetEntriesで生成するMemoryDictに`saveToUserDict`を渡していなかったため、読み込み後は常にtrueになっていました。

loadによるMemoryDict更新後も維持するように修正します。
またFileDictでsaveToUserDictをもたず、常にMemoryDict.saveToUserDictを参照するように変更します。