### PR TITLE
テストのOptional展開をXCTUnwrapに置き換える

### DIFF
--- a/macSKKTests/Data+EucJis2004Tests.swift
+++ b/macSKKTests/Data+EucJis2004Tests.swift
@@ -7,13 +7,13 @@ import XCTest
 
 final class URLEucJis2004Tests: XCTestCase {
     func testLoad() throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "euc-jis-2004", withExtension: "txt")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "euc-jis-2004", withExtension: "txt"))
         let data = try Data(contentsOf: fileURL)
         XCTAssertEqual(try data.eucJis2004String(), "川﨑")
     }
 
     func testLoadFail() throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8"))
         let data = try Data(contentsOf: fileURL)
         XCTAssertThrowsError(try data.eucJis2004String()) {
             XCTAssertEqual($0 as! EucJis2004Error, EucJis2004Error.convert)
@@ -21,7 +21,7 @@ final class URLEucJis2004Tests: XCTestCase {
     }
 
     func testLoadEmpty() throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "empty", withExtension: "txt")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "empty", withExtension: "txt"))
         let data = try Data(contentsOf: fileURL)
         XCTAssertEqual(try data.eucJis2004String(), "")
     }

--- a/macSKKTests/DateConversionTests.swift
+++ b/macSKKTests/DateConversionTests.swift
@@ -12,15 +12,12 @@ final class DateConversionTests: XCTestCase {
         XCTAssertNil(DateConversion(dict: ["format": "yyyy-MM-dd", "locale": "ja_JP", "calendar": "xxxx"])) // calendarが不正
     }
 
-    func testEncodeAndDecode() {
-        let conversion = DateConversion(dict: ["format": "yyyy-MM-dd", "locale": "ja_JP", "calendar": "gregorian"])
-        XCTAssertNotNil(conversion)
-        let encoded = conversion!.encode()
-        let decoded = DateConversion(dict: encoded)
-        XCTAssertNotNil(decoded)
-        XCTAssertEqual(decoded!.format, conversion!.format)
-        XCTAssertEqual(decoded!.locale, conversion!.locale)
-        XCTAssertEqual(decoded!.calendar, conversion!.calendar)
-        XCTAssertNotEqual(decoded!.id, conversion!.id) // idは毎回再生成されるので一致しない
+    func testEncodeAndDecode() throws {
+        let conversion = try XCTUnwrap(DateConversion(dict: ["format": "yyyy-MM-dd", "locale": "ja_JP", "calendar": "gregorian"]))
+        let decoded = try XCTUnwrap(DateConversion(dict: conversion.encode()))
+        XCTAssertEqual(decoded.format, conversion.format)
+        XCTAssertEqual(decoded.locale, conversion.locale)
+        XCTAssertEqual(decoded.calendar, conversion.calendar)
+        XCTAssertNotEqual(decoded.id, conversion.id) // idは毎回再生成されるので一致しない
     }
 }

--- a/macSKKTests/DateConversionYomiTests.swift
+++ b/macSKKTests/DateConversionYomiTests.swift
@@ -11,16 +11,13 @@ final class DateConversionYomiTests: XCTestCase {
         XCTAssertNil(DateConversion.Yomi(dict: ["yomi": "きょう", "relative": "xxxx"])) // 現在との差分が不正
     }
 
-    func testEncodeAndDecode() {
+    func testEncodeAndDecode() throws {
         // Test with yomi and relative
-        let yomi = DateConversion.Yomi(dict: ["yomi": "きょう", "relative": "tomorrow"])
-        XCTAssertNotNil(yomi)
-        let encoded = yomi!.encode()
-        let decoded = DateConversion.Yomi(dict: encoded)
-        XCTAssertNotNil(decoded)
-        XCTAssertEqual(decoded!.yomi, yomi!.yomi)
-        XCTAssertEqual(decoded!.relative, yomi!.relative)
-        XCTAssertNotEqual(decoded!.id, yomi!.id) // idは毎回再生成されるので一致しない
+        let yomi = try XCTUnwrap(DateConversion.Yomi(dict: ["yomi": "きょう", "relative": "tomorrow"]))
+        let decoded = try XCTUnwrap(DateConversion.Yomi(dict: yomi.encode()))
+        XCTAssertEqual(decoded.yomi, yomi.yomi)
+        XCTAssertEqual(decoded.relative, yomi.relative)
+        XCTAssertNotEqual(decoded.id, yomi.id) // idは毎回再生成されるので一致しない
     }
 
     func testTimeInterval() {

--- a/macSKKTests/EntryTests.swift
+++ b/macSKKTests/EntryTests.swift
@@ -18,7 +18,7 @@ final class EntryTests: XCTestCase {
     }
 
     func testAnnotation() throws {
-        guard let entry = Entry(line: "けい /京;10^16/", dictId: "") else { XCTFail(); return }
+        let entry = try XCTUnwrap(Entry(line: "けい /京;10^16/", dictId: ""))
         XCTAssertEqual(entry.candidates[0].word, "京")
         XCTAssertEqual(entry.candidates[0].annotation?.text, "10^16")
         XCTAssertEqual(Entry(line: "あ /亜;*個人注釈/", dictId: "")?.candidates.first?.annotation?.text, "個人注釈")

--- a/macSKKTests/FileDictTests.swift
+++ b/macSKKTests/FileDictTests.swift
@@ -9,14 +9,14 @@ import XCTest
     let fileURL = Bundle(for: FileDictTests.self).url(forResource: "empty", withExtension: "txt")!
 
     func testLoadContainsBom() async throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "utf8-bom", withExtension: "txt")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "utf8-bom", withExtension: "txt"))
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
         await dict.load()
         XCTAssertEqual(dict.dict.entries, ["ゆにこーど": [Word("ユニコード")]])
     }
 
     func testLoadJson() async throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json"))
         let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
         let dictId = dict.id
         let loadingExpectation = expectation(forNotification: notificationNameDictLoad, object: nil) { notification in
@@ -40,7 +40,7 @@ import XCTest
     }
 
     func testLoadJsonBroken() async throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.broken", withExtension: "json")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "SKK-JISYO.broken", withExtension: "json"))
         let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
         let dictId = dict.id
         let loadingExpectation = expectation(forNotification: notificationNameDictLoad, object: nil) { notification in
@@ -60,7 +60,7 @@ import XCTest
     }
 
     func testLoadGzippedTraditional() async throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8.gz")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8.gz"))
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: true)
         let dictId = dict.id
         let loadingExpectation = expectation(forNotification: notificationNameDictLoad, object: nil) { notification in
@@ -83,7 +83,7 @@ import XCTest
     }
 
     func testLoadGzippedJson() async throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json.gz")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "json.gz"))
         let dict = try FileDict(contentsOf: fileURL, type: .json, readonly: true, saveToUserDict: true)
         let dictId = dict.id
         let loadingExpectation = expectation(forNotification: notificationNameDictLoad, object: nil) { notification in
@@ -106,7 +106,7 @@ import XCTest
     }
 
     func testLoadSaveToUserDict() async throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "SKK-JISYO.test", withExtension: "utf8"))
         // saveToUserDict = false
         let dict = try FileDict(contentsOf: fileURL, type: .traditional(.utf8), readonly: true, saveToUserDict: false)
         XCTAssertFalse(dict.saveToUserDict)

--- a/macSKKTests/RomajiTests.swift
+++ b/macSKKTests/RomajiTests.swift
@@ -26,7 +26,7 @@ class RomajiTests: XCTestCase {
     }
 
     func testConvert() throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "kana-rule-for-test", withExtension: "conf")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "kana-rule-for-test", withExtension: "conf"))
         let kanaRule = try Romaji(contentsOf: fileURL, initialRomaji: nil)
         XCTAssertEqual(kanaRule.convert("a", punctuation: .default), Romaji.ConvertedMoji(input: "", kakutei: Romaji.Moji(firstRomaji: "a", kana: "あ")))
         // nだけではまだ「ん」になるかは確定しない (な行などに派生する可能性がある)

--- a/macSKKTests/SKKServDestinationTests.swift
+++ b/macSKKTests/SKKServDestinationTests.swift
@@ -28,18 +28,18 @@ final class SKKServDestinationTests: XCTestCase {
 
     func testDecodeResponseUTF8Found() throws {
         let destination = SKKServDestination(host: "localhost", port: 1178, requestEncoding: .utf8, responseEncoding: .utf8)
-        XCTAssertEqual(destination.decodeResponse("1/変換/返還/\n".data(using: .utf8)!), "1/変換/返還/\n")
+        XCTAssertEqual(destination.decodeResponse(try XCTUnwrap("1/変換/返還/\n".data(using: .utf8))), "1/変換/返還/\n")
     }
 
     func testDecodeResponseEUCFound() throws {
         let destination = SKKServDestination(host: "localhost", port: 1178, requestEncoding: .japaneseEUC, responseEncoding: .japaneseEUC)
-        XCTAssertEqual(destination.decodeResponse("1/変換/返還/\n".data(using: .japaneseEUC)!), "1/変換/返還/\n")
+        XCTAssertEqual(destination.decodeResponse(try XCTUnwrap("1/変換/返還/\n".data(using: .japaneseEUC))), "1/変換/返還/\n")
     }
 
     // 応答UTF-8設定なのに候補なし応答がEUCエコーで返る混在サーバ: デコード失敗なのでnilを返す
     func testDecodeResponseUTF8ButEucNotFound() throws {
         let destination = SKKServDestination(host: "localhost", port: 1178, requestEncoding: .japaneseEUC, responseEncoding: .utf8)
-        let eucNotFound = "4へんかん".data(using: .japaneseEUC)!  // UTF-8としては不正なバイト列
+        let eucNotFound = try XCTUnwrap("4へんかん".data(using: .japaneseEUC))  // UTF-8としては不正なバイト列
         XCTAssertNil(destination.decodeResponse(eucNotFound))
     }
 

--- a/macSKKTests/URL+AdditionsTests.swift
+++ b/macSKKTests/URL+AdditionsTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class URLAdditionsTests: XCTestCase {
     func testIsLoadable() throws {
-        let kanaRuleFileURL = Bundle.main.url(forResource: "kana-rule", withExtension: "conf")!
+        let kanaRuleFileURL = try XCTUnwrap(Bundle.main.url(forResource: "kana-rule", withExtension: "conf"))
         XCTAssertTrue(try kanaRuleFileURL.isReadable())
         let applications = URL(fileURLWithPath: "/Applications")
         XCTAssertFalse(try applications.isReadable())

--- a/macSKKTests/UpdateCheckerTests.swift
+++ b/macSKKTests/UpdateCheckerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class UpdateCheckerTests: XCTestCase {
     func testDecode() throws {
-        let fileURL = Bundle(for: Self.self).url(forResource: "release", withExtension: "json")!
+        let fileURL = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "release", withExtension: "json"))
         let data = try Data(NSData(contentsOf: fileURL))
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601


### PR DESCRIPTION
ユニットテストのリファクタリング。[XCTUnwrap](https://developer.apple.com/documentation/xctest/xctunwrap(_:_:file:line:)) を使ってOptionalの値がnilかどうかのアサーションとアンラップをまとめてやります。

- fixtureのBundle.url(forResource:)! を12箇所置き換え
- DateConversion(Yomi)Testsの XCTAssertNotNil + `!` を解消
- EntryTestsの guard let + XCTFail() を解消
- SKKServDestinationTestsの data(using:)! を置き換え

FileDictTestsのstored propertyと Romaji.defaultKanaRule は try を書ける文脈がないため対象外としました。